### PR TITLE
[FEATURE] save terrain and reuse by name

### DIFF
--- a/examples/rigid/terrain_height_field.py
+++ b/examples/rigid/terrain_height_field.py
@@ -46,6 +46,8 @@ def main():
             horizontal_scale=horizontal_scale,
             vertical_scale=vertical_scale,
             height_field=height_field,
+            name="example",
+            # from_stored=True,
         ),
     )
     ########################## build ##########################

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -653,6 +653,8 @@ class Terrain(Morph):
         ["random_uniform_terrain", "pyramid_stairs_terrain", "sloped_terrain"],
     ]
     height_field: Any = None
+    name: str = "default"  # name to store and reuse the terrain
+    from_stored: Any = None
 
     def __init__(self, **data):
         super().__init__(**data)


### PR DESCRIPTION
## Description
Save terrain each time created from trimesh. IIt could be reused by assigning `name` and `from_stored` in morph.

## Related Issue
None. But can extremely reduce the compile time.

## How Has This Been Tested?
Run `examples/rigid/terrain_height_field.py`