### PR TITLE
fix(docs): correct numbering in the "What is Genesis?" feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Genesis is a physics platform designed for general purpose *Robotics/Embodied AI
 1. A **universal physics engine** re-built from the ground up, capable of simulating a wide range of materials and physical phenomena.
 2. A **lightweight**, **ultra-fast**, **pythonic**, and **user-friendly** robotics simulation platform.
 3. A powerful and fast **photo-realistic rendering system**.
-3. A **generative data engine** that transforms user-prompted natural language description into various modalities of data.
+4. A **generative data engine** that transforms user-prompted natural language description into various modalities of data.
 
 Powered by a universal physics engine re-designed and re-built from the ground up, Genesis integrates various physics solvers and their coupling into a unified framework. This core physics engine is further enhanced by a generative agent framework that operates at an upper level, aiming towards fully **automated data generation** for robotics and beyond. 
 


### PR DESCRIPTION
Previously, the last item in the numbered "What is Genesis?" list was incorrectly labeled as "3." instead of "4.".

This commit updates the numbering to maintain consistency and clarity.