### PR TITLE
[MISC] Add warning when importing MJCF Box w/collision checking

### DIFF
--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -284,8 +284,10 @@ def parse_geom(mj, i_g, scale, convexify, surface, xml_path):
 
     elif mj_type == mujoco.mjtGeom.mjGEOM_BOX:
         if is_col:
-            gs.logger.warning(f"Genesis does not currently support MJCF geom type: \
-                              {mj_type} with collisions enabled (conaffinity or contype).")
+            gs.logger.warning(
+                f"Genesis does not currently support MJCF geom type: \
+                              {mj_type} with collisions enabled (conaffinity or contype)."
+            )
 
         tmesh = trimesh.creation.box(extents=mj.geom_size[i_g, :3] * 2)
         data *= 2

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -283,6 +283,10 @@ def parse_geom(mj, i_g, scale, convexify, surface, xml_path):
         gs_type = gs.GEOM_TYPE.CYLINDER
 
     elif mj_type == mujoco.mjtGeom.mjGEOM_BOX:
+        if is_col:
+            gs.logger.warning(f"Genesis does not currently support MJCF geom type: \
+                              {mj_type} with collisions enabled (conaffinity or contype).")
+
         tmesh = trimesh.creation.box(extents=mj.geom_size[i_g, :3] * 2)
         data *= 2
         gs_type = gs.GEOM_TYPE.BOX


### PR DESCRIPTION
## Description
Collision checking currently doesn't work with an MJCF Box. This PR adds a warning. 

## Related Issue
See: https://github.com/Genesis-Embodied-AI/Genesis/issues/287

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## How Has This Been / Can This Be Tested?
Latest main commit, Linux Kernel 5.14.0

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.