### PR TITLE
Add camera follow entity feature

### DIFF
--- a/examples/drone/interactive_drone.py
+++ b/examples/drone/interactive_drone.py
@@ -134,6 +134,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-v", "--vis", action="store_true", default=True, help="Enable visualization (default: True)")
     parser.add_argument("-m", "--mac", action="store_true", default=False, help="Running on MacOS (default: False)")
+    parser.add_argument("-f", "--follow", action="store_true", default=False, help="Enable camera follow (default: False)")
     args = parser.parse_args()
 
     # Initialize Genesis
@@ -183,6 +184,16 @@ def main():
     # Start keyboard listener
     listener = keyboard.Listener(on_press=controller.on_press, on_release=controller.on_release)
     listener.start()
+
+    if args.follow:
+        camera = scene.add_camera(
+            res=(640, 480),
+            pos=(0.0, -4.0, 2.0),
+            lookat=(0.0, 0.0, 0.5),
+            fov=45,
+            GUI=True,
+        )
+        scene.set_camera_follow_entity(camera, drone, height=2.0, smoothing=0.1)
 
     if args.mac:
         # Run simulation in another thread

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -729,6 +729,10 @@ class Scene(RBC):
         if self._show_FPS:
             self.FPS_tracker.step()
 
+        # Update camera to follow entity if enabled
+        if hasattr(self, "_camera_follow_entity") and self._camera_follow_entity is not None:
+            self._camera_follow_entity.follow_entity()
+
     def _step_grad(self):
         self._sim.collect_output_grads()
         self._sim._step_grad()
@@ -912,6 +916,24 @@ class Scene(RBC):
 
         self._backward_ready = False
         self._forward_ready = False
+
+    def set_camera_follow_entity(self, camera, entity, height=None, smoothing=None):
+        """
+        Set the camera to follow a specified entity.
+
+        Parameters
+        ----------
+        camera : genesis.Camera
+            The camera to follow the entity.
+        entity : genesis.Entity
+            The entity to follow.
+        height : float, optional
+            The height at which the camera should follow the entity. If None, the camera will maintain its current height.
+        smoothing : float, optional
+            The smoothing factor for the camera's movement. If None, no smoothing will be applied.
+        """
+        camera.follow_entity(entity, height, smoothing)
+        self._camera_follow_entity = camera
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------


### PR DESCRIPTION
Fixes #538

Add functionality for the camera to follow an entity.

* **Camera Class (`genesis/vis/camera.py`)**
  - Add `_follow_entity`, `_follow_height`, and `_follow_smoothing` attributes.
  - Add `follow_entity` method to set the camera to follow a specified entity.
  - Update `render` method to call `follow_entity` if enabled.

* **Scene Class (`genesis/engine/scene.py`)**
  - Add `set_camera_follow_entity` method to set the camera to follow a specified entity.
  - Update `step` method to call `set_camera_follow_entity` if enabled.

* **Drone Example (`examples/drone/interactive_drone.py`)**
  - Add `--follow` argument to enable camera follow.
  - Update `main` function to use `follow_entity` method if `--follow` argument is provided.

