### PR TITLE
[Bugfix] unstable hybrid robot example

### DIFF
--- a/examples/tutorials/advanced_hybrid_robot.py
+++ b/examples/tutorials/advanced_hybrid_robot.py
@@ -21,6 +21,7 @@ scene = gs.Scene(
         gravity=(0, 0, -9.8),
         enable_collision=True,
         enable_self_collision=False,
+        contact_resolve_time=0.02,  # avoid the rigid contact solver being too stiff otherwise will cause large impulse (especially we have small dt for rigid solver)
     ),
     mpm_options=gs.options.MPMOptions(
         dt=dt,


### PR DESCRIPTION
Previously, `contact_resolve_time` was hardcoded to 0.02 but now it is set to None with default value as twice the `substep_dt` in the rigid solver. In hybrid robot setup, the `dt`'s of the rigid and the mpm solver are set to the same value to avoid drifting in coupling. However, this makes the `contact_resolve_time` becomes super small, leading to a stiff system and large impulse. Thus, we need to set the `contact_resolve_time` to a larger number (0.02) to fix the issue.

Related issue: https://github.com/Genesis-Embodied-AI/Genesis/issues/476