### PR TITLE
avoid trimesh import failure when pyrender has issue

### DIFF
--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -4,9 +4,10 @@ import genesis as gs
 import genesis.utils.geom as gu
 import genesis.utils.mesh as mu
 import genesis.utils.particle as pu
+from genesis.ext import trimesh
 
 try:
-    from genesis.ext import pyrender, trimesh
+    from genesis.ext import pyrender
     from genesis.ext.pyrender.jit_render import JITRenderer
 except Exception as e:
     print(f"[Error]: {e}\n")
@@ -199,14 +200,13 @@ class RasterizerContext:
 
                 for link in links:
                     link_T = gu.trans_quat_to_T(links_pos[link.idx], links_quat[link.idx])
-                    buffer_updates[self._scene.get_buffer_id(self.link_frame_nodes[link.uid], "model")] = (
-                        link_T.transpose([0, 2, 1])
-                    )
+                    buffer_updates[
+                        self._scene.get_buffer_id(self.link_frame_nodes[link.uid], "model")
+                    ] = link_T.transpose([0, 2, 1])
 
     def on_tool(self):
         if self.sim.tool_solver.is_active():
             for tool_entity in self.sim.tool_solver.entities:
-
                 if tool_entity.mesh is not None:
                     mesh = trimesh.Trimesh(
                         tool_entity.mesh.init_vertices_np,
@@ -411,9 +411,9 @@ class RasterizerContext:
                     tfs = np.tile(np.eye(4), (mpm_entity.n_particles, 1, 1))
                     tfs[:, :3, 3] = particles_all[mpm_entity.particle_start : mpm_entity.particle_end]
 
-                    buffer_updates[self._scene.get_buffer_id(self.static_nodes[mpm_entity.uid], "model")] = (
-                        tfs.transpose([0, 2, 1])
-                    )
+                    buffer_updates[
+                        self._scene.get_buffer_id(self.static_nodes[mpm_entity.uid], "model")
+                    ] = tfs.transpose([0, 2, 1])
 
                 elif mpm_entity.surface.vis_mode == "visual":
                     mpm_entity._vmesh.verts = vverts_all[mpm_entity.vvert_start : mpm_entity.vvert_end]
@@ -476,9 +476,9 @@ class RasterizerContext:
                     tfs = np.tile(np.eye(4), (sph_entity.n_particles, 1, 1))
                     tfs[:, :3, 3] = particles_all[sph_entity.particle_start : sph_entity.particle_end]
 
-                    buffer_updates[self._scene.get_buffer_id(self.static_nodes[sph_entity.uid], "model")] = (
-                        tfs.transpose([0, 2, 1])
-                    )
+                    buffer_updates[
+                        self._scene.get_buffer_id(self.static_nodes[sph_entity.uid], "model")
+                    ] = tfs.transpose([0, 2, 1])
 
     def on_pbd(self):
         if self.sim.pbd_solver.is_active():
@@ -556,9 +556,9 @@ class RasterizerContext:
                         tfs = np.tile(np.eye(4), (pbd_entity.n_particles, 1, 1))
                         tfs[:, :3, 3] = particles_all[pbd_entity.particle_start : pbd_entity.particle_end]
 
-                        buffer_updates[self._scene.get_buffer_id(self.static_nodes[pbd_entity.uid], "model")] = (
-                            tfs.transpose([0, 2, 1])
-                        )
+                        buffer_updates[
+                            self._scene.get_buffer_id(self.static_nodes[pbd_entity.uid], "model")
+                        ] = tfs.transpose([0, 2, 1])
 
                     elif self.render_particle_as == "tet":
                         new_verts = mu.transform_tets_mesh_verts(
@@ -574,7 +574,6 @@ class RasterizerContext:
                             buffer_updates[self._scene.get_buffer_id(node, "normal")] = normal_data
 
                 elif pbd_entity.surface.vis_mode == "visual":
-
                     vverts = vverts_all[pbd_entity.vvert_start : pbd_entity.vvert_end]
                     node = self.static_nodes[pbd_entity.uid]
                     update_data = self._scene.reorder_vertices(node, vverts)


### PR DESCRIPTION
- Separated the trimesh import from pyrender

Avoid failure case like following:

```bash
[Error]: couldn't connect to display ""

Failed to import pyrender. Rendering will not work.
[Genesis] [08:48:54] [INFO] ╭─────────────────────────────────────────────────────────────────────────────────────╮
[Genesis] [08:48:54] [INFO] │┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉ Genesis ┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉│
[Genesis] [08:48:54] [INFO] ╰─────────────────────────────────────────────────────────────────────────────────────╯
[Genesis] [08:48:54] [INFO] Running on [NVIDIA GeForce RTX 3090] with backend gs.cuda. Device memory: 23.69 GB.
[Genesis] [08:48:54] [DEBUG] [Taichi] version 1.7.2, llvm 15.0.4, commit 0131dce9, linux, python 3.11.10
[Genesis] [08:48:54] [DEBUG] [Taichi] Starting on arch=cuda
[Genesis] [08:48:54] [INFO] 🚀 Genesis initialized. 🔖 version: 0.2.0, 🌱 seed: None, 📏 precision: '32', 🐛 debug: False, 🎨 theme: 'dark'.
Traceback (most recent call last):
  File "/workspace/examples/elastic_dragon.py", line 58, in <module>
    main()
  File "/workspace/examples/elastic_dragon.py", line 19, in main
    scene = gs.Scene(
            ^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/genesis/utils/misc.py", line 27, in new_init
    original_init(self, *args, **kwargs)
  File "/opt/conda/lib/python3.11/site-packages/genesis/engine/scene.py", line 148, in __init__
    self._visualizer = Visualizer(
                       ^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/genesis/vis/visualizer.py", line 26, in __init__
    self._context = RasterizerContext(vis_options)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/genesis/vis/rasterizer_context.py", line 37, in __init__
    self.init_meshes()
  File "/opt/conda/lib/python3.11/site-packages/genesis/vis/rasterizer_context.py", line 52, in init_meshes
    self.link_frame_mesh = trimesh.creation.axis(origin_size=0.03, axis_radius=0.025, axis_length=1.0)
                           ^^^^^^^
NameError: name 'trimesh' is not defined
[Genesis] [08:48:55] [INFO] 💤 Exiting Genesis and caching compiled kernels...
```