### PR TITLE
Remove torch import, keep viewer open in render_on_macos.py

### DIFF
--- a/examples/render_on_macos.py
+++ b/examples/render_on_macos.py
@@ -1,9 +1,5 @@
 import argparse
-
-import torch
-
 import genesis as gs
-
 
 def main():
 
@@ -60,8 +56,8 @@ def run_sim(scene, enable_vis):
         if i > 200:
             break
 
-    if enable_vis:
-        scene.viewer.stop()
+    # if enable_vis:
+    #    scene.viewer.stop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- `torch` import is not needed
- I guess most users would like to keep the viewer open to do something with the simulation. Maybe it's an idea to add an argument for this behavior where the default is to keep it open.