### PR TITLE
[Feature] Allows to turn on/off batch (links/dofs) info

### DIFF
--- a/examples/rigid/set_phys_attr.py
+++ b/examples/rigid/set_phys_attr.py
@@ -1,0 +1,205 @@
+import argparse
+
+import numpy as np
+
+import genesis as gs
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--vis", action="store_true", default=False)
+    args = parser.parse_args()
+
+    ########################## init ##########################
+    gs.init(backend=gs.gpu)
+
+    ########################## create a scene ##########################
+    viewer_options = gs.options.ViewerOptions(
+        camera_pos=(0, -3.5, 2.5),
+        camera_lookat=(0.0, 0.0, 0.5),
+        camera_fov=40,
+        max_FPS=60,
+    )
+
+    scene = gs.Scene(
+        viewer_options=viewer_options,
+        sim_options=gs.options.SimOptions(
+            dt=0.01,
+        ),
+        show_viewer=args.vis,
+        rigid_options=gs.options.RigidOptions(
+            # NOTE: Batching dofs/links info to set different physical attributes across environments (in parallel)
+            #       By default, both are False as it's faster and thus only turn this on if necessary
+            batch_dofs_info=True,
+            batch_links_info=True,
+        ),
+    )
+
+    ########################## entities ##########################
+    plane = scene.add_entity(
+        gs.morphs.Plane(),
+    )
+    franka = scene.add_entity(
+        gs.morphs.MJCF(file="xml/franka_emika_panda/panda.xml"),
+    )
+    ########################## build ##########################
+    scene.build(n_envs=2) # test with 2 different environments
+
+    jnt_names = [
+        "joint1",
+        "joint2",
+        "joint3",
+        "joint4",
+        "joint5",
+        "joint6",
+        "joint7",
+        "finger_joint1",
+        "finger_joint2",
+    ]
+    dofs_idx = [franka.get_joint(name).dof_idx_local for name in jnt_names]
+
+    lnk_names = [
+        "link0",
+        'link1',
+        'link2',
+        'link3',
+        'link4',
+        'link5',
+        'link6',
+        'link7',
+        'hand',
+        'left_finger',
+        'right_finger',
+    ]
+    links_idx = [franka.get_link(name).idx_local for name in lnk_names]
+
+    # Optional: set control gains
+    franka.set_dofs_kp(
+        np.array([
+            [4500, 4500, 3500, 3500, 2000, 2000, 2000, 100, 100],
+            [100, 100, 2000, 2000, 2000, 3500, 3500, 4500, 4500],
+        ]),
+        dofs_idx,
+    )
+    print("=== kp ===\n", franka.get_dofs_kp())
+    franka.set_dofs_kv(
+        np.array([
+            [450, 450, 350, 350, 200, 200, 200, 10, 10],
+            [10, 10, 200, 200, 200, 350, 350, 450, 450],
+        ]),
+        dofs_idx,
+    )
+    print("=== kv ===\n", franka.get_dofs_kv())
+    franka.set_dofs_force_range(
+        np.array([
+            [-87, -87, -87, -87, -12, -12, -12, -100, -100],
+            [-120, -100, -12, -12, -12, -87, -87, -87, -87],
+        ]),
+        np.array([
+            [87, 87, 87, 87, 12, 12, 12, 100, 100],
+            [100, 100, 12, 12, 12, 87, 87, 87, 87],
+        ]),
+        dofs_idx,
+    )
+    print("=== force range ===\n", franka.get_dofs_force_range())
+    franka.set_dofs_armature(
+        np.array([
+            [0.1] * len(dofs_idx),
+            [0.2] * len(dofs_idx),
+        ]),
+        dofs_idx,
+    )
+    print("=== armature ===\n", franka.get_dofs_armature())
+    franka.set_dofs_stiffness(
+        np.array([
+            [0.] * len(dofs_idx),
+            [0.1] * len(dofs_idx),
+        ]),
+        dofs_idx,
+    )
+    print("=== stiffness ===\n", franka.get_dofs_stiffness())
+    franka.set_dofs_invweight(
+        np.array([
+            [5.5882, 0.9693, 6.8053, 3.9007, 7.8085, 6.6139, 9.4213, 8.6984, 8.6984],
+            [8.6984, 8.6984, 9.4213, 6.6139, 7.8085, 3.9007, 6.8053, 0.9693, 5.5882],
+        ]),
+        dofs_idx,
+    )
+    print("=== invweight ===\n", franka.get_dofs_invweight())
+    franka.set_dofs_damping(
+        np.array([
+            [1.] * len(dofs_idx),
+            [2.] * len(dofs_idx),
+        ]),
+        dofs_idx,
+    )
+    print("=== damping ===\n", franka.get_dofs_damping())
+    franka.set_links_inertial_mass(
+        np.array([
+            [0.6298, 4.9707, 0.6469, 3.2286, 3.5879, 1.2259, 1.6666, 0.7355, 0.7300, 0.0150, 0.0150],
+            [0.015, 0.015, 0.73, 0.7355, 1.6666, 1.2259, 3.5879, 3.2286, 0.6469, 4.9707, 0.6298],
+        ]),
+        links_idx,
+    )
+    print("=== links inertial mass ===\n", franka.get_links_inertial_mass())
+    franka.set_links_invweight(
+        np.array([
+            [0.0, 3.6037e-05, 0.00030664, 0.025365, 0.036351, 0.072328, 0.089559, 0.11661, 0.11288, 3.0179, 3.0179],
+            [3.0179, 3.0179, 0.11288, 0.11661, 0.089559, 0.072328, 0.036351, 0.025365, 0.00030664, 3.6037e-05, 0.0],
+        ]),
+        links_idx,
+    )
+    print("=== links invweight ===\n", franka.get_links_invweight())
+
+    # Hard reset
+    for i in range(150):
+        if i < 50:
+            franka.set_dofs_position(np.array([1, 1, 0, 0, 0, 0, 0, 0.04, 0.04])[None, :].repeat(scene.n_envs, 0), dofs_idx)
+        elif i < 100:
+            franka.set_dofs_position(np.array([-1, 0.8, 1, -2, 1, 0.5, -0.5, 0.04, 0.04])[None, :].repeat(scene.n_envs, 0), dofs_idx)
+        else:
+            franka.set_dofs_position(np.array([0, 0, 0, 0, 0, 0, 0, 0, 0])[None, :].repeat(scene.n_envs, 0), dofs_idx)
+
+        scene.step()
+
+    # PD control
+    for i in range(1250):
+        if i == 0:
+            franka.control_dofs_position(
+                np.array([1, 1, 0, 0, 0, 0, 0, 0.04, 0.04])[None, :].repeat(scene.n_envs, 0),
+                dofs_idx,
+            )
+        elif i == 250:
+            franka.control_dofs_position(
+                np.array([-1, 0.8, 1, -2, 1, 0.5, -0.5, 0.04, 0.04])[None, :].repeat(scene.n_envs, 0),
+                dofs_idx,
+            )
+        elif i == 500:
+            franka.control_dofs_position(
+                np.array([0, 0, 0, 0, 0, 0, 0, 0, 0])[None, :].repeat(scene.n_envs, 0),
+                dofs_idx,
+            )
+        elif i == 750:
+            # control first dof with velocity, and the rest with position
+            franka.control_dofs_position(
+                np.array([0, 0, 0, 0, 0, 0, 0, 0, 0])[1:][None, :].repeat(scene.n_envs, 0),
+                dofs_idx[1:],
+            )
+            franka.control_dofs_velocity(
+                np.array([1.0, 0, 0, 0, 0, 0, 0, 0, 0])[:1][None, :].repeat(scene.n_envs, 0),
+                dofs_idx[:1],
+            )
+        elif i == 1000:
+            franka.control_dofs_force(
+                np.array([0, 0, 0, 0, 0, 0, 0, 0, 0])[None, :].repeat(scene.n_envs, 0),
+                dofs_idx,
+            )
+        # This is the internal control force computed based on the given control command
+        # If using force control, it's the same as the given control command
+        print("control force:", franka.get_dofs_control_force(dofs_idx))
+
+        scene.step()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rigid/set_phys_attr.py
+++ b/examples/rigid/set_phys_attr.py
@@ -43,7 +43,7 @@ def main():
         gs.morphs.MJCF(file="xml/franka_emika_panda/panda.xml"),
     )
     ########################## build ##########################
-    scene.build(n_envs=2) # test with 2 different environments
+    scene.build(n_envs=2)  # test with 2 different environments
 
     jnt_names = [
         "joint1",
@@ -60,93 +60,113 @@ def main():
 
     lnk_names = [
         "link0",
-        'link1',
-        'link2',
-        'link3',
-        'link4',
-        'link5',
-        'link6',
-        'link7',
-        'hand',
-        'left_finger',
-        'right_finger',
+        "link1",
+        "link2",
+        "link3",
+        "link4",
+        "link5",
+        "link6",
+        "link7",
+        "hand",
+        "left_finger",
+        "right_finger",
     ]
     links_idx = [franka.get_link(name).idx_local for name in lnk_names]
 
     # Optional: set control gains
     franka.set_dofs_kp(
-        np.array([
-            [4500, 4500, 3500, 3500, 2000, 2000, 2000, 100, 100],
-            [100, 100, 2000, 2000, 2000, 3500, 3500, 4500, 4500],
-        ]),
+        np.array(
+            [
+                [4500, 4500, 3500, 3500, 2000, 2000, 2000, 100, 100],
+                [100, 100, 2000, 2000, 2000, 3500, 3500, 4500, 4500],
+            ]
+        ),
         dofs_idx,
     )
     print("=== kp ===\n", franka.get_dofs_kp())
     franka.set_dofs_kv(
-        np.array([
-            [450, 450, 350, 350, 200, 200, 200, 10, 10],
-            [10, 10, 200, 200, 200, 350, 350, 450, 450],
-        ]),
+        np.array(
+            [
+                [450, 450, 350, 350, 200, 200, 200, 10, 10],
+                [10, 10, 200, 200, 200, 350, 350, 450, 450],
+            ]
+        ),
         dofs_idx,
     )
     print("=== kv ===\n", franka.get_dofs_kv())
     franka.set_dofs_force_range(
-        np.array([
-            [-87, -87, -87, -87, -12, -12, -12, -100, -100],
-            [-120, -100, -12, -12, -12, -87, -87, -87, -87],
-        ]),
-        np.array([
-            [87, 87, 87, 87, 12, 12, 12, 100, 100],
-            [100, 100, 12, 12, 12, 87, 87, 87, 87],
-        ]),
+        np.array(
+            [
+                [-87, -87, -87, -87, -12, -12, -12, -100, -100],
+                [-120, -100, -12, -12, -12, -87, -87, -87, -87],
+            ]
+        ),
+        np.array(
+            [
+                [87, 87, 87, 87, 12, 12, 12, 100, 100],
+                [100, 100, 12, 12, 12, 87, 87, 87, 87],
+            ]
+        ),
         dofs_idx,
     )
     print("=== force range ===\n", franka.get_dofs_force_range())
     franka.set_dofs_armature(
-        np.array([
-            [0.1] * len(dofs_idx),
-            [0.2] * len(dofs_idx),
-        ]),
+        np.array(
+            [
+                [0.1] * len(dofs_idx),
+                [0.2] * len(dofs_idx),
+            ]
+        ),
         dofs_idx,
     )
     print("=== armature ===\n", franka.get_dofs_armature())
     franka.set_dofs_stiffness(
-        np.array([
-            [0.] * len(dofs_idx),
-            [0.1] * len(dofs_idx),
-        ]),
+        np.array(
+            [
+                [0.0] * len(dofs_idx),
+                [0.1] * len(dofs_idx),
+            ]
+        ),
         dofs_idx,
     )
     print("=== stiffness ===\n", franka.get_dofs_stiffness())
     franka.set_dofs_invweight(
-        np.array([
-            [5.5882, 0.9693, 6.8053, 3.9007, 7.8085, 6.6139, 9.4213, 8.6984, 8.6984],
-            [8.6984, 8.6984, 9.4213, 6.6139, 7.8085, 3.9007, 6.8053, 0.9693, 5.5882],
-        ]),
+        np.array(
+            [
+                [5.5882, 0.9693, 6.8053, 3.9007, 7.8085, 6.6139, 9.4213, 8.6984, 8.6984],
+                [8.6984, 8.6984, 9.4213, 6.6139, 7.8085, 3.9007, 6.8053, 0.9693, 5.5882],
+            ]
+        ),
         dofs_idx,
     )
     print("=== invweight ===\n", franka.get_dofs_invweight())
     franka.set_dofs_damping(
-        np.array([
-            [1.] * len(dofs_idx),
-            [2.] * len(dofs_idx),
-        ]),
+        np.array(
+            [
+                [1.0] * len(dofs_idx),
+                [2.0] * len(dofs_idx),
+            ]
+        ),
         dofs_idx,
     )
     print("=== damping ===\n", franka.get_dofs_damping())
     franka.set_links_inertial_mass(
-        np.array([
-            [0.6298, 4.9707, 0.6469, 3.2286, 3.5879, 1.2259, 1.6666, 0.7355, 0.7300, 0.0150, 0.0150],
-            [0.015, 0.015, 0.73, 0.7355, 1.6666, 1.2259, 3.5879, 3.2286, 0.6469, 4.9707, 0.6298],
-        ]),
+        np.array(
+            [
+                [0.6298, 4.9707, 0.6469, 3.2286, 3.5879, 1.2259, 1.6666, 0.7355, 0.7300, 0.0150, 0.0150],
+                [0.015, 0.015, 0.73, 0.7355, 1.6666, 1.2259, 3.5879, 3.2286, 0.6469, 4.9707, 0.6298],
+            ]
+        ),
         links_idx,
     )
     print("=== links inertial mass ===\n", franka.get_links_inertial_mass())
     franka.set_links_invweight(
-        np.array([
-            [0.0, 3.6037e-05, 0.00030664, 0.025365, 0.036351, 0.072328, 0.089559, 0.11661, 0.11288, 3.0179, 3.0179],
-            [3.0179, 3.0179, 0.11288, 0.11661, 0.089559, 0.072328, 0.036351, 0.025365, 0.00030664, 3.6037e-05, 0.0],
-        ]),
+        np.array(
+            [
+                [0.0, 3.6037e-05, 0.00030664, 0.025365, 0.036351, 0.072328, 0.089559, 0.11661, 0.11288, 3.0179, 3.0179],
+                [3.0179, 3.0179, 0.11288, 0.11661, 0.089559, 0.072328, 0.036351, 0.025365, 0.00030664, 3.6037e-05, 0.0],
+            ]
+        ),
         links_idx,
     )
     print("=== links invweight ===\n", franka.get_links_invweight())
@@ -154,9 +174,13 @@ def main():
     # Hard reset
     for i in range(150):
         if i < 50:
-            franka.set_dofs_position(np.array([1, 1, 0, 0, 0, 0, 0, 0.04, 0.04])[None, :].repeat(scene.n_envs, 0), dofs_idx)
+            franka.set_dofs_position(
+                np.array([1, 1, 0, 0, 0, 0, 0, 0.04, 0.04])[None, :].repeat(scene.n_envs, 0), dofs_idx
+            )
         elif i < 100:
-            franka.set_dofs_position(np.array([-1, 0.8, 1, -2, 1, 0.5, -0.5, 0.04, 0.04])[None, :].repeat(scene.n_envs, 0), dofs_idx)
+            franka.set_dofs_position(
+                np.array([-1, 0.8, 1, -2, 1, 0.5, -0.5, 0.04, 0.04])[None, :].repeat(scene.n_envs, 0), dofs_idx
+            )
         else:
             franka.set_dofs_position(np.array([0, 0, 0, 0, 0, 0, 0, 0, 0])[None, :].repeat(scene.n_envs, 0), dofs_idx)
 

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1162,7 +1162,11 @@ class RigidEntity(Entity):
                         for i_l in range(self.link_start, self.link_end):
                             I_l = [i_l, i_b] if ti.static(self.solver._options.batch_links_info) else i_l
                             l_info = self._solver.links_info[I_l]
-                            I_dof_start = [l_info.dof_start, i_b] if ti.static(self.solver._options.batch_dofs_info) else l_info.dof_start
+                            I_dof_start = (
+                                [l_info.dof_start, i_b]
+                                if ti.static(self.solver._options.batch_dofs_info)
+                                else l_info.dof_start
+                            )
                             dof_info = self._solver.dofs_info[I_dof_start]
                             q_start = l_info.q_start
 
@@ -1714,7 +1718,7 @@ class RigidEntity(Entity):
         else:
             ls_idx_local = torch.as_tensor(ls_idx_local, dtype=gs.tc_int)
             if (ls_idx_local < 0).any() or (ls_idx_local >= self.n_links).any():
-                gs.raise_exception('`ls_idx_local` exceeds valid range.')
+                gs.raise_exception("`ls_idx_local` exceeds valid range.")
         return ls_idx_local
 
     def _get_ls_idx(self, ls_idx_local=None):

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1722,7 +1722,7 @@ class RigidEntity(Entity):
             self.zero_all_dofs_velocity(envs_idx)
 
     @gs.assert_built
-    def set_dofs_kp(self, kp, dofs_idx_local=None):
+    def set_dofs_kp(self, kp, dofs_idx_local=None, envs_idx=None):
         """
         Set the entity's dofs' positional gains for the PD controller.
 
@@ -1732,12 +1732,14 @@ class RigidEntity(Entity):
             The positional gains to set.
         dofs_idx_local : None | array_like, optional
             The indices of the dofs to set. If None, all dofs will be set. Note that here this uses the local `q_idx`, not the scene-level one. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
         """
 
-        self._solver.set_dofs_kp(kp, self._get_dofs_idx(dofs_idx_local))
+        self._solver.set_dofs_kp(kp, self._get_dofs_idx(dofs_idx_local), envs_idx)
 
     @gs.assert_built
-    def set_dofs_kv(self, kv, dofs_idx_local=None):
+    def set_dofs_kv(self, kv, dofs_idx_local=None, envs_idx=None):
         """
         Set the entity's dofs' velocity gains for the PD controller.
 
@@ -1747,11 +1749,13 @@ class RigidEntity(Entity):
             The velocity gains to set.
         dofs_idx_local : None | array_like, optional
             The indices of the dofs to set. If None, all dofs will be set. Note that here this uses the local `q_idx`, not the scene-level one. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
         """
-        self._solver.set_dofs_kv(kv, self._get_dofs_idx(dofs_idx_local))
+        self._solver.set_dofs_kv(kv, self._get_dofs_idx(dofs_idx_local), envs_idx)
 
     @gs.assert_built
-    def set_dofs_force_range(self, lower, upper, dofs_idx_local=None):
+    def set_dofs_force_range(self, lower, upper, dofs_idx_local=None, envs_idx=None):
         """
         Set the entity's dofs' force range.
 
@@ -1763,9 +1767,11 @@ class RigidEntity(Entity):
             The upper bounds of the force range.
         dofs_idx_local : None | array_like, optional
             The indices of the dofs to set. If None, all dofs will be set. Note that here this uses the local `q_idx`, not the scene-level one. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
         """
 
-        self._solver.set_dofs_force_range(lower, upper, self._get_dofs_idx(dofs_idx_local))
+        self._solver.set_dofs_force_range(lower, upper, self._get_dofs_idx(dofs_idx_local), envs_idx)
 
     @gs.assert_built
     def set_dofs_velocity(self, velocity, dofs_idx_local=None, envs_idx=None):
@@ -1954,7 +1960,7 @@ class RigidEntity(Entity):
         return self._solver.get_dofs_position(self._get_dofs_idx(dofs_idx_local), envs_idx)
 
     @gs.assert_built
-    def get_dofs_kp(self, dofs_idx_local=None):
+    def get_dofs_kp(self, dofs_idx_local=None, envs_idx=None):
         """
         Get the positional gain (kp) for the entity's dofs used by the PD controller.
 
@@ -1962,16 +1968,18 @@ class RigidEntity(Entity):
         ----------
         dofs_idx_local : None | array_like, optional
             The indices of the dofs to get. If None, all dofs will be returned. Note that here this uses the local `q_idx`, not the scene-level one. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
 
         Returns
         -------
-        kp : torch.Tensor, shape (n_dofs,)
+        kp : torch.Tensor, shape (n_dofs,) or (n_envs, n_dofs)
             The positional gain (kp) for the entity's dofs.
         """
-        return self._solver.get_dofs_kp(self._get_dofs_idx(dofs_idx_local))
+        return self._solver.get_dofs_kp(self._get_dofs_idx(dofs_idx_local), envs_idx)
 
     @gs.assert_built
-    def get_dofs_kv(self, dofs_idx_local=None):
+    def get_dofs_kv(self, dofs_idx_local=None, envs_idx=None):
         """
         Get the velocity gain (kv) for the entity's dofs used by the PD controller.
 
@@ -1979,16 +1987,18 @@ class RigidEntity(Entity):
         ----------
         dofs_idx_local : None | array_like, optional
             The indices of the dofs to get. If None, all dofs will be returned. Note that here this uses the local `q_idx`, not the scene-level one. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
 
         Returns
         -------
-        kv : torch.Tensor, shape (n_dofs,)
+        kv : torch.Tensor, shape (n_dofs,) or (n_envs, n_dofs)
             The velocity gain (kv) for the entity's dofs.
         """
-        return self._solver.get_dofs_kv(self._get_dofs_idx(dofs_idx_local))
+        return self._solver.get_dofs_kv(self._get_dofs_idx(dofs_idx_local), envs_idx)
 
     @gs.assert_built
-    def get_dofs_force_range(self, dofs_idx_local=None):
+    def get_dofs_force_range(self, dofs_idx_local=None, envs_idx=None):
         """
         Get the force range (min and max limits) for the entity's dofs.
 
@@ -1996,18 +2006,20 @@ class RigidEntity(Entity):
         ----------
         dofs_idx_local : None | array_like, optional
             The indices of the dofs to get. If None, all dofs will be returned. Note that here this uses the local `q_idx`, not the scene-level one. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
 
         Returns
         -------
-        lower_limit : torch.Tensor, shape (n_dofs,)
+        lower_limit : torch.Tensor, shape (n_dofs,) or (n_envs, n_dofs)
             The lower limit of the force range for the entity's dofs.
-        upper_limit : torch.Tensor, shape (n_dofs,)
+        upper_limit : torch.Tensor, shape (n_dofs,) or (n_envs, n_dofs)
             The upper limit of the force range for the entity's dofs.
         """
-        return self._solver.get_dofs_force_range(self._get_dofs_idx(dofs_idx_local))
+        return self._solver.get_dofs_force_range(self._get_dofs_idx(dofs_idx_local), envs_idx)
 
     @gs.assert_built
-    def get_dofs_limit(self, dofs_idx=None):
+    def get_dofs_limit(self, dofs_idx=None, envs_idx=None):
         """
         Get the positional limits (min and max) for the entity's dofs.
 
@@ -2015,15 +2027,17 @@ class RigidEntity(Entity):
         ----------
         dofs_idx : None | array_like, optional
             The indices of the dofs to get. If None, all dofs will be returned. Note that here this uses the local `q_idx`, not the scene-level one. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
 
         Returns
         -------
-        lower_limit : torch.Tensor, shape (n_dofs,)
+        lower_limit : torch.Tensor, shape (n_dofs,) or (n_envs, n_dofs)
             The lower limit of the positional limits for the entity's dofs.
-        upper_limit : torch.Tensor, shape (n_dofs,)
+        upper_limit : torch.Tensor, shape (n_dofs,) or (n_envs, n_dofs)
             The upper limit of the positional limits for the entity's dofs.
         """
-        return self._solver.get_dofs_limit(self._get_dofs_idx(dofs_idx))
+        return self._solver.get_dofs_limit(self._get_dofs_idx(dofs_idx), envs_idx)
 
     @gs.assert_built
     def zero_all_dofs_velocity(self, envs_idx=None):

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1568,6 +1568,14 @@ class RigidEntity(Entity):
         return self._solver.get_links_ang(np.arange(self.link_start, self.link_end), envs_idx)
 
     @gs.assert_built
+    def get_links_inertial_mass(self, ls_idx_local=None, envs_idx=None):
+        return self._solver.get_links_inertial_mass(self._get_ls_idx(ls_idx_local), envs_idx)
+
+    @gs.assert_built
+    def get_links_invweight(self, ls_idx_local=None, envs_idx=None):
+        return self._solver.get_links_invweight(self._get_ls_idx(ls_idx_local), envs_idx)
+
+    @gs.assert_built
     def set_pos(self, pos, zero_velocity=True, envs_idx=None):
         """
         Set position of the entity's base link.
@@ -1700,6 +1708,18 @@ class RigidEntity(Entity):
     def _get_dofs_idx(self, dofs_idx_local=None):
         return self._get_dofs_idx_local(dofs_idx_local) + self._dof_start
 
+    def _get_ls_idx_local(self, ls_idx_local=None):
+        if ls_idx_local is None:
+            ls_idx_local = torch.arange(self.n_links, dtype=torch.int32, device=gs.device)
+        else:
+            ls_idx_local = torch.as_tensor(ls_idx_local, dtype=gs.tc_int)
+            if (ls_idx_local < 0).any() or (ls_idx_local >= self.n_links).any():
+                gs.raise_exception('`ls_idx_local` exceeds valid range.')
+        return ls_idx_local
+
+    def _get_ls_idx(self, ls_idx_local=None):
+        return self._get_ls_idx_local(ls_idx_local) + self._link_start
+
     @gs.assert_built
     def set_qpos(self, qpos, qs_idx_local=None, zero_velocity=True, envs_idx=None):
         """
@@ -1772,6 +1792,22 @@ class RigidEntity(Entity):
         """
 
         self._solver.set_dofs_force_range(lower, upper, self._get_dofs_idx(dofs_idx_local), envs_idx)
+
+    @gs.assert_built
+    def set_dofs_stiffness(self, stiffness, dofs_idx_local=None, envs_idx=None):
+        self._solver.set_dofs_stiffness(stiffness, self._get_dofs_idx(dofs_idx_local), envs_idx)
+
+    @gs.assert_built
+    def set_dofs_invweight(self, invweight, dofs_idx_local=None, envs_idx=None):
+        self._solver.set_dofs_invweight(invweight, self._get_dofs_idx(dofs_idx_local), envs_idx)
+
+    @gs.assert_built
+    def set_dofs_armature(self, armature, dofs_idx_local=None, envs_idx=None):
+        self._solver.set_dofs_armature(armature, self._get_dofs_idx(dofs_idx_local), envs_idx)
+
+    @gs.assert_built
+    def set_dofs_damping(self, damping, dofs_idx_local=None, envs_idx=None):
+        self._solver.set_dofs_damping(damping, self._get_dofs_idx(dofs_idx_local), envs_idx)
 
     @gs.assert_built
     def set_dofs_velocity(self, velocity, dofs_idx_local=None, envs_idx=None):
@@ -2040,6 +2076,22 @@ class RigidEntity(Entity):
         return self._solver.get_dofs_limit(self._get_dofs_idx(dofs_idx), envs_idx)
 
     @gs.assert_built
+    def get_dofs_stiffness(self, dofs_idx_local=None, envs_idx=None):
+        return self._solver.get_dofs_stiffness(self._get_dofs_idx(dofs_idx_local), envs_idx)
+
+    @gs.assert_built
+    def get_dofs_invweight(self, dofs_idx_local=None, envs_idx=None):
+        return self._solver.get_dofs_invweight(self._get_dofs_idx(dofs_idx_local), envs_idx)
+
+    @gs.assert_built
+    def get_dofs_armature(self, dofs_idx_local=None, envs_idx=None):
+        return self._solver.get_dofs_armature(self._get_dofs_idx(dofs_idx_local), envs_idx)
+
+    @gs.assert_built
+    def get_dofs_damping(self, dofs_idx_local=None, envs_idx=None):
+        return self._solver.get_dofs_damping(self._get_dofs_idx(dofs_idx_local), envs_idx)
+
+    @gs.assert_built
     def zero_all_dofs_velocity(self, envs_idx=None):
         """
         Zero the velocity of all the entity's dofs.
@@ -2270,6 +2322,14 @@ class RigidEntity(Entity):
         for i in range(len(link_indices)):
             link_indices[i] += self._link_start
         self._solver.set_links_COM_shift(com_shift, link_indices, envs_idx)
+
+    @gs.assert_built
+    def set_links_inertial_mass(self, inertial_mass, ls_idx_local=None, envs_idx=None):
+        self._solver.set_links_inertial_mass(inertial_mass, self._get_ls_idx(ls_idx_local), envs_idx)
+
+    @gs.assert_built
+    def set_links_invweight(self, invweight, ls_idx_local=None, envs_idx=None):
+        self._solver.set_links_invweight(invweight, self._get_ls_idx(ls_idx_local), envs_idx)
 
     @gs.assert_built
     def get_mass(self):

--- a/genesis/engine/entities/rigid_entity/rigid_joint.py
+++ b/genesis/engine/entities/rigid_entity/rigid_joint.py
@@ -125,7 +125,8 @@ class RigidJoint(RBC):
     def _kernel_get_quat(self, tensor: ti.types.ndarray()):
 
         for i_b in range(self._solver._B):
-            l_info = self._solver.links_info[self._idx, i_b]
+            I_l = [self._idx, i_b] if ti.static(self._solver._options.batch_links_info) else self._idx
+            l_info = self._solver.links_info[I_l]
             i_p = l_info.parent_idx
 
             p_pos = ti.Vector.zero(gs.ti_float, 3)

--- a/genesis/engine/entities/rigid_entity/rigid_joint.py
+++ b/genesis/engine/entities/rigid_entity/rigid_joint.py
@@ -90,7 +90,8 @@ class RigidJoint(RBC):
     def _kernel_get_pos(self, tensor: ti.types.ndarray()):
 
         for i_b in range(self._solver._B):
-            l_info = self._solver.links_info[self._idx, i_b]
+            I_l = [self._idx, i_b] if ti.static(self._solver._options.batch_links_info) else self._idx
+            l_info = self._solver.links_info[I_l]
             i_p = l_info.parent_idx
 
             p_pos = ti.Vector.zero(gs.ti_float, 3)

--- a/genesis/engine/solvers/rigid/collider_decomp.py
+++ b/genesis/engine/solvers/rigid/collider_decomp.py
@@ -51,6 +51,10 @@ class Collider:
         links_root_idx = self._solver.links_info.root_idx.to_numpy()
         links_parent_idx = self._solver.links_info.parent_idx.to_numpy()
         links_is_fixed = self._solver.links_info.is_fixed.to_numpy()
+        if self._solver._options.batch_links_info:
+            links_root_idx = links_root_idx[:, 0]
+            links_parent_idx = links_parent_idx[:, 0]
+            links_is_fixed = links_is_fixed[:, 0]
         n_possible_pairs = 0
         for i in range(self._solver.n_geoms):
             for j in range(i + 1, self._solver.n_geoms):

--- a/genesis/engine/solvers/rigid/collider_decomp.py
+++ b/genesis/engine/solvers/rigid/collider_decomp.py
@@ -164,10 +164,13 @@ class Collider:
                     i_la = self.contact_data[i_c, i_b].link_a
                     i_lb = self.contact_data[i_c, i_b].link_b
 
+                    I_la = [i_la, i_b] if ti.static(self._solver._options.batch_links_info) else i_la
+                    I_lb = [i_lb, i_b] if ti.static(self._solver._options.batch_links_info) else i_lb
+
                     # pair of hibernated-fixed links -> hibernated contact
                     # TODO: we should also include hibernated-hibernated links and wake up the whole contact island once a new collision is detected
-                    if (self._solver.links_state[i_la, i_b].hibernated and self._solver.links_info[i_lb].is_fixed) or (
-                        self._solver.links_state[i_lb, i_b].hibernated and self._solver.links_info[i_la].is_fixed
+                    if (self._solver.links_state[i_la, i_b].hibernated and self._solver.links_info[I_lb].is_fixed) or (
+                        self._solver.links_state[i_lb, i_b].hibernated and self._solver.links_info[I_la].is_fixed
                     ):
                         i_c_hibernated = self.n_contacts_hibernated[i_b]
                         if i_c != i_c_hibernated:
@@ -549,6 +552,8 @@ class Collider:
     def _func_check_collision_valid(self, i_ga, i_gb, i_b):
         i_la = self._solver.geoms_info[i_ga].link_idx
         i_lb = self._solver.geoms_info[i_gb].link_idx
+        I_la = [i_la, i_b] if ti.static(self._solver._options.batch_links_info) else i_la
+        I_lb = [i_lb, i_b] if ti.static(self._solver._options.batch_links_info) else i_lb
         is_valid = True
 
         # geoms in the same link
@@ -558,22 +563,22 @@ class Collider:
         # self collision
         if (
             ti.static(not self._solver._enable_self_collision)
-            and self._solver.links_info[i_la].root_idx == self._solver.links_info[i_lb].root_idx
+            and self._solver.links_info[I_la].root_idx == self._solver.links_info[I_lb].root_idx
         ):
             is_valid = False
 
         # adjacent links
-        if self._solver.links_info[i_la].parent_idx == i_lb or self._solver.links_info[i_lb].parent_idx == i_la:
+        if self._solver.links_info[I_la].parent_idx == i_lb or self._solver.links_info[I_lb].parent_idx == i_la:
             is_valid = False
 
         # pair of fixed links
-        if self._solver.links_info[i_la].is_fixed and self._solver.links_info[i_lb].is_fixed:
+        if self._solver.links_info[I_la].is_fixed and self._solver.links_info[I_lb].is_fixed:
             is_valid = False
 
         # hibernated <-> fixed links
         if ti.static(self._solver._use_hibernation):
-            if (self._solver.links_state[i_la, i_b].hibernated and self._solver.links_info[i_lb].is_fixed) or (
-                self._solver.links_state[i_lb, i_b].hibernated and self._solver.links_info[i_la].is_fixed
+            if (self._solver.links_state[i_la, i_b].hibernated and self._solver.links_info[I_lb].is_fixed) or (
+                self._solver.links_state[i_lb, i_b].hibernated and self._solver.links_info[I_la].is_fixed
             ):
                 is_valid = False
 
@@ -994,7 +999,9 @@ class Collider:
 
         i_la = self._solver.geoms_info[i_ga].link_idx
         i_lb = self._solver.geoms_info[i_gb].link_idx
-        is_self_pair = self._solver.links_info.root_idx[i_la] == self._solver.links_info.root_idx[i_lb]
+        I_la = [i_la, i_b] if ti.static(self._solver._options.batch_links_info) else i_la
+        I_lb = [i_lb, i_b] if ti.static(self._solver._options.batch_links_info) else i_lb
+        is_self_pair = self._solver.links_info.root_idx[I_la] == self._solver.links_info.root_idx[I_lb]
         multi_contact = (
             self._solver.geoms_info[i_ga].type != gs.GEOM_TYPE.SPHERE
             and self._solver.geoms_info[i_gb].type != gs.GEOM_TYPE.SPHERE

--- a/genesis/engine/solvers/rigid/constraint_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/constraint_solver_decomp.py
@@ -105,12 +105,14 @@ class ConstraintSolver:
                 impact = self._collider.contact_data[i_col, i_b]
                 link_a = impact.link_a
                 link_b = impact.link_b
+                link_a_maybe_batch = [link_a, i_b] if ti.static(self._solver._options.batch_links_info) else link_a
+                link_b_maybe_batch = [link_b, i_b] if ti.static(self._solver._options.batch_links_info) else link_b
                 f = impact.friction
                 pos = impact.pos
 
                 d1, d2 = gu.orthogonals(impact.normal)
 
-                t = self._solver.links_info[link_a].invweight + self._solver.links_info[link_b].invweight * (
+                t = self._solver.links_info[link_a_maybe_batch].invweight + self._solver.links_info[link_b_maybe_batch].invweight * (
                     link_b > -1
                 )
                 for i in range(4):
@@ -143,10 +145,11 @@ class ConstraintSolver:
                             link = link_b
 
                         while link > -1:
+                            link_maybe_batch = [link, i_b] if ti.static(self._solver._options.batch_links_info) else link
 
                             # reverse order to make sure dofs in each row of self.jac_relevant_dofs is strictly descending
-                            for i_d_ in range(self._solver.links_info[link].n_dofs):
-                                i_d = self._solver.links_info[link].dof_end - 1 - i_d_
+                            for i_d_ in range(self._solver.links_info[link_maybe_batch].n_dofs):
+                                i_d = self._solver.links_info[link_maybe_batch].dof_end - 1 - i_d_
 
                                 cdof_ang = self._solver.dofs_state[i_d, i_b].cdof_ang
                                 cdot_vel = self._solver.dofs_state[i_d, i_b].cdof_vel
@@ -164,7 +167,7 @@ class ConstraintSolver:
                                     self.jac_relevant_dofs[n_con, con_n_relevant_dofs, i_b] = i_d
                                     con_n_relevant_dofs += 1
 
-                            link = self._solver.links_info[link].parent_idx
+                            link = self._solver.links_info[link_maybe_batch].parent_idx
 
                     if ti.static(self.sparse_solve):
                         self.jac_n_relevant_dofs[n_con, i_b] = con_n_relevant_dofs
@@ -183,21 +186,23 @@ class ConstraintSolver:
         ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for i_b in range(self._B):
             for i_l in range(self._solver.n_links):
-                l_info = self._solver.links_info[i_l]
+                I_l = [i_l, i_b] if ti.static(self._solver._options.batch_links_info) else i_l
+                l_info = self._solver.links_info[I_l]
                 if l_info.joint_type == gs.JOINT_TYPE.REVOLUTE or l_info.joint_type == gs.JOINT_TYPE.PRISMATIC:
 
                     i_q = l_info.q_start
                     i_d = l_info.dof_start
-                    pos_min = self._solver.qpos[i_q, i_b] - self._solver.dofs_info[i_d].limit[0]
-                    pos_max = self._solver.dofs_info[i_d].limit[1] - self._solver.qpos[i_q, i_b]
+                    I_d = [i_d, i_b] if ti.static(self._solver._options.batch_dofs_info) else i_d
+                    pos_min = self._solver.qpos[i_q, i_b] - self._solver.dofs_info[I_d].limit[0]
+                    pos_max = self._solver.dofs_info[I_d].limit[1] - self._solver.qpos[i_q, i_b]
                     pos = min(min(pos_min, pos_max), 0)
 
                     side = ((pos_min < pos_max) * 2 - 1) * (pos < 0)
 
                     jac = side
                     jac_qvel = jac * self._solver.dofs_state[i_d, i_b].vel
-                    imp, aref = gu.imp_aref(self._solver.dofs_info[i_d].sol_params, pos, jac_qvel)
-                    diag = self._solver.dofs_info[i_d].invweight * (pos < 0) * (1 - imp) / (imp + gs.EPS)
+                    imp, aref = gu.imp_aref(self._solver.dofs_info[I_d].sol_params, pos, jac_qvel)
+                    diag = self._solver.dofs_info[I_d].invweight * (pos < 0) * (1 - imp) / (imp + gs.EPS)
                     aref = aref * (pos < 0)
                     if pos < 0:
                         n_con = self.n_constraints[i_b]

--- a/genesis/engine/solvers/rigid/constraint_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/constraint_solver_decomp.py
@@ -112,9 +112,9 @@ class ConstraintSolver:
 
                 d1, d2 = gu.orthogonals(impact.normal)
 
-                t = self._solver.links_info[link_a_maybe_batch].invweight + self._solver.links_info[link_b_maybe_batch].invweight * (
-                    link_b > -1
-                )
+                t = self._solver.links_info[link_a_maybe_batch].invweight + self._solver.links_info[
+                    link_b_maybe_batch
+                ].invweight * (link_b > -1)
                 for i in range(4):
                     n = -d1 * f - impact.normal
                     if i == 1:
@@ -145,7 +145,9 @@ class ConstraintSolver:
                             link = link_b
 
                         while link > -1:
-                            link_maybe_batch = [link, i_b] if ti.static(self._solver._options.batch_links_info) else link
+                            link_maybe_batch = (
+                                [link, i_b] if ti.static(self._solver._options.batch_links_info) else link
+                            )
 
                             # reverse order to make sure dofs in each row of self.jac_relevant_dofs is strictly descending
                             for i_d_ in range(self._solver.links_info[link_maybe_batch].n_dofs):

--- a/genesis/engine/solvers/rigid/constraint_solver_decomp_island.py
+++ b/genesis/engine/solvers/rigid/constraint_solver_decomp_island.py
@@ -224,13 +224,13 @@ class ConstraintSolverIsland:
             e_info = self.entities_info[i_e]
 
             for i_l in range(e_info.link_start, e_info.link_end):
-                I_l = [i_l, i_b] if ti.static(self._options.batch_links_info) else i_l
+                I_l = [i_l, i_b] if ti.static(self._solver._options.batch_links_info) else i_l
                 l_info = self._solver.links_info[I_l]
                 if l_info.joint_type == gs.JOINT_TYPE.REVOLUTE or l_info.joint_type == gs.JOINT_TYPE.PRISMATIC:
 
                     i_q = l_info.q_start
                     i_d = l_info.dof_start
-                    I_d = [i_d, i_b] if ti.static(self._options.batch_dofs_info) else i_d
+                    I_d = [i_d, i_b] if ti.static(self._solver._options.batch_dofs_info) else i_d
                     pos_min = self._solver.qpos[i_q, i_b] - self._solver.dofs_info[I_d].limit[0]
                     pos_max = self._solver.dofs_info[I_d].limit[1] - self._solver.qpos[i_q, i_b]
                     pos = min(min(pos_min, pos_max), 0)

--- a/genesis/engine/solvers/rigid/constraint_solver_decomp_island.py
+++ b/genesis/engine/solvers/rigid/constraint_solver_decomp_island.py
@@ -131,12 +131,14 @@ class ConstraintSolverIsland:
             impact = self._collider.contact_data[i_col, i_b]
             link_a = impact.link_a
             link_b = impact.link_b
+            link_a_maybe_batch = [link_a, i_b] if ti.static(self._solver._options.batch_links_info) else link_a
+            link_b_maybe_batch = [link_b, i_b] if ti.static(self._solver._options.batch_links_info) else link_b
             f = impact.friction
             pos = impact.pos
 
             d1, d2 = gu.orthogonals(impact.normal)
 
-            t = self._solver.links_info[link_a].invweight + self._solver.links_info[link_b].invweight * (link_b > -1)
+            t = self._solver.links_info[link_a_maybe_batch].invweight + self._solver.links_info[link_b_maybe_batch].invweight * (link_b > -1)
 
             for i in range(4):
                 n = -d1 * f - impact.normal
@@ -170,10 +172,11 @@ class ConstraintSolverIsland:
                         link = link_b
 
                     while link > -1:
+                        link_maybe_batch = [link, i_b] if ti.static(self._solver._options.batch_links_info) else link
 
                         # reverse order to make sure dofs in each row of self.jac_relevant_dofs is strictly descending
                         for i_d_ in range(self._solver.links_info[link].n_dofs):
-                            i_d = self._solver.links_info[link].dof_end - 1 - i_d_
+                            i_d = self._solver.links_info[link_maybe_batch].dof_end - 1 - i_d_
 
                             cdof_ang = self._solver.dofs_state[i_d, i_b].cdof_ang
                             cdot_vel = self._solver.dofs_state[i_d, i_b].cdof_vel
@@ -190,7 +193,7 @@ class ConstraintSolverIsland:
                                 self.jac_relevant_dofs[n_con, con_n_relevant_dofs, i_b] = i_d
                                 con_n_relevant_dofs += 1
 
-                        link = self._solver.links_info[link].parent_idx
+                        link = self._solver.links_info[link_maybe_batch].parent_idx
 
                 if ti.static(self.sparse_solve):
                     self.jac_n_relevant_dofs[n_con, i_b] = con_n_relevant_dofs
@@ -207,8 +210,8 @@ class ConstraintSolverIsland:
 
             if ti.static(self._solver._use_hibernation):
                 # wake up entities
-                self._solver._func_wakeup_entity(self._solver.links_info[link_a].entity_idx, i_b)
-                self._solver._func_wakeup_entity(self._solver.links_info[link_b].entity_idx, i_b)
+                self._solver._func_wakeup_entity(self._solver.links_info[link_a_maybe_batch].entity_idx, i_b)
+                self._solver._func_wakeup_entity(self._solver.links_info[link_b_maybe_batch].entity_idx, i_b)
 
     @ti.func
     def add_joint_limit_constraints(self, island, i_b):
@@ -219,22 +222,23 @@ class ConstraintSolverIsland:
             e_info = self.entities_info[i_e]
 
             for i_l in range(e_info.link_start, e_info.link_end):
-
-                l_info = self._solver.links_info[i_l]
+                I_l = [i_l, i_b] if ti.static(self._options.batch_links_info) else i_l
+                l_info = self._solver.links_info[I_l]
                 if l_info.joint_type == gs.JOINT_TYPE.REVOLUTE or l_info.joint_type == gs.JOINT_TYPE.PRISMATIC:
 
                     i_q = l_info.q_start
                     i_d = l_info.dof_start
-                    pos_min = self._solver.qpos[i_q, i_b] - self._solver.dofs_info[i_d].limit[0]
-                    pos_max = self._solver.dofs_info[i_d].limit[1] - self._solver.qpos[i_q, i_b]
+                    I_d = [i_d, i_b] if ti.static(self._options.batch_dofs_info) else i_d
+                    pos_min = self._solver.qpos[i_q, i_b] - self._solver.dofs_info[I_d].limit[0]
+                    pos_max = self._solver.dofs_info[I_d].limit[1] - self._solver.qpos[i_q, i_b]
                     pos = min(min(pos_min, pos_max), 0)
 
                     side = ((pos_min < pos_max) * 2 - 1) * (pos < 0)
 
                     jac = side
                     jac_qvel = jac * self._solver.dofs_state[i_d, i_b].vel
-                    imp, aref = gu.imp_aref(self._solver.dofs_info[i_d].sol_params, pos, jac_qvel)
-                    diag = self._solver.dofs_info[i_d].invweight * (pos < 0) * (1 - imp) / (imp + gs.EPS)
+                    imp, aref = gu.imp_aref(self._solver.dofs_info[I_d].sol_params, pos, jac_qvel)
+                    diag = self._solver.dofs_info[I_d].invweight * (pos < 0) * (1 - imp) / (imp + gs.EPS)
                     aref = aref * (pos < 0)
                     if pos < 0:
                         n_con = self.n_constraints[i_b]

--- a/genesis/engine/solvers/rigid/constraint_solver_decomp_island.py
+++ b/genesis/engine/solvers/rigid/constraint_solver_decomp_island.py
@@ -138,7 +138,9 @@ class ConstraintSolverIsland:
 
             d1, d2 = gu.orthogonals(impact.normal)
 
-            t = self._solver.links_info[link_a_maybe_batch].invweight + self._solver.links_info[link_b_maybe_batch].invweight * (link_b > -1)
+            t = self._solver.links_info[link_a_maybe_batch].invweight + self._solver.links_info[
+                link_b_maybe_batch
+            ].invweight * (link_b > -1)
 
             for i in range(4):
                 n = -d1 * f - impact.normal

--- a/genesis/engine/solvers/rigid/contact_island.py
+++ b/genesis/engine/solvers/rigid/contact_island.py
@@ -66,8 +66,11 @@ class ContactIsland:
 
     @ti.func
     def add_edge(self, link_a, link_b, i_b):
-        ea = self.solver.links_info[link_a].entity_idx
-        eb = self.solver.links_info[link_b].entity_idx
+        link_a_maybe_batch = [link_a, i_b] if ti.static(self.solver._options.batch_links_info) else link_a
+        link_b_maybe_batch = [link_b, i_b] if ti.static(self.solver._options.batch_links_info) else link_b
+
+        ea = self.solver.links_info[link_a_maybe_batch].entity_idx
+        eb = self.solver.links_info[link_b_maybe_batch].entity_idx
 
         self.entity_edge[ea, i_b].n = self.entity_edge[ea, i_b].n + 1
         self.entity_edge[eb, i_b].n = self.entity_edge[eb, i_b].n + 1
@@ -100,9 +103,11 @@ class ContactIsland:
                 impact = self.collider.contact_data[i_col, i_b]
                 link_a = impact.link_a
                 link_b = impact.link_b
+                link_a_maybe_batch = [link_a, i_b] if ti.static(self.solver._options.batch_links_info) else link_a
+                link_b_maybe_batch = [link_b, i_b] if ti.static(self.solver._options.batch_links_info) else link_b
 
-                ea = self.solver.links_info[link_a].entity_idx
-                eb = self.solver.links_info[link_b].entity_idx
+                ea = self.solver.links_info[link_a_maybe_batch].entity_idx
+                eb = self.solver.links_info[link_b_maybe_batch].entity_idx
 
                 island_a = self.entity_island[ea, i_b]
                 island_b = self.entity_island[eb, i_b]

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -346,7 +346,7 @@ class RigidSolver(Solver):
     ):
         ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for I in ti.grouped(self.dofs_info):
-            i = I[0] # batching (if any) will be the second dim
+            i = I[0]  # batching (if any) will be the second dim
 
             for j in ti.static(range(3)):
                 self.dofs_info[I].motion_ang[j] = dofs_motion_ang[i, j]
@@ -2499,7 +2499,9 @@ class RigidSolver(Solver):
                         q_end = l_info.q_end
 
                         for j_d in range(q_end - q_start):
-                            I_d = [dof_start + j_d, i_b] if ti.static(self._options.batch_dofs_info) else dof_start + j_d
+                            I_d = (
+                                [dof_start + j_d, i_b] if ti.static(self._options.batch_dofs_info) else dof_start + j_d
+                            )
                             self.dofs_state[dof_start + j_d, i_b].qf_passive = (
                                 -self.qpos[q_start + j_d, i_b] * self.dofs_info[I_d].stiffness
                             )
@@ -3358,9 +3360,11 @@ class RigidSolver(Solver):
 
     def _set_links_info(self, tensor, links_idx, name, envs_idx=None):
         if self._options.batch_links_info:
-            tensor, links_idx, envs_idx = self._validate_1D_io_variables(tensor, links_idx, envs_idx, idx_name='links_idx')
+            tensor, links_idx, envs_idx = self._validate_1D_io_variables(
+                tensor, links_idx, envs_idx, idx_name="links_idx"
+            )
         else:
-            tensor, links_idx = self._validate_1D_io_variables(tensor, links_idx, idx_name='links_idx', batched=False)
+            tensor, links_idx = self._validate_1D_io_variables(tensor, links_idx, idx_name="links_idx", batched=False)
             envs_idx = torch.empty(())
 
         if name == "invweight":
@@ -3928,7 +3932,9 @@ class RigidSolver(Solver):
 
     def _get_links_info(self, links_idx, name, envs_idx=None):
         if self._options.batch_links_info:
-            tensor, links_idx, envs_idx = self._validate_1D_io_variables(None, links_idx, envs_idx, idx_name="links_idx")
+            tensor, links_idx, envs_idx = self._validate_1D_io_variables(
+                None, links_idx, envs_idx, idx_name="links_idx"
+            )
         else:
             tensor, links_idx = self._validate_1D_io_variables(None, links_idx, idx_name="links_idx", batched=False)
             envs_idx = torch.empty(())

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -313,7 +313,7 @@ class RigidSolver(Solver):
 
         joints = self.joints
         is_nonempty = np.concatenate([joint.dofs_motion_ang for joint in joints], dtype=gs.np_float).shape[0] > 0
-        if is_nonempty: # handle the case where there is a link with no dofs -- otherwise may cause invalid memory
+        if is_nonempty:  # handle the case where there is a link with no dofs -- otherwise may cause invalid memory
             self._kernel_init_dof_fields(
                 dofs_motion_ang=np.concatenate([joint.dofs_motion_ang for joint in joints], dtype=gs.np_float),
                 dofs_motion_vel=np.concatenate([joint.dofs_motion_vel for joint in joints], dtype=gs.np_float),

--- a/genesis/options/solvers.py
+++ b/genesis/options/solvers.py
@@ -185,6 +185,10 @@ class RigidOptions(Options):
     integrator: gs.integrator = gs.integrator.approximate_implicitfast
     IK_max_targets: int = 6
 
+    # batching info
+    batch_links_info: Optional[bool] = False
+    batch_dofs_info: Optional[bool] = False
+
     # constraint solver
     constraint_solver: gs.constraint_solver = gs.constraint_solver.CG
     iterations: int = 100


### PR DESCRIPTION
In the rigid solver option, there are `batch_links_info` and `batch_dofs_info`. If either is set to True, in the rigid solver, we introduce additional batch dimension (like in `links_state` or `dofs_state`). If they are both set to False, the built kernels in the solver should resemble those from the original code -- w/o the batch dimension.

An example is added in `examples/rigid/set_phys_attr.py`, which demonstrates how to set kp, kv, force range, armature, stiffness, invweight, damping for dofs and inertial mass, and invweight for links.

Related issues: https://github.com/Genesis-Embodied-AI/Genesis/issues/70, https://github.com/Genesis-Embodied-AI/Genesis/issues/120