### PR TITLE
Fix:Remove ANSI sequences and format issues in RBC.__repr

### DIFF
--- a/genesis/datatypes.py
+++ b/genesis/datatypes.py
@@ -42,10 +42,10 @@ class List(list, RBC):
     def _repr_elem_colorized(self, elem, common_length=0):
         content = self._repr_elem(elem, common_length)
         idx = content.find(">")
-        formatted_content = f"{colors.BLUE}{formats.ITALIC}{content[:idx+1]}{formats.RESET}{content[idx+1:]}"
+        formatted_content = f"{colors.BLUE}{formats.ITALIC}{content[:idx + 1]}{formats.RESET}{content[idx + 1:]}"
         idx = formatted_content.find(":")
         if idx >= 0:
-            formatted_content = f"{formatted_content[:idx]}{colors.GRAY}:{colors.MINT}{formatted_content[idx+1:]}"
+            formatted_content = f"{formatted_content[:idx]}{colors.GRAY}:{colors.MINT}{formatted_content[idx + 1:]}"
         formatted_content += formats.RESET
         return formatted_content
 
@@ -73,6 +73,10 @@ class List(list, RBC):
         return repr_str
 
     def __repr__(self):
+        if not __debug__:
+            self.__colorized__repr__()
+
+    def __colorized__repr__(self):
         repr_str = f"{colors.BLUE}{self._repr_type()}(len={colors.MINT}{formats.UNDERLINE}{len(self)}{formats.RESET}{colors.BLUE}, ["
 
         if len(self) == 0:
@@ -119,8 +123,8 @@ class List(list, RBC):
         right_line_len = line_len - left_line_len
 
         repr_str = (
-            f"{colors.CORN}{'─' * left_line_len} {formats.BOLD}{formats.ITALIC}{header}{formats.RESET} {colors.CORN}{'─' * right_line_len}{formats.RESET}\n"
-            + repr_str
+                f"{colors.CORN}{'─' * left_line_len} {formats.BOLD}{formats.ITALIC}{header}{formats.RESET} {colors.CORN}{'─' * right_line_len}{formats.RESET}\n"
+                + repr_str
         )
 
         return repr_str

--- a/genesis/options/options.py
+++ b/genesis/options/options.py
@@ -43,11 +43,15 @@ class Options(BaseModel, RBC):
     def _repr_type(cls):
         return f"<{cls.__module__}.{cls.__qualname__}>".replace("genesis", "gs")
 
-    def __repr__(self) -> str:
+    def __repr__(self):
+        if not __debug__:
+            self.__colorized__repr__()
+
+    def __colorized__repr__(self) -> str:
         property_attrs = self.__dict__.keys()
         max_attr_len = max([len(attr) for attr in property_attrs])
 
-        repr_str = f"{colors.CORN}{'─'*(max_attr_len + 3)} {formats.BOLD}{formats.ITALIC}{self._repr_type()}{formats.RESET} {colors.CORN}{'─' * (max_attr_len + 3)}\n"
+        repr_str = f"{colors.CORN}{'─' * (max_attr_len + 3)} {formats.BOLD}{formats.ITALIC}{self._repr_type()}{formats.RESET} {colors.CORN}{'─' * (max_attr_len + 3)}\n"
 
         for attr in property_attrs:
             formatted_str = f"{colors.BLUE}'{attr}'{formats.RESET}"

--- a/genesis/repr_base.py
+++ b/genesis/repr_base.py
@@ -31,7 +31,11 @@ class RBC:
             repr_str += f", material: {self.material}"
         return repr_str
 
-    def __repr__(self) -> str:
+    def __repr__(self):
+        if not __debug__:
+            self.__colorized__repr__()
+
+    def __colorized__repr__(self) -> str:
         all_attrs = self.__dir__()
         property_attrs = []
 
@@ -55,7 +59,7 @@ class RBC:
                 continue
             idx = content.find(">")
             # format with italic and color
-            formatted_content = f"{colors.MINT}{formats.ITALIC}{content[:idx+1]}{formats.RESET}{colors.MINT}{content[idx+1:]}{formats.RESET}"
+            formatted_content = f"{colors.MINT}{formats.ITALIC}{content[:idx + 1]}{formats.RESET}{colors.MINT}{content[idx + 1:]}{formats.RESET}"
             # in case it's multi-line
             if isinstance(getattr(self, attr), gs.List):
                 # 4 = 2 x ' + : + space
@@ -81,8 +85,8 @@ class RBC:
         right_line_len = max(right_line_len, min_line_len)
 
         repr_str = (
-            f"{colors.CORN}{'─'*left_line_len} {formats.BOLD}{formats.ITALIC}{self._repr_type()}{formats.RESET} {colors.CORN}{'─'*right_line_len}\n"
-            + repr_str
+                f"{colors.CORN}{'─' * left_line_len} {formats.BOLD}{formats.ITALIC}{self._repr_type()}{formats.RESET} {colors.CORN}{'─' * right_line_len}\n"
+                + repr_str
         )
 
         return repr_str


### PR DESCRIPTION
### Problem description
ANSI escape sequences (color and format control characters) used in the `__repr__` method may appear garbled in unsupported environments in debugging or terminal output, affecting the readability of debugger output or logging.

### Problem
- The console of a debugger such as PyCharm or VSCode does not parse ANSI escape sequences correctly.
- Attribute values are displayed inconsistently across multiple lines, with some members being displayed as “gibberish”.
- Some property values may throw exceptions when accessed, resulting in no display.
![before](https://github.com/user-attachments/assets/2f43d246-68e4-4780-9490-8523746b99af)


### Changes
Determine whether the current environment is a debug environment, so as to solve the problem of ANSI garbled code in the debug environment.

**Example of modified output**:
```text
<gs.Scene> t=<int>: 0 dt=<float>: 0.02 requires_grad=<bool>: False substeps=<int>: 2 visualizer=<gs.
![after](https://github.com/user-attachments/assets/b8d3a6d9-d9f3-4ccf-988c-7f7e6d607545)


