### PR TITLE
numpy 2.0

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,5 +1,5 @@
 # Start with a base image that includes CUDA
-FROM nvidia/cuda:12.8.0-cudnn9-runtime-ubuntu24.04
+FROM nvidia/cuda:12.8.0-cudnn-runtime-ubuntu24.04
 
 # Label the image
 LABEL description="Python 3.12 with PyTorch, CUDA support, and a user named ci with sudo access"

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,15 +1,15 @@
 # Start with a base image that includes CUDA
-FROM nvidia/cuda:12.8.0-cudnn-runtime-ubuntu24.04
+FROM nvidia/cuda:11.3.1-cudnn8-runtime-ubuntu20.04
 
 # Label the image
-LABEL description="Python 3.12 with PyTorch, CUDA support, and a user named ci with sudo access"
+LABEL description="Python 3.11 with PyTorch, CUDA support, and a user named ci with sudo access"
 
-# Install necessary packages for Python 3.12 and sudo
+# Install necessary packages for Python 3.11 and sudo
 RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common sudo && \
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
-    apt-get install -y python3.12 python3.12-venv python3.12-dev python3-pip && \
+    apt-get install -y python3.11 python3.11-venv python3.11-dev python3-pip && \
     rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user 'ci' with a password and give sudo privileges
@@ -22,8 +22,8 @@ USER ci
 WORKDIR /home/ci
 
 # Set up the virtual environment in user's home directory
-RUN python3.12 -m venv venv
+RUN python3.11 -m venv venv
 ENV PATH="/home/ci/venv/bin:$PATH"
 
 # Install PyTorch with CUDA support
-RUN pip install --no-cache-dir torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu126
+RUN pip install --no-cache-dir torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,15 +1,15 @@
 # Start with a base image that includes CUDA
-FROM nvidia/cuda:11.3.1-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:12.8.0-cudnn9-runtime-ubuntu24.04
 
 # Label the image
-LABEL description="Python 3.11 with PyTorch, CUDA support, and a user named ci with sudo access"
+LABEL description="Python 3.12 with PyTorch, CUDA support, and a user named ci with sudo access"
 
-# Install necessary packages for Python 3.11 and sudo
+# Install necessary packages for Python 3.12 and sudo
 RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common sudo && \
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
-    apt-get install -y python3.11 python3.11-venv python3.11-dev python3-pip && \
+    apt-get install -y python3.12 python3.12-venv python3.12-dev python3-pip && \
     rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user 'ci' with a password and give sudo privileges
@@ -22,8 +22,8 @@ USER ci
 WORKDIR /home/ci
 
 # Set up the virtual environment in user's home directory
-RUN python3.11 -m venv venv
+RUN python3.12 -m venv venv
 ENV PATH="/home/ci/venv/bin:$PATH"
 
 # Install PyTorch with CUDA support
-RUN pip install --no-cache-dir torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
+RUN pip install --no-cache-dir torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu126

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
       #   python-version: ["3.9"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 

--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -223,11 +223,17 @@ class RigidGeom(RBC):
         self.vert_neighbor_start = gsd_dict["vert_neighbor_start"]
 
     def _compute_sd(self, query_points):
-        sd, _, _, _ = igl.signed_distance(query_points, self._sdf_verts, self._sdf_faces)
+        try:
+            sd, _, _ = igl.signed_distance(query_points, self._sdf_verts, self._sdf_faces)
+        except:
+            sd, _, _, _ = igl.signed_distance(query_points, self._sdf_verts, self._sdf_faces)
         return sd
 
     def _compute_closest_verts(self, query_points):
-        _, closest_faces, _, _ = igl.signed_distance(query_points, self._init_verts, self._init_faces)
+        try:
+            _, closest_faces, _ = igl.signed_distance(query_points, self._init_verts, self._init_faces)
+        except:
+            _, closest_faces, _, _ = igl.signed_distance(query_points, self._init_verts, self._init_faces)
         verts_ids = self._init_faces[closest_faces]
         verts_ids = verts_ids[
             np.arange(len(query_points)).astype(int),

--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -223,11 +223,11 @@ class RigidGeom(RBC):
         self.vert_neighbor_start = gsd_dict["vert_neighbor_start"]
 
     def _compute_sd(self, query_points):
-        sd, _, _ = igl.signed_distance(query_points, self._sdf_verts, self._sdf_faces)
+        sd, _, _, _ = igl.signed_distance(query_points, self._sdf_verts, self._sdf_faces)
         return sd
 
     def _compute_closest_verts(self, query_points):
-        _, closest_faces, _ = igl.signed_distance(query_points, self._init_verts, self._init_faces)
+        _, closest_faces, _, _ = igl.signed_distance(query_points, self._init_verts, self._init_faces)
         verts_ids = self._init_faces[closest_faces]
         verts_ids = verts_ids[
             np.arange(len(query_points)).astype(int),

--- a/genesis/ext/pyrender/mesh.py
+++ b/genesis/ext/pyrender/mesh.py
@@ -82,7 +82,7 @@ class Mesh(object):
     def bounds(self):
         """(2,3) float : The axis-aligned bounds of the mesh."""
         if self._bounds is None:
-            bounds = np.array([[np.infty, np.infty, np.infty], [-np.infty, -np.infty, -np.infty]])
+            bounds = np.array([[np.inf, np.inf, np.inf], [-np.inf, -np.inf, -np.inf]])
             for p in self.primitives:
                 bounds[0] = np.minimum(bounds[0], p.bounds[0])
                 bounds[1] = np.maximum(bounds[1], p.bounds[1])

--- a/genesis/ext/trimesh/base.py
+++ b/genesis/ext/trimesh/base.py
@@ -359,7 +359,7 @@ class Trimesh(Geometry3D):
             return
         # check if any values are larger than tol.merge
         # don't set the normals if they are all zero
-        ptp = values.ptp()
+        ptp = np.ptp(values)
         if not np.isfinite(ptp):
             log.debug("face_normals contain NaN, ignoring!")
             return
@@ -446,7 +446,7 @@ class Trimesh(Geometry3D):
             values = np.asanyarray(values, order="C", dtype=np.float64)
             if values.shape == self.vertices.shape:
                 # check to see if they assigned all zeros
-                if values.ptp() < tol.merge:
+                if np.ptp(values) < tol.merge:
                     log.debug("vertex_normals are all zero!")
                 self._cache["vertex_normals"] = values
 
@@ -501,7 +501,7 @@ class Trimesh(Geometry3D):
         # if mesh is empty return None
         if self.bounds is None:
             return None
-        extents = self.bounds.ptp(axis=0)
+        extents = np.ptp(self.bounds, axis=0)
 
         return extents
 

--- a/genesis/ext/trimesh/bounds.py
+++ b/genesis/ext/trimesh/bounds.py
@@ -272,7 +272,7 @@ def oriented_bounds(obj, angle_digits=1, ordered=True, normal=None, coplanar_tol
         area = ((x.max(axis=1) - x.min(axis=1)) * (y.max(axis=1) - y.min(axis=1))).min()
 
         # the volume is 2D area plus the projected height
-        volume = area * projected[:, 2].ptp()
+        volume = area * np.ptp(projected[:, 2])
 
         # store this transform if it's better than one we've seen
         if volume < min_volume:
@@ -283,7 +283,7 @@ def oriented_bounds(obj, angle_digits=1, ordered=True, normal=None, coplanar_tol
     # part so now we need to do the bookkeeping to find the box
     vert_ones = np.column_stack((vertices, np.ones(len(vertices)))).T
     projected = np.dot(min_2D, vert_ones).T[:, :3]
-    height = projected[:, 2].ptp()
+    height = np.ptp(projected[:, 2])
     rotation_2D, box = oriented_bounds_2D(projected[:, :2])
     min_extents = np.append(box, height)
     rotation_2D[:2, 2] = 0.0
@@ -294,7 +294,7 @@ def oriented_bounds(obj, angle_digits=1, ordered=True, normal=None, coplanar_tol
 
     # transform points using our matrix to find the translation
     transformed = transformations.transform_points(vertices, to_origin)
-    box_center = transformed.min(axis=0) + transformed.ptp(axis=0) * 0.5
+    box_center = transformed.min(axis=0) + np.ptp(transformed, axis=0) * 0.5
     to_origin[:3, 3] = -box_center
 
     # return ordered 3D extents
@@ -374,7 +374,7 @@ def minimum_cylinder(obj, sample_count=6, angle_tol=0.001):
         """
         to_2D = transformations.spherical_matrix(*spherical, axes="rxyz")
         projected = transformations.transform_points(hull, matrix=to_2D)
-        height = projected[:, 2].ptp()
+        height = np.ptp(projected[:, 2])
 
         try:
             center_2D, radius = nsphere.minimum_nsphere(projected[:, :2])
@@ -403,7 +403,7 @@ def minimum_cylinder(obj, sample_count=6, angle_tol=0.001):
         # transform vertices to plane to check
         on_plane = transformations.transform_points(obj.vertices, to_2D)
         # cylinder height is overall Z span
-        height = on_plane[:, 2].ptp()
+        height = np.ptp(on_plane[:, 2])
         # center mass is correct on plane, but position
         # along symmetry axis may be wrong so slide it
         slide = transformations.translation_matrix([0, 0, (height / 2.0) - on_plane[:, 2].max()])
@@ -473,7 +473,7 @@ def to_extents(bounds):
     if bounds.shape != (2, 3):
         raise ValueError("bounds must be (2, 3)")
 
-    extents = bounds.ptp(axis=0)
+    extents = np.ptp(bounds, axis=0)
     transform = np.eye(4)
     transform[:3, 3] = bounds.mean(axis=0)
 

--- a/genesis/ext/trimesh/creation.py
+++ b/genesis/ext/trimesh/creation.py
@@ -558,7 +558,7 @@ def box(extents=None, transform=None, bounds=None, **kwargs):
         bounds = np.array(bounds, dtype=np.float64)
         if bounds.shape != (2, 3):
             raise ValueError("`bounds` must be (2, 3) float!")
-        extents = bounds.ptp(axis=0)
+        extents = np.ptp(bounds, axis=0)
         vertices *= extents
         vertices += bounds[0]
     elif extents is not None:

--- a/genesis/ext/trimesh/graph.py
+++ b/genesis/ext/trimesh/graph.py
@@ -532,7 +532,7 @@ def split_traversal(traversal, edges, edges_hash=None):
             continue
         # make sure it's not already closed
         edge = np.sort([t[0], t[-1]])
-        if edge.ptp() == 0:
+        if np.ptp(edge) == 0:
             continue
         close = grouping.hashable_rows(edge.reshape((1, 2)))[0]
         # if we need the edge add it

--- a/genesis/ext/trimesh/graph.py
+++ b/genesis/ext/trimesh/graph.py
@@ -510,7 +510,7 @@ def split_traversal(traversal, edges, edges_hash=None):
     # hash each edge so we can compare to edge set
     trav_hash = grouping.hashable_rows(np.sort(trav_edge, axis=1))
     # check if each edge is contained in edge set
-    contained = np.in1d(trav_hash, edges_hash)
+    contained = np.isin(trav_hash, edges_hash)
 
     # exit early if every edge of traversal exists
     if contained.all():

--- a/genesis/ext/trimesh/interval.py
+++ b/genesis/ext/trimesh/interval.py
@@ -111,7 +111,7 @@ def intersection(a, b, digits=8):
     overlap[current] = np.column_stack([a[current][:, 0], b[current][:, 1]])
 
     # is range overlapping at all
-    intersects = overlap.ptp(axis=1) > 10**-digits
+    intersects = np.ptp(overlap, axis=1) > 10**-digits
 
     if is_1D:
         return intersects[0], overlap[0]

--- a/genesis/ext/trimesh/nsphere.py
+++ b/genesis/ext/trimesh/nsphere.py
@@ -69,7 +69,7 @@ def minimum_nsphere(obj):
     # this used to pass qhull_options 'QbB' to Voronoi however this had a bug somewhere
     # to avoid this we scale to a unit cube ourselves inside this function
     points_origin = points.min(axis=0)
-    points_scale = points.ptp(axis=0).min()
+    points_scale = np.ptp(points, axis=0).min()
     points = (points - points_origin) / points_scale
 
     # if all of the points are on an n-sphere already the voronoi
@@ -167,7 +167,7 @@ def fit_nsphere(points, prior=None):
 
     radii = util.row_norm(points - center_result)
     radius = radii.mean()
-    error = radii.ptp()
+    error = np.ptp(radii)
     return center_result, radius, error
 
 

--- a/genesis/ext/trimesh/path/entities.py
+++ b/genesis/ext/trimesh/path/entities.py
@@ -361,7 +361,7 @@ class Text(Entity):
     @origin.setter
     def origin(self, value):
         value = int(value)
-        if not hasattr(self, "points") or self.points.ptp() == 0:
+        if not hasattr(self, "points") or np.ptp(self.points) == 0:
             self.points = np.ones(3, dtype=np.int64) * value
         else:
             self.points[0] = value

--- a/genesis/ext/trimesh/path/exchange/svg_io.py
+++ b/genesis/ext/trimesh/path/exchange/svg_io.py
@@ -337,7 +337,7 @@ def _svg_path_convert(paths, force=None):
                 )
                 # all arcs share the same center radius and rotation
                 closed = False
-                if verts[:, 4:].ptp(axis=0).mean() < 1e-3:
+                if np.ptp(verts[:, 4:], axis=0).mean() < 1e-3:
                     start, end = verts[:, :2], verts[:, 2:4]
                     # if every end point matches the start point of a new
                     # arc that means this is really a closed circle made

--- a/genesis/ext/trimesh/path/packing.py
+++ b/genesis/ext/trimesh/path/packing.py
@@ -206,7 +206,7 @@ def rectangles_single(extents, size=None, shuffle=False, rotate=True):
         # if no bounds are passed start it with the size of a large
         # rectangle exactly which will require re-rooting for
         # subsequent insertions
-        root_bounds = [[0.0] * dimension, extents[extents.ptp(axis=1).argmax()]]
+        root_bounds = [[0.0] * dimension, extents[np.ptp(extents, axis=1).argmax()]]
     else:
         # restrict the bounds to passed size and disallow re-rooting
         root_bounds = [[0.0] * dimension, size]
@@ -226,7 +226,7 @@ def rectangles_single(extents, size=None, shuffle=False, rotate=True):
             # get the size of the current root node
             bounds = root.bounds
             # current extents
-            current = bounds.ptp(axis=0)
+            current = np.ptp(bounds, axis=0)
 
             # pick the direction which has the least hyper-volume.
             best = np.inf
@@ -276,7 +276,7 @@ def rectangles_single(extents, size=None, shuffle=False, rotate=True):
             new_root.child = [RectangleBin(bounds_ori), RectangleBin(bounds_ins)]
 
             # insert the original sheet into the new tree
-            root_offset = new_root.child[0].insert(bounds.ptp(axis=0), rotate=rotate)
+            root_offset = new_root.child[0].insert(np.ptp(bounds, axis=0), rotate=rotate)
             # we sized the cells so original tree would fit
             assert root_offset is not None
 
@@ -450,7 +450,7 @@ def rectangles(extents, size=None, density_escape=0.99, spacing=0.0, iterations=
         bounds, insert = rectangles_single(extents=extents, size=size, shuffle=(i != 0))
 
         count = insert.sum()
-        extents_all = bounds.reshape((-1, dim)).ptp(axis=0)
+        extents_all = np.ptp(bounds.reshape((-1, dim)), axis=0)
 
         if quanta is not None:
             # compute the density using an upsized quanta
@@ -508,7 +508,7 @@ def images(images, power_resize=False):
 
     # offsets should be integer multiple of pizels
     offset = bounds[:, 0].round().astype(int)
-    extents = bounds.reshape((-1, 2)).ptp(axis=0)
+    extents = np.ptp(bounds.reshape((-1, 2)), axis=0)
     size = extents.round().astype(int)
     if power_resize:
         # round up all dimensions to powers of 2
@@ -629,7 +629,7 @@ def roll_transform(bounds, extents):
         return []
 
     # find the size of the AABB of the passed bounds
-    passed = bounds.ptp(axis=1)
+    passed = np.ptp(bounds, axis=1)
     # zeroth index is 2D, `1` is 3D
     dimension = passed.shape[1]
 
@@ -657,7 +657,7 @@ def roll_transform(bounds, extents):
         rolled = np.roll(extents, roll, axis=1)
         # check to see if the rolled original extents
         # match the requested bounding box
-        ok = (passed - rolled).ptp(axis=1) < _TOL_ZERO
+        ok = np.ptp((passed - rolled), axis=1) < _TOL_ZERO
         if not ok.any():
             continue
 

--- a/genesis/ext/trimesh/path/path.py
+++ b/genesis/ext/trimesh/path/path.py
@@ -278,7 +278,7 @@ class Path(parent.Geometry):
           Approximate size of the world holding this path
         """
         # use vertices peak-peak rather than exact extents
-        scale = float((self.vertices.ptp(axis=0) ** 2).sum() ** 0.5)
+        scale = float((np.ptp(self.vertices, axis=0) ** 2).sum() ** 0.5)
         return scale
 
     @caching.cache_decorator
@@ -339,7 +339,7 @@ class Path(parent.Geometry):
         extents : (dimension,) float
           Edge length of AABB
         """
-        return self.bounds.ptp(axis=0)
+        return np.ptp(self.bounds, axis=0)
 
     @property
     def units(self):
@@ -871,7 +871,7 @@ class Path3D(Path):
         # Z values of vertices which are referenced
         heights = flat[referenced][:, 2]
         # points are not on a plane because Z varies
-        if heights.ptp() > tol.planar:
+        if np.ptp(heights) > tol.planar:
             # since Z is inconsistent set height to zero
             height = 0.0
             if check:

--- a/genesis/ext/trimesh/path/polygons.py
+++ b/genesis/ext/trimesh/path/polygons.py
@@ -391,7 +391,7 @@ def medial_axis(polygon, resolution=None, clip=None):
     # a circle will have a single point medial axis
     if len(polygon.interiors) == 0:
         # what is the approximate scale of the polygon
-        scale = np.reshape(polygon.bounds, (2, 2)).ptp(axis=0).max()
+        scale = np.ptp(np.reshape(polygon.bounds, (2, 2)), axis=0).max()
         # a (center, radius, error) tuple
         fit = fit_circle_check(polygon.exterior.coords, scale=scale)
         # is this polygon in fact a circle
@@ -407,7 +407,7 @@ def medial_axis(polygon, resolution=None, clip=None):
     from shapely import vectorized
 
     if resolution is None:
-        resolution = np.reshape(polygon.bounds, (2, 2)).ptp(axis=0).max() / 100
+        resolution = np.ptp(np.reshape(polygon.bounds, (2, 2)), axis=0).max() / 100
 
     # get evenly spaced points on the polygons boundaries
     samples = resample_boundaries(polygon=polygon, resolution=resolution, clip=clip)
@@ -436,7 +436,7 @@ def medial_axis(polygon, resolution=None, clip=None):
 
     if tol.strict:
         # make sure we didn't screw up indexes
-        assert (vertices[edges_final] - voronoi.vertices[edges]).ptp() < 1e-5
+        assert np.ptp((vertices[edges_final] - voronoi.vertices[edges])) < 1e-5
 
     return edges_final, vertices
 
@@ -510,7 +510,7 @@ def polygon_scale(polygon):
     scale : float
       Length of AABB diagonal
     """
-    extents = np.reshape(polygon.bounds, (2, 2)).ptp(axis=0)
+    extents = np.ptp(np.reshape(polygon.bounds, (2, 2)), axis=0)
     scale = (extents**2).sum() ** 0.5
 
     return scale
@@ -580,7 +580,7 @@ def sample(polygon, count, factor=1.5, max_iter=10):
 
     # get size of bounding box
     bounds = np.reshape(polygon.bounds, (2, 2))
-    extents = bounds.ptp(axis=0)
+    extents = np.ptp(bounds, axis=0)
 
     # how many points to check per loop iteration
     per_loop = int(count * factor)
@@ -654,7 +654,7 @@ def repair_invalid(polygon, scale=None, rtol=0.5):
         return basic
 
     if scale is None:
-        distance = 0.002 * np.reshape(polygon.bounds, (2, 2)).ptp(axis=0).mean()
+        distance = 0.002 * np.ptp(np.reshape(polygon.bounds, (2, 2)), axis=0).mean()
     else:
         distance = 0.002 * scale
 
@@ -816,7 +816,7 @@ def projected(mesh, normal, origin=None, ignore_sign=True, rpad=1e-5, apad=None,
         padding += float(apad)
     if rpad is not None:
         # get the 2D scale as the longest side of the AABB
-        scale = vertices_2D.ptp(axis=0).max()
+        scale = np.ptp(vertices_2D, axis=0).max()
         # apply the scale-relative padding
         padding += float(rpad) * scale
 

--- a/genesis/ext/trimesh/path/raster.py
+++ b/genesis/ext/trimesh/path/raster.py
@@ -57,7 +57,7 @@ def rasterize(path, pitch=None, origin=None, resolution=None, fill=True, width=N
 
     # if resolution is None make it larger than path
     if resolution is None:
-        span = np.vstack((path.bounds, origin)).ptp(axis=0)
+        span = np.ptp(np.vstack((path.bounds, origin)), axis=0)
         resolution = np.ceil(span / pitch) + 2
     # get resolution as a (2,) int tuple
     resolution = np.asanyarray(resolution, dtype=np.int64)

--- a/genesis/ext/trimesh/path/segments.py
+++ b/genesis/ext/trimesh/path/segments.py
@@ -301,7 +301,7 @@ def overlap(origins, vectors, params):
     # create the overlapping segment pairs (2, 2, 3)
     segments = np.array([o + v * new_range.reshape((-1, 1)) for o, v in zip(origins, vectors)])
     # get the length of the new range
-    length = new_range.ptp()
+    length = np.ptp(new_range)
 
     return length, segments
 

--- a/genesis/ext/trimesh/path/simplify.py
+++ b/genesis/ext/trimesh/path/simplify.py
@@ -134,7 +134,7 @@ def is_circle(points, scale, verbose=False):
     if np.linalg.norm(points[0] - points[-1]) > tol.merge:
         return None
 
-    box = points.ptp(axis=0)
+    box = np.ptp(points, axis=0)
     # the bounding box size of the points
     # check aspect ratio as an early exit if the path is not a circle
     aspect = np.divide(*box)

--- a/genesis/ext/trimesh/points.py
+++ b/genesis/ext/trimesh/points.py
@@ -552,7 +552,7 @@ class PointCloud(Geometry3D):
         extents : (3,) float
           Edge length of axis aligned bounding box
         """
-        return self.bounds.ptp(axis=0)
+        return np.ptp(self.bounds, axis=0)
 
     @property
     def centroid(self):

--- a/genesis/ext/trimesh/primitives.py
+++ b/genesis/ext/trimesh/primitives.py
@@ -691,7 +691,7 @@ class Box(_Primitive):
             if bounds.shape != (2, 3):
                 raise ValueError("`bounds` must be (2, 3) float")
             # create extents from AABB
-            extents = bounds.ptp(axis=0)
+            extents = np.ptp(bounds, axis=0)
             # translate to the center of the box
             transform = np.eye(4)
             transform[:3, 3] = bounds[0] + extents / 2.0

--- a/genesis/ext/trimesh/proximity.py
+++ b/genesis/ext/trimesh/proximity.py
@@ -183,7 +183,7 @@ def closest_point(mesh, points):
 
     # however: same closest point on two different faces
     # find the best one and correct triangle ids if necessary
-    check_distance = two_dists.ptp(axis=1) < tol.merge
+    check_distance = np.ptp(two_dists, axis=1) < tol.merge
     check_magnitude = np.all(np.abs(two_dists) > tol.merge, axis=1)
 
     # mask results where corrections may be apply

--- a/genesis/ext/trimesh/scene/cameras.py
+++ b/genesis/ext/trimesh/scene/cameras.py
@@ -317,7 +317,7 @@ def look_at(points, fov, rotation=None, distance=None, center=None, pad=None):
 
     if center is None:
         # Find the center of the points' AABB in camera frame
-        center_c = points_c.min(axis=0) + 0.5 * points_c.ptp(axis=0)
+        center_c = points_c.min(axis=0) + 0.5 * np.ptp(points_c, axis=0)
     else:
         # Transform center to camera frame
         center_c = rinv.dot(center)

--- a/genesis/ext/trimesh/transformations.py
+++ b/genesis/ext/trimesh/transformations.py
@@ -2225,13 +2225,13 @@ def is_rigid(matrix, epsilon=1e-8):
         return False
 
     # make sure last row has no scaling
-    if (matrix[-1] - [0, 0, 0, 1]).ptp() > epsilon:
+    if np.ptp((matrix[-1] - [0, 0, 0, 1])) > epsilon:
         return False
 
     # check dot product of rotation against transpose
     check = np.dot(matrix[:3, :3], matrix[:3, :3].T) - _IDENTITY[:3, :3]
 
-    return check.ptp() < epsilon
+    return np.ptp(check) < epsilon
 
 
 def scale_and_translate(scale=None, translate=None):

--- a/genesis/ext/trimesh/util.py
+++ b/genesis/ext/trimesh/util.py
@@ -2179,7 +2179,7 @@ def allclose(a, b, atol=1e-8):
     -----------
     bool indicating if all elements are within `atol`.
     """
-    return float((a - b).ptp()) < atol
+    return float(np.ptp((a - b))) < atol
 
 
 class FunctionRegistry(Mapping):

--- a/genesis/ext/trimesh/viewer/windowed.py
+++ b/genesis/ext/trimesh/viewer/windowed.py
@@ -548,9 +548,9 @@ class SceneViewer(pyglet.window.Window):
                 center = bounds.mean(axis=0)
                 # set the grid to the lowest Z position
                 # also offset by the scale to avoid interference
-                center[2] = bounds[0][2] - (bounds[:, 2].ptp() / 100)
+                center[2] = bounds[0][2] - (np.ptp(bounds[:, 2]) / 100)
                 # choose the side length by maximum XY length
-                side = bounds.ptp(axis=0)[:2].max()
+                side = np.ptp(bounds, axis=0)[:2].max()
                 # create an axis marker sized relative to the scene
                 grid_mesh = grid(side=side, count=4, transform=translation_matrix(center))
                 # convert the path to vertexlist args

--- a/genesis/ext/trimesh/visual/color.py
+++ b/genesis/ext/trimesh/visual/color.py
@@ -827,7 +827,7 @@ def interpolate(values, color_map=None, dtype=np.uint8):
     # make input always float
     values = np.asanyarray(values, dtype=np.float64).ravel()
     # scale values to 0.0 - 1.0 and get colors
-    colors = cmap((values - values.min()) / values.ptp())
+    colors = cmap((values - values.min()) / np.ptp(values))
     # convert to 0-255 RGBA
     rgba = to_rgba(colors, dtype=dtype)
 

--- a/genesis/ext/trimesh/voxel/creation.py
+++ b/genesis/ext/trimesh/voxel/creation.py
@@ -147,7 +147,7 @@ def local_voxelize(mesh, point, pitch, radius, fill=True, **kwargs):
 
         where = np.where(contains)[0] + 1
         # use in1d vs isin for older numpy versions
-        internal = np.in1d(regions.flatten(), where).reshape(regions.shape)
+        internal = np.isin(regions.flatten(), where).reshape(regions.shape)
 
         voxels = np.logical_or(voxels, internal)
 

--- a/genesis/ext/trimesh/voxel/ops.py
+++ b/genesis/ext/trimesh/voxel/ops.py
@@ -288,7 +288,7 @@ def boolean_sparse(a, b, operation=np.logical_and):
     # find the bounding box of both arrays
     extrema = np.array([a.min(axis=0), a.max(axis=0), b.min(axis=0), b.max(axis=0)])
     origin = extrema.min(axis=0) - 1
-    size = tuple(extrema.ptp(axis=0) + 2)
+    size = tuple(np.ptp(extrema, axis=0) + 2)
 
     # put nearby voxel arrays into same shape sparse array
     sp_a = sparse.COO((a - origin).T, data=np.ones(len(a), dtype=bool), shape=size)

--- a/genesis/ext/urdfpy/urdf.py
+++ b/genesis/ext/urdfpy/urdf.py
@@ -2202,8 +2202,8 @@ class Joint(URDFType):
         if self.joint_limit is None:
             return True
         cfg = float(cfg)
-        lower = -np.infty
-        upper = np.infty
+        lower = -np.inf
+        upper = np.inf
         if self.limit.lower is not None:
             lower = self.limit.lower
         if self.limit.upper is not None:
@@ -2870,7 +2870,7 @@ class URDF(URDFType):
         """(n,2) float : A lower and upper limit for each joint."""
         limits = []
         for joint in self.actuated_joints:
-            limit = [-np.infty, np.infty]
+            limit = [-np.inf, np.inf]
             if joint.limit is not None:
                 if joint.limit.lower is not None:
                     limit[0] = joint.limit.lower

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "PyOpenGL",
     "freetype-py",
     "pyglet",
-    "libigl==2.5.4.dev0",
+    "libigl",
     "pygltflib == 1.16.0",
     "mujoco == 3.2.5",
     "pycollada",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "PyOpenGL",
     "freetype-py",
     "pyglet",
-    "libigl",
+    "libigl==2.5.4.dev0",
     "pygltflib == 1.16.0",
     "mujoco == 3.2.5",
     "pycollada",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython>=3.0.0", "numpy==1.26.4"]
+requires = ["setuptools", "wheel", "cython>=3.0.0", "numpy>=1.26.4"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -15,7 +15,7 @@ dependencies = [
     "scikit-image",
     "taichi == 1.7.3",
     "pydantic == 2.7.1",
-    "numpy == 1.26.4",
+    "numpy >= 1.26.4",
     "six",
     "PyOpenGL",
     "freetype-py",


### PR DESCRIPTION
#709
```bash
Traceback (most recent call last):
  File "/test/test.py", line 7, in <module>
    scene = gs.Scene(show_viewer=True)
  File "/usr/local/lib/python3.10/dist-packages/genesis/utils/misc.py", line 28, in new_init
    original_init(self, *args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/genesis/engine/scene.py", line 147, in __init__
    self._visualizer = Visualizer(
  File "/usr/local/lib/python3.10/dist-packages/genesis/vis/visualizer.py", line 26, in __init__
    self._context = RasterizerContext(vis_options)
  File "/usr/local/lib/python3.10/dist-packages/genesis/vis/rasterizer_context.py", line 37, in __init__
    self.init_meshes()
  File "/usr/local/lib/python3.10/dist-packages/genesis/vis/rasterizer_context.py", line 52, in init_meshes
    self.link_frame_mesh = trimesh.creation.axis(origin_size=0.03, axis_radius=0.025, axis_length=1.0)
  File "/usr/local/lib/python3.10/dist-packages/genesis/ext/trimesh/creation.py", line 1113, in axis
    axis_origin.apply_transform(transform)
  File "/usr/local/lib/python3.10/dist-packages/genesis/ext/trimesh/base.py", line 2342, in apply_transform
    elif util.allclose(matrix, np.eye(4), 1e-8):
  File "/usr/local/lib/python3.10/dist-packages/genesis/ext/trimesh/util.py", line 2182, in allclose
    return float((a - b).ptp()) < atol
AttributeError: ptp was removed from the ndarray class in NumPy 2.0. Use np.ptp(arr, ...) instead.
[Genesis] [22:26:45] [INFO] 💤 Exiting Genesis and caching compiled kernels...
```
https://numpy.org/doc/2.0/reference/generated/numpy.ptp.html
https://numpy.org/doc/stable/numpy_2_0_migration_guide.html
cc @YilingQiao  I use ruff to migrate to numpy 2.0. It's working now