### PR TITLE
Fix cpu option in example

### DIFF
--- a/examples/coupling/cloth_on_rigid.py
+++ b/examples/coupling/cloth_on_rigid.py
@@ -12,7 +12,7 @@ def main():
     args = parser.parse_args()
 
     ########################## init ##########################
-    gs.init(seed=0, precision="32", logging_level="debug")
+    gs.init(seed=0, precision="32", logging_level="debug", backend=gs.cpu if args.cpu else gs.gpu)
 
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(


### PR DESCRIPTION
This PR sets the cpu option in the simulator when you use pass the `--cpu` arg in the `cloth_on_rigid.py` example

And thank you very much for making this simulator, I really enjoyed the few hours I could play around with it and look forward to be able to have a force-torque sensor soon :)