### PR TITLE
[BUG FIX] ext/pyrender/viewer: resolve macOS crashes when initialising Tk()

### DIFF
--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -16,6 +16,8 @@ import genesis as gs
 
 from tkinter import Tk
 from tkinter import filedialog
+root = Tk()
+root.withdraw()
 
 import pyglet
 from moviepy.video.io.ffmpeg_writer import FFMPEG_VideoWriter
@@ -961,7 +963,6 @@ class Viewer(pyglet.window.Window):
         }
         filetypes = [file_types[x] for x in file_exts]
         try:
-            root = Tk()
             save_dir = self.viewer_flags["save_directory"]
             if save_dir is None:
                 save_dir = os.getcwd()
@@ -971,7 +972,6 @@ class Viewer(pyglet.window.Window):
         except Exception:
             return None
 
-        root.destroy()
         if filename == ():
             return None
         return filename

--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -14,15 +14,8 @@ import OpenGL
 
 import genesis as gs
 
-try:
-    from Tkinter import Tk
-    from Tkinter import tkFileDialog as filedialog
-except Exception:
-    try:
-        from tkinter import Tk
-        from tkinter import filedialog as filedialog
-    except Exception:
-        pass
+from tkinter import Tk
+from tkinter import filedialog
 
 import pyglet
 from moviepy.video.io.ffmpeg_writer import FFMPEG_VideoWriter


### PR DESCRIPTION
This PR should resolve [Issue#91](https://github.com/Genesis-Embodied-AI/Genesis/issues/91).
On macOS, a Tk instance should be initiated before creating the viewer.