### PR TITLE
Fix bug in from_torch method

### DIFF
--- a/genesis/grad/creation_ops.py
+++ b/genesis/grad/creation_ops.py
@@ -89,7 +89,7 @@ def from_torch(torch_tensor, dtype=None, requires_grad=False, detach=True, scene
         )
         requires_grad = True
 
-    gs_tensor = Tensor(torch_tensor.to(gs.device).to(dtype), scene=scene).clone()
+    gs_tensor = Tensor(torch_tensor.to(device=gs.device, dtype=dtype), scene=scene).clone()
 
     if detach:
         gs_tensor = gs_tensor.detach(sceneless=False)


### PR DESCRIPTION
This bug specifically causes an issue in MacOS, since the MPS framework (Apple silicon) doesn't support float64. Since the newly created tensor was being moved to MPS _before_ being casted to the target dtype (float32), the code would crash. Doing both casting and moving devices at the same time fixes this bug.

## To reproduce
On MacOS, simply run `python examples/pbd_liquid.py` and observe the following error:
```
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64. Please use float32 instead.
```

After this bugfix, this error no longer occurs.
