### PR TITLE
[BUGFIX] Drone rpm to cpu 

### DIFF
--- a/examples/drone/hover_env.py
+++ b/examples/drone/hover_env.py
@@ -131,8 +131,13 @@ class HoverEnv:
         self.actions = torch.clip(actions, -self.env_cfg["clip_actions"], self.env_cfg["clip_actions"])
         exec_actions = self.actions
 
-        # 14468 is hover rpm
-        self.drone.set_propellels_rpm((1 + exec_actions * 0.8) * 14468.429183500699)
+        # 14468 is hover env
+        rpm = (1 + exec_actions * 0.8) * 14468.429183500699
+        if rpm.is_cuda:
+            rpm_cpu = rpm.cpu()
+        else:
+            rpm_cpu = rpm
+        self.drone.set_propellels_rpm(rpm_cpu)
         self.scene.step()
 
         # update buffers


### PR DESCRIPTION
## Problem

Using `python examples/drone/hover_train.py -e drone-hovering -B 8192 --max_iterations 10` was not working:

```bash
root@9f23f87289b1:/workspace# python examples/drone/hover_train.py -e drone-hovering -B 8192 --max_iterations 30 
Actor MLP: Sequential(
  (0): Linear(in_features=17, out_features=128, bias=True)
  (1): Tanh()
  (2): Linear(in_features=128, out_features=128, bias=True)
  (3): Tanh()
  (4): Linear(in_features=128, out_features=4, bias=True)
)
Critic MLP: Sequential(
  (0): Linear(in_features=17, out_features=128, bias=True)
  (1): Tanh()
  (2): Linear(in_features=128, out_features=128, bias=True)
  (3): Tanh()
  (4): Linear(in_features=128, out_features=1, bias=True)
)
Traceback (most recent call last):
  File "/workspace/examples/drone/hover_train.py", line 150, in <module>
    main()
  File "/workspace/examples/drone/hover_train.py", line 146, in main
    runner.learn(num_learning_iterations=args.max_iterations, init_at_random_ep_len=True)
  File "/workspace/rsl_rl/rsl_rl/runners/on_policy_runner.py", line 108, in learn
    obs, privileged_obs, rewards, dones, infos = self.env.step(actions)
                                                 ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/examples/drone/hover_env.py", line 135, in step
    self.drone.set_propellels_rpm((1 + exec_actions * 0.8) * 14468.429183500699)
  File "/opt/conda/lib/python3.11/site-packages/genesis/engine/entities/drone_entity.py", line 50, in set_propellels_rpm
    propellels_rpm = self.solver._process_dim(np.array(propellels_rpm, dtype=gs.np_float)).T
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/_tensor.py", line 1151, in __array__
    return self.numpy().astype(dtype, copy=False)
           ^^^^^^^^^^^^
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```

## Fix

Change propellers rpm to `cpu` before applying to drone. 