### PR TITLE
[BUG FIX] Update texrepeat handling for mjcf

### DIFF
--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -303,7 +303,7 @@ def parse_geom(mj, i_g, scale, convexify, surface, xml_path):
                 uv_coordinates /= uv_coordinates.max(axis=0)
                 image = Image.open(os.path.join(assets_dir, tex_path)).convert("RGBA")
                 image_array = np.array(image)
-                tex_repeat = mj.mat_texrepeat[mat_id].astype(int)
+                tex_repeat = np.ceil(mj.mat_texrepeat[mat_id]).astype(int)
                 image_array = np.tile(image_array, (tex_repeat[0], tex_repeat[1], 1))
                 visual = TextureVisuals(uv=uv_coordinates, image=Image.fromarray(image_array, mode="RGBA"))
                 tmesh.visual = visual
@@ -337,7 +337,7 @@ def parse_geom(mj, i_g, scale, convexify, surface, xml_path):
 
                 image = Image.open(os.path.join(assets_dir, tex_path)).convert("RGBA")
                 image_array = np.array(image)
-                tex_repeat = mj.mat_texrepeat[mat_id].astype(int)
+                tex_repeat = np.ceil(mj.mat_texrepeat[mat_id]).astype(int)
                 image_array = np.tile(image_array, (tex_repeat[0], tex_repeat[1], 1))
                 visual = TextureVisuals(uv=uv, image=Image.fromarray(image_array, mode="RGBA"))
 


### PR DESCRIPTION
## Description
Replaced converting numpy array elements (`array.astype(int)`) with np.ceil operation (`np.ceil(array).astype(int)`). The reason I used this operation is [texrepeat values are positive](https://mujoco.readthedocs.io/en/stable/XMLreference.html#asset-material-texrepeat).

## Related Issue
Resolves Genesis-Embodied-AI/Genesis#616

## Motivation and Context
When mjcf texrepeat is handled, it is converted to integer. That causes some issues for values such as `[0.5, 0.5]` which is rounded down to `[0, 0]`. The zeros array ends up emptying the image_array at [307](https://github.com/Genesis-Embodied-AI/Genesis/blob/bae90367948d7ace52924c7442cc39aa81a15ec4/genesis/utils/mjcf.py#L307) and [341](https://github.com/Genesis-Embodied-AI/Genesis/blob/bae90367948d7ace52924c7442cc39aa81a15ec4/genesis/utils/mjcf.py#L341) of `utils/mjcf.py`.

## How Has This Been / Can This Be Tested?

This is a minimal example to reproduce the bug.

```python
import numpy as np

def reproduce_error():
    # emulating utils/mjcf.py from line 305 to 307
    image_array_before = np.ones((2048, 2048, 4))
    tex_repeat = np.array([0.5, 0.5]).astype(int)
    image_array_after = np.tile(
        image_array_before, (tex_repeat[0], tex_repeat[1], 1)
    )  # this becomes an empty array
    print(
        image_array_before.shape, image_array_after.shape
    )  # (2048, 2048, 4) (0, 0, 4)

    # emulate options/textures.py line 155
    np.max(image_array_after, axis=(0, 1))  # This will throw ValueError

def fix_error():
    # emulating utils/mjcf.py from line 305 to 307
    image_array_before = np.ones((2048, 2048, 4))
    tex_repeat = np.ceil([0.5, 0.5]).astype(int)
    image_array_after = np.tile(image_array_before, (tex_repeat[0], tex_repeat[1], 1))
    print(
        image_array_before.shape, image_array_after.shape
    )  # (2048, 2048, 4) (2048, 2048, 4)

    # emulate options/textures.py line 155
    np.max(image_array_after, axis=(0, 1))  # Works yeay

if __name__ == "__main__":
    reproduce_error()
    fix_error()
```

To test the changes in Genesis, download the zip folder from #616 and run the following:

```python
import genesis as gs
import time

gs.init(backend=gs.cpu)
scene = gs.Scene(show_FPS=False, show_viewer=True)
scene.add_entity(gs.morphs.MJCF(file='floor_backing_room/model.xml'))

scene.build()

i = 0
while i < 100:
    scene.step()
    time.sleep(0.1)
    i += 1
```

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
