### PR TITLE
Add default help message for gs CLI when no arguments are provided: _main.py

### DIFF
--- a/genesis/_main.py
+++ b/genesis/_main.py
@@ -252,6 +252,8 @@ def main():
         view(args.filename, args.collision, args.rotate, args.scale)
     elif args.command == "animate":
         animate(args.filename_pattern, args.fps)
+    elif args.command == None:
+        parser.print_help()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added `parser.print_help()` to ensure users receive guidance on available commands instead of the CLI failing silently.