### PR TITLE
Fix silent FFMPEG failure

### DIFF
--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -8,8 +8,8 @@ import genesis.utils.particle as pu
 try:
     from genesis.ext import pyrender, trimesh
     from genesis.ext.pyrender.jit_render import JITRenderer
-except:
-    pass
+except Exception as e:
+    print(f"[Error]: {e}\n")
 from genesis.utils.misc import tensor_to_array
 
 


### PR DESCRIPTION
This pull request addresses issue #26 by ensuring an error message is displayed when the `trimesh`, `pyrender`, and/or `JITRenderer` modules fail to import due to a missing `ffmpeg` library, rather than allowing the process to fail silently.

Note that this use of `try/except` is still problematic and should probably be addressed in future updates. But at least this temporary fix will keep people from spending a lot of time trying to figure out the issue.