### PR TITLE
[BUG FIX] Add .gitattributes file for line endings handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Force LF line endings for shell scripts
+*.sh text eol=lf
+
+# Force LF line endings for configuration files
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.conf text eol=lf
+
+# Force LF for Docker-related files
+Dockerfile text eol=lf
+*.dockerignore text eol=lf


### PR DESCRIPTION
When shell scripts have Windows style CRLF line endings, Unix systems may not recognize them as valid executible files. The core.autocrlf input setting tells Git to convert CRLF to LF, and keep LF as is. Fixes errors building dockers, and addresses the build_luisa.sh errors.