### PR TITLE
[BUG FIX] Mouse drag crashing the viewer in edge cases

### DIFF
--- a/genesis/ext/pyrender/trackball.py
+++ b/genesis/ext/pyrender/trackball.py
@@ -46,7 +46,7 @@ class Trackball(object):
 
         self._state = Trackball.STATE_ROTATE
 
-        self._pdown = None  # Initialize _pdown attribute to None
+        self._pdown = np.array([0.0, 0.0], dtype=np.float32)
 
     @property
     def pose(self):
@@ -98,9 +98,7 @@ class Trackball(object):
             motion between this point and the one marked by down().
         """
         point = np.array(point, dtype=np.float32)
-        # get the "down" point defaulting to current point making
-        # this a no-op if the "down" event didn't trigger for some reason
-        dx, dy = point - getattr(self, "_pdown", point)
+        dx, dy = point - self._pdown
         mindim = 0.3 * np.min(self._size)
 
         target = self._target

--- a/genesis/ext/pyrender/trackball.py
+++ b/genesis/ext/pyrender/trackball.py
@@ -88,7 +88,7 @@ class Trackball(object):
         self._target = self._n_target
 
     def drag(self, point):
-        """Update the tracball during a drag.
+        """Update the trackball during a drag.
 
         Parameters
         ----------


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->
This change initializes the `_pdown` instance variable of the `Trackball` object, which stores the x, y values of the initial mouse press for the camera drag in the viewer. It ensures `_pdown` is initialized to zeroes instead of `None`, preventing crashes in edge cases. Additionally, it removes the use of `getattr` to access `_pdown`, as it is always initialized.

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

<!--- Resolves Genesis-Embodied-AI/Genesis#<your-issue-number> -->
No related existing issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously, viewer would crash if the `on_mouse_drag` callback was triggered before `on_mouse_click`. This happened because when the initial mouse press that should set `_pdown` attribute was missing, it had original value `None` from when the `Trackball` instance is created, resulting in a `TypeError` during camera drag calculations. This might happen in couple of edge cases, one way I am able to reliably reproduce it in my Ubuntu 24.04 system is listed below.

### Steps to reproduce
1. Launch a genesis script with the viewer.
2. Don't click inside the window.
3. Click and drag the top bar of the window and snap it to one of the screen edges to trigger edge snap resizing.
4. Move the mouse back inside the window.  

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
[Screencast from 2025-01-27 21-26-23.webm](https://github.com/user-attachments/assets/eecff99a-d136-4686-b15d-a44a6053d4a1)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
