### PR TITLE
[BUG FIX] fix AttributeError: 'HoverEnv' object has no attribute 'target'

### DIFF
--- a/examples/drone/hover_env.py
+++ b/examples/drone/hover_env.py
@@ -64,6 +64,8 @@ class HoverEnv:
                                     ),
                                 ),
                             )
+        else:
+            self.target = None
 
         # add camera
         if self.env_cfg["visualize_camera"]:


### PR DESCRIPTION
### Change
Added initialization of the target attribute in the `__init__` method of the `HoverEnv` class to ensure it is always defined.