### PR TITLE
[Bug Fix] Modify the deprecated interp2d method into the supported RegularGridInterpolator method

### DIFF
--- a/genesis/ext/isaacgym/terrain_utils.py
+++ b/genesis/ext/isaacgym/terrain_utils.py
@@ -77,11 +77,13 @@ def random_uniform_terrain(
     x = np.linspace(0, terrain.width * terrain.horizontal_scale, height_field_downsampled.shape[0])
     y = np.linspace(0, terrain.length * terrain.horizontal_scale, height_field_downsampled.shape[1])
 
-    f = interpolate.interp2d(y, x, height_field_downsampled, kind="linear")
+    # f = interpolate.interp2d(y, x, height_field_downsampled, kind="linear")
+    f = interpolate.RegularGridInterpolator((y, x), height_field_downsampled, method="linear")
 
     x_upsampled = np.linspace(0, terrain.width * terrain.horizontal_scale, terrain.width)
     y_upsampled = np.linspace(0, terrain.length * terrain.horizontal_scale, terrain.length)
-    z_upsampled = np.rint(f(y_upsampled, x_upsampled))
+    # z_upsampled = np.rint(f(y_upsampled, x_upsampled))
+    z_upsampled = np.rint(f((y_upsampled, x_upsampled)))
 
     terrain.height_field_raw += z_upsampled.astype(np.int16)
     return terrain


### PR DESCRIPTION
将不受新版本`SciPy`支持的方法`interp2d`，修改为受支持的`RegularGridInterpolator`方法
Modify the method interp2d, which is not supported by the new version of SciPy, into the supported RegularGridInterpolator method.

issue #507

具体修改如下：
```python
    # f = interpolate.interp2d(y, x, height_field_downsampled, kind="linear")
    f = interpolate.RegularGridInterpolator((y, x), height_field_downsampled, method="linear")

    x_upsampled = np.linspace(0, terrain.width * terrain.horizontal_scale, terrain.width)
    y_upsampled = np.linspace(0, terrain.length * terrain.horizontal_scale, terrain.length)
    # z_upsampled = np.rint(f(y_upsampled, x_upsampled))
    z_upsampled = np.rint(f((y_upsampled, x_upsampled)))
```
