### PR TITLE
[FEATURE] Camera and viewer able to follow and entity

### DIFF
--- a/examples/drone/interactive_drone.py
+++ b/examples/drone/interactive_drone.py
@@ -91,23 +91,6 @@ class DroneController:
         return self.rpms
 
 
-def update_camera(scene, drone):
-    """Updates the camera position to follow the drone"""
-    if not scene.viewer:
-        return
-
-    drone_pos = drone.get_pos()
-
-    # Camera position relative to drone
-    offset_x = 0.0  # centered horizontally
-    offset_y = -4.0  # 4 units behind (in Y axis)
-    offset_z = 2.0  # 2 units above
-
-    camera_pos = (float(drone_pos[0] + offset_x), float(drone_pos[1] + offset_y), float(drone_pos[2] + offset_z))
-
-    # Update camera position and look target
-    scene.viewer.set_camera_pose(pos=camera_pos, lookat=tuple(float(x) for x in drone_pos))
-
 
 def run_sim(scene, drone, controller):
     while controller.running:
@@ -118,9 +101,6 @@ def run_sim(scene, drone, controller):
 
             # Update physics
             scene.step()
-
-            # Update camera position to follow drone
-            update_camera(scene, drone)
 
             time.sleep(1 / 60)  # Limit simulation rate
         except Exception as e:
@@ -164,6 +144,8 @@ def main():
             pos=(0.0, 0, 0.5),  # Start a bit higher
         ),
     )
+
+    scene.viewer.follow_entity(drone)
 
     # Build scene
     scene.build()

--- a/examples/locomotion/go2_env.py
+++ b/examples/locomotion/go2_env.py
@@ -64,6 +64,16 @@ class Go2Env:
             ),
         )
 
+        # add follower camera
+        if show_viewer:
+            self.follower_camera = self.scene.add_camera(res=(640,480),
+                                        pos=(0.0, 2.0, 0.5),
+                                        lookat=(0.0, 0.0, 0.5),
+                                        fov=40,
+                                        GUI=True)
+            # follow the robot at a fixed height and orientation 
+            self.follower_camera.follow_entity(self.robot, fixed_axis=(None, None, 0.5), smoothing=0.5, fix_orientation=True)
+
         # build
         self.scene.build(n_envs=num_envs)
 
@@ -123,6 +133,9 @@ class Go2Env:
         target_dof_pos = exec_actions * self.env_cfg["action_scale"] + self.default_dof_pos
         self.robot.control_dofs_position(target_dof_pos, self.motor_dofs)
         self.scene.step()
+
+        if hasattr(self, "follower_camera"):
+            self.follower_camera.render()
 
         # update buffers
         self.episode_length_buf += 1

--- a/examples/locomotion/go2_train.py
+++ b/examples/locomotion/go2_train.py
@@ -137,6 +137,7 @@ def get_cfgs():
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--vis", action="store_true", default=False, help="Enable visualization (default: False)")
     parser.add_argument("-e", "--exp_name", type=str, default="go2-walking")
     parser.add_argument("-B", "--num_envs", type=int, default=4096)
     parser.add_argument("--max_iterations", type=int, default=100)
@@ -153,7 +154,7 @@ def main():
     os.makedirs(log_dir, exist_ok=True)
 
     env = Go2Env(
-        num_envs=args.num_envs, env_cfg=env_cfg, obs_cfg=obs_cfg, reward_cfg=reward_cfg, command_cfg=command_cfg
+        num_envs=args.num_envs, env_cfg=env_cfg, obs_cfg=obs_cfg, reward_cfg=reward_cfg, command_cfg=command_cfg, show_viewer=args.vis
     )
 
     runner = OnPolicyRunner(env, train_cfg, log_dir, device="cuda:0")

--- a/genesis/vis/viewer.py
+++ b/genesis/vis/viewer.py
@@ -42,6 +42,12 @@ class Viewer(RBC):
 
         self.context = context
 
+        self._followed_entity = None
+        self._follow_fixed_axis = None
+        self._follow_smoothing = None
+        self._follow_fix_orientation = None
+        self._follow_lookat = None
+
         if self._max_FPS is not None:
             self.rate = Rate(self._max_FPS)
 
@@ -109,6 +115,9 @@ class Viewer(RBC):
         self._camera_node = self.context.add_node(pyrender.PerspectiveCamera(yfov=yfov), pose=pose)
 
     def update(self):
+        if self._followed_entity is not None:
+            self.update_following()
+
         with self.lock:
             buffer_updates = self.context.update()
             for buffer_id, buffer_data in buffer_updates.items():
@@ -152,6 +161,57 @@ class Viewer(RBC):
                 gs.raise_exception("pose should be a 4x4 matrix.")
 
         self._pyrender_viewer._trackball.set_camera_pose(pose)
+
+    def follow_entity(self, entity, fixed_axis=(None, None, None), smoothing=None, fix_orientation=False):
+        """
+        Set the viewer to follow a specified entity.
+        Parameters
+        ----------
+        entity : genesis.Entity
+            The entity to follow.
+        fixed_axis : (float, float, float), optional
+            The fixed axis for the viewer's movement. For each axis, if None, the viewer will move freely. If a float, the viewer will be fixed on at that value.
+            For example, [None, None, None] will allow the viewer to move freely while following, [None, None, 0.5] will fix the viewer's z-axis at 0.5.   
+        smoothing : float, optional
+            The smoothing factor in ]0,1[ for the viewer's movement. If None, no smoothing will be applied.
+        fix_orientation : bool, optional
+            If True, the viewer will maintain its orientation relative to the world. If False, the viewer will look at the base link of the entity.
+        """
+        self._followed_entity = entity
+        self._follow_fixed_axis = fixed_axis
+        self._follow_smoothing = smoothing
+        self._follow_fix_orientation = fix_orientation
+        self._follow_lookat = self._camera_init_lookat
+
+    def update_following(self):
+        """
+        Update the viewer position to follow the specified entity.
+        """
+        entity_pos = self._followed_entity.get_pos().cpu().numpy()
+        if entity_pos.ndim > 1: #check for multiple envs
+            entity_pos = entity_pos[0]
+        camera_pose = np.array(self._pyrender_viewer._trackball.pose)
+        camera_pos = np.array(self._pyrender_viewer._trackball.pose[:3, 3])
+
+        if self._follow_smoothing is not None:
+            # Smooth viewer movement with a low-pass filter
+            camera_pos = self._follow_smoothing * camera_pos + (1 - self._follow_smoothing) * (entity_pos + np.array(self._camera_init_pos)) 
+            self._follow_lookat = self._follow_smoothing * self._follow_lookat + (1 - self._follow_smoothing) * entity_pos
+        else:
+            camera_pos = entity_pos + np.array(self._camera_init_pos)
+            self._follow_lookat = entity_pos
+
+        for i, fixed_axis in enumerate(self._follow_fixed_axis):
+            # Fix the camera's position along the specified axis
+            if fixed_axis is not None:
+                camera_pos[i] = fixed_axis
+
+        if self._follow_fix_orientation:
+            # Keep the camera orientation fixed by overriding the lookat point
+            camera_pose[:3, 3] = camera_pos
+            self.set_camera_pose(pose=camera_pose)
+        else:
+            self.set_camera_pose(pos=camera_pos, lookat=self._follow_lookat)
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------


### PR DESCRIPTION
Fixes #538 and #554 

Hello ! 

I made changes to the camera and viewer class so that they can now follow an entity in various ways.

For both the viewer and any camera, once they are created, you can : 
```python

scene = gs.Scene(
            sim_options=gs.options.SimOptions(dt=0.02, substeps=2),
            viewer_options=gs.options.ViewerOptions(
                max_FPS=50,
                camera_pos=(2.0, 0.0, 2.5),
                camera_lookat=(0.0, 0.0, 0.5),
                camera_fov=40,
            ),
            show_viewer=True,
        )

entity = scene.add_entity() #load any enity

scene.viewer.follow_entity(entity)

follower_camera = scene.add_camera(res=(640,480),
                                        pos=(0.0, 2.0, 0.5),
                                        lookat=(0.0, 0.0, 0.5),
                                        fov=40,
                                        GUI=True)
 
follower_camera.follow_entity(entity, fixed_axis=(None, None, 0.5), smoothing=0.5, fix_orientation=True)
```
In this code both the viewer and follower_camera will follow the entity. The viewer will be rigidly linked to the entity, no smoothing (a bit nauseating if you do locomotion ahah!). The second one will have a smoothed motion on the xy plane and a fixed height of 0.5m. 

`fixed_axis` is used to fix the camera movement on a chosen axis `[x, y, z]`, if set to `None` the camera is able to move on this axis during the following. If set to a float the camera will stay fixed at this value on this axis. **This does not fix its orientation. Hence won't change where the camera looks at, just its position the camera can still look up with a fixed z**

`fix_orientation` is used alongside the `fixed_axis` because even though you fixed some axis the camera will rotate due to the call of `lookat`, this can lead to unwanted movement. For example, if fixed on the z height in a locomotion case the robot's gait might lead to some z movement and those would be repercuted on the camera orientation doing ups and downs.

# Added code 
* camera.py
    + Added attributes relative to the following 
    + Added function `follow_entity` to register the followed entity with some arguments related to the cameras' movement
    + Updated the `render` function to compute the camera's position with `update_following`

* viewer.py
    + Basicaly the same, variation on the functions to call to set the camera's position

* interactive_drone.py
    + Removed the `update_camera` function since it is now redundant, the viewer is directly set to follow the drone

* go2_env.py
    + Added a follower camera on the side of the robot, the camera have fixed height and orientation

* go2_train.py
    + Added `-v` / `--vis` to enable the gui for the viewer and follower camera

# Examples
You can run 
```
python examples/drone/interactive_drone.py
python examples/locomotion/go2_train.py -v
```

# TODO 

The camera only follow the first env due to [`camera.py`](https://github.com/jgleyze/Genesis/blob/2c3502fb99617bd4834a90699d4a394e87d1c0c5/genesis/vis/camera.py#L286-L287)

I don't really know how to get the id of each env here...

