### PR TITLE
[BUG FIX] Adding torch as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "coacd",
     "OpenEXR",
     "black",
+    "torch",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
When installing via `pip install -e .` in a conda environment, torch had to be installed after to make the examples work.
a manual `pip install torch` worked.

This PR adds torch as dependency in pyproject.toml