### PR TITLE
[BUG FIX] Updated texrepeat handling for mjcf

### DIFF
--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -303,7 +303,7 @@ def parse_geom(mj, i_g, scale, convexify, surface, xml_path):
                 uv_coordinates /= uv_coordinates.max(axis=0)
                 image = Image.open(os.path.join(assets_dir, tex_path)).convert("RGBA")
                 image_array = np.array(image)
-                tex_repeat = mj.mat_texrepeat[mat_id].astype(int)
+                tex_repeat = np.ceil(mj.mat_texrepeat[mat_id]).astype(int)
                 image_array = np.tile(image_array, (tex_repeat[0], tex_repeat[1], 1))
                 visual = TextureVisuals(uv=uv_coordinates, image=Image.fromarray(image_array, mode="RGBA"))
                 tmesh.visual = visual
@@ -337,7 +337,7 @@ def parse_geom(mj, i_g, scale, convexify, surface, xml_path):
 
                 image = Image.open(os.path.join(assets_dir, tex_path)).convert("RGBA")
                 image_array = np.array(image)
-                tex_repeat = mj.mat_texrepeat[mat_id].astype(int)
+                tex_repeat = np.ceil(mj.mat_texrepeat[mat_id]).astype(int)
                 image_array = np.tile(image_array, (tex_repeat[0], tex_repeat[1], 1))
                 visual = TextureVisuals(uv=uv, image=Image.fromarray(image_array, mode="RGBA"))
 


### PR DESCRIPTION
## Description
Replaced converting numpy array elements (`array.astype(int)`) with np.ceil operation (`np.ceil(array).astype(int)`)

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#616

## Motivation and Context
When mjcf texrepeat is handled, it is converted to integer. That causes some issues for values such as `[0.5, 0.5]` which is rounded down to `[0, 0]`. The zeros array ends up emptying the image_array at [the line 307 of utils/mjcf.py](https://github.com/Genesis-Embodied-AI/Genesis/blob/36b6670a4a0783d4ed58d6cd8edbd5662727677f/genesis/utils/mjcf.py#L307C1-L307C86).

## How Has This Been / Can This Be Tested?
For reproducing it, please refer to #616 

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
