### PR TITLE
Fix custom XML file display in simulation environment

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -449,6 +449,8 @@ class RigidEntity(Entity):
                     sol_params=g_info["sol_params"],
                     data=g_info["data"],
                     needs_coup=self.material.needs_coup,
+                    contype=g_info["contype"],
+                    conaffinity=g_info["conaffinity"],
                 )
             if not g_info["is_col"] and morph.visualization:
                 link._add_vgeom(

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -377,6 +377,10 @@ def parse_geom(mj, i_g, scale, convexify, surface, xml_path):
     friction = mj.geom_friction[i_g, 0]
     sol_params = np.concatenate((mj.geom_solref[i_g], mj.geom_solimp[i_g]))
 
+    # Add handling for contype and conaffinity attributes
+    contype = mj.geom_contype[i_g] if mj.geom_contype[i_g] else 0
+    conaffinity = mj.geom_conaffinity[i_g] if mj.geom_conaffinity[i_g] else 0
+
     info = {
         "type": gs_type,
         "pos": pos,
@@ -387,6 +391,8 @@ def parse_geom(mj, i_g, scale, convexify, surface, xml_path):
         "data": data,
         "friction": friction,
         "sol_params": sol_params,
+        "contype": contype,
+        "conaffinity": conaffinity,
     }
 
     return info


### PR DESCRIPTION
Fixes #548

Add handling for `contype` and `conaffinity` attributes in the simulation environment.

* Update `genesis/utils/mjcf.py` to parse `contype` and `conaffinity` attributes in the `parse_geom` function and set them to 0 if not specified.
* Update `genesis/engine/entities/rigid_entity/rigid_entity.py` to handle `contype` and `conaffinity` attributes in the `_load_MJCF` method and pass them to the `RigidGeom` constructor.

