### PR TITLE
[BUG FIX] limit memory usage in supportfield

### DIFF
--- a/genesis/engine/solvers/rigid/support_field_decomp.py
+++ b/genesis/engine/solvers/rigid/support_field_decomp.py
@@ -44,8 +44,15 @@ class SupportField:
                 vert_end = self.solver.geoms_info.vert_end[i_g]
                 this_pos = init_pos[vert_start:vert_end]
 
-                dot_products = v1.dot(this_pos.T)
-                max_indices = np.argmax(dot_products, axis=1)
+                num_v = v1.shape[0]
+                window_size = int(5e8 // this_pos.shape[0])
+                max_indices = np.empty(num_v, dtype=np.intp)
+
+                for i in range(0, num_v, window_size):
+                    end = min(i + window_size, num_v)
+                    dot_chunk = v1[i:end] @ this_pos.T
+                    max_indices[i:end] = np.argmax(dot_chunk, axis=1)
+
                 support = this_pos[max_indices]
 
                 support_cell_start.append(start)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->
Limit memory usage by using maximum window size 5e8 while computing supporting field.

## Motivation and Context
Huge terrain may encounter ~100 GiB memory usage in this step.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I read the **CONTRIBUTING** document.
- [ x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [ x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
