### PR TITLE
[Bug Fix] avoid changing input link index in rigid_entity

### DIFF
--- a/examples/rigid/domain_randomization.py
+++ b/examples/rigid/domain_randomization.py
@@ -46,15 +46,15 @@ def main():
     ########################## domain randomization ##########################
     robot.set_friction_ratio(
         friction_ratio=0.5 + torch.rand(scene.n_envs, robot.n_links),
-        link_indices=np.arange(0, robot.n_links),
+        ls_idx_local=np.arange(0, robot.n_links),
     )
     robot.set_mass_shift(
         mass_shift=-0.5 + torch.rand(scene.n_envs, robot.n_links),
-        link_indices=np.arange(0, robot.n_links),
+        ls_idx_local=np.arange(0, robot.n_links),
     )
     robot.set_COM_shift(
         com_shift=-0.05 + 0.1 * torch.rand(scene.n_envs, robot.n_links, 3),
-        link_indices=np.arange(0, robot.n_links),
+        ls_idx_local=np.arange(0, robot.n_links),
     )
 
     joint_names = [

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -2323,9 +2323,7 @@ class RigidEntity(Entity):
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         """
         geom_indices = [
-            self._links[il]._geom_start + g_idx
-            for il in ls_idx_local
-            for g_idx in range(self._links[il].n_geoms)
+            self._links[il]._geom_start + g_idx for il in ls_idx_local for g_idx in range(self._links[il].n_geoms)
         ]
 
         self._solver.set_geoms_friction_ratio(

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -2351,9 +2351,8 @@ class RigidEntity(Entity):
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         """
-        for i in range(len(link_indices)):
-            link_indices[i] += self._link_start
-        self._solver.set_links_mass_shift(mass_shift, link_indices, envs_idx)
+        global_link_indices = [self._link_start + i for i in link_indices]
+        self._solver.set_links_mass_shift(mass_shift, global_link_indices, envs_idx)
 
     def set_COM_shift(self, com_shift, link_indices, envs_idx=None):
         """
@@ -2367,9 +2366,8 @@ class RigidEntity(Entity):
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         """
-        for i in range(len(link_indices)):
-            link_indices[i] += self._link_start
-        self._solver.set_links_COM_shift(com_shift, link_indices, envs_idx)
+        global_link_indices = [self._link_start + i for i in link_indices]
+        self._solver.set_links_COM_shift(com_shift, global_link_indices, envs_idx)
 
     @gs.assert_built
     def set_links_inertial_mass(self, inertial_mass, ls_idx_local=None, envs_idx=None):


### PR DESCRIPTION
RigidEntiry set_mass_shift and set_COM_shift changed the function parameters link_indicies and we normally don't expect so.

create a temporary list instead so it does not affect the input parameters:

        global_link_indices = [self._link_start + i for i in link_indices]
        self._solver.set_links_COM_shift(com_shift, global_link_indices, envs_idx)