### PR TITLE
Fix build arm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.9"
 dependencies = [
     "psutil",
     "scikit-image",
-    "taichi == 1.7.3",
+    "taichi >= 1.7.3",
     "pydantic == 2.7.1",
     "numpy == 1.26.4",
     "six",
@@ -26,7 +26,7 @@ dependencies = [
     "pycollada",
     "opencv-python",
     "lxml",
-    "tetgen == 0.6.4",
+    "tetgen == 0.6.5",
     "screeninfo",
     "PyGEL3D",
     "moviepy >= 2.0.0",


### PR DESCRIPTION
Fix build ARM devices
```
INFO: pip is looking at multiple versions of genesis-world to determine which version is compatible with other requirements. This could take a while.
ERROR: Could not find a version that satisfies the requirement tetgen==0.6.4 (from genesis-world) (from versions: 0.1.0, 0.1.1, 0.1.2, 0.2.0, 0.2.1, 0.2.2, 0.3.0, 0.3.1, 0.3.2, 0.3.3, 0.3.4, 0.4.0, 0.4.2, 0.5.2, 0.5.3, 0.5.4, 0.5.5, 0.6.0, 0.6.1, 0.6.2, 0.6.3, 0.6.5)
ERROR: No matching distribution found for tetgen==0.6.4

```