### PR TITLE
[Feature] add particle free in MPM

### DIFF
--- a/genesis/engine/entities/mpm_entity.py
+++ b/genesis/engine/entities/mpm_entity.py
@@ -185,6 +185,27 @@ class MPMEntity(ParticleEntity):
 
             self.set_muscle_direction(muscle_direction)
 
+    def set_free(self, free):
+        self._assert_active()
+
+        self.solver._kernel_set_free(
+            self._particle_start,
+            self._n_particles,
+            free,
+        )
+
+    def get_free(self):
+        self._assert_active()
+
+        free = gs.zeros((self._n_particles,), dtype=int, requires_grad=False, scene=self._scene)
+        self.solver._kernel_get_free(
+            self._particle_start,
+            self._n_particles,
+            free,
+        )
+
+        return free
+
     @ti.kernel
     def clear_grad(self, f: ti.i32):
         for i in range(self.n_particles):

--- a/genesis/engine/solvers/mpm_solver.py
+++ b/genesis/engine/solvers/mpm_solver.py
@@ -385,7 +385,7 @@ class MPMSolver(Solver):
                         )
                         self.grid[f, base - self._grid_offset + offset].mass += weight * self.particles_info[i].mass
 
-                    if self.particles_info[i].free == 0: # non-free particles behave as boundary conditions
+                    if self.particles_info[i].free == 0:  # non-free particles behave as boundary conditions
                         self.grid[f, base - self._grid_offset + offset].vel_in = ti.Vector.zero(gs.ti_float, 3)
 
     @ti.kernel

--- a/genesis/engine/solvers/mpm_solver.py
+++ b/genesis/engine/solvers/mpm_solver.py
@@ -93,6 +93,7 @@ class MPMSolver(Solver):
             mat_idx=gs.ti_int,
             mass=gs.ti_float,
             default_Jp=gs.ti_float,
+            free=gs.ti_int,
             # for muscle
             muscle_group=gs.ti_int,
             muscle_direction=gs.ti_vec3,
@@ -384,6 +385,9 @@ class MPMSolver(Solver):
                         )
                         self.grid[f, base - self._grid_offset + offset].mass += weight * self.particles_info[i].mass
 
+                    if self.particles_info[i].free == 0: # non-free particles behave as boundary conditions
+                        self.grid[f, base - self._grid_offset + offset].vel_in = ti.Vector.zero(gs.ti_float, 3)
+
     @ti.kernel
     def g2p(self, f: ti.i32):
         for i in range(self._n_particles):
@@ -658,6 +662,7 @@ class MPMSolver(Solver):
             self.particles_info[i_global].mat_idx = mat_idx
             self.particles_info[i_global].default_Jp = mat_default_Jp
             self.particles_info[i_global].mass = self._p_vol * mat_rho
+            self.particles_info[i_global].free = 1
             self.particles_info[i_global].muscle_group = 0
             self.particles_info[i_global].muscle_direction = ti.Vector([0.0, 0.0, 1.0], dt=gs.ti_float)
 
@@ -815,6 +820,28 @@ class MPMSolver(Solver):
             i_global = i + particle_start
             for j in ti.static(range(3)):
                 self.particles_info[i_global].muscle_direction[j] = muscle_direction[i, j]
+
+    @ti.kernel
+    def _kernel_set_free(
+        self,
+        particle_start: ti.i32,
+        n_particles: ti.i32,
+        free: ti.types.ndarray(),
+    ):
+        for i in range(n_particles):
+            i_global = i + particle_start
+            self.particles_info[i_global].free = free[i]
+
+    @ti.kernel
+    def _kernel_get_free(
+        self,
+        particle_start: ti.i32,
+        n_particles: ti.i32,
+        free: ti.types.ndarray(),
+    ):
+        for i in range(n_particles):
+            i_global = i + particle_start
+            free[i] = self.particles_info[i_global].free
 
     @ti.kernel
     def _kernel_get_state(


### PR DESCRIPTION
Feature support for https://github.com/Genesis-Embodied-AI/Genesis/issues/190

New APIs: `mpm_entity.set/get_free`.
Non-free particles behave as boundary conditions.

Example code
```
import genesis as gs

########################## init ##########################
gs.init()

########################## create a scene ##########################

scene = gs.Scene(
    sim_options=gs.options.SimOptions(
        dt=4e-3,
        substeps=10,
    ),
    mpm_options=gs.options.MPMOptions(
        lower_bound=(-0.5, -1.0, 0.0),
        upper_bound=(0.5, 1.0, 1),
    ),
    vis_options=gs.options.VisOptions(
        visualize_mpm_boundary=True,
    ),
    viewer_options=gs.options.ViewerOptions(
        camera_fov=30,
        res=(960, 640),
    ),
    show_viewer=True,
)

########################## entities ##########################
plane = scene.add_entity(
    morph=gs.morphs.Plane(),
)

obj = scene.add_entity(
    material=gs.materials.MPM.Elastic(),
    morph=gs.morphs.Box(
        pos=(0.0, -0.5, 0.25),
        size=(0.2, 0.5, 0.2),
    ),
    surface=gs.surfaces.Default(
        color=(1.0, 0.4, 0.4),
        vis_mode="particle",
    ),
)

########################## build ##########################
scene.build()

################### set active/free/non-fixed particles ####################
pos = obj.get_state().pos.detach().cpu()
is_fixed = pos[:, 1] < (pos.min(0)[0][1] + 0.2)
free = obj.get_free()
free[is_fixed] = 0
obj.set_free(free)

########################## run ##########################
for i in range(1000):
    scene.step()
```