### PR TITLE
[BUG] Better handling of rendering import failure.

### DIFF
--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -5,11 +5,8 @@ import genesis.utils.geom as gu
 import genesis.utils.mesh as mu
 import genesis.utils.particle as pu
 
-try:
-    from genesis.ext import pyrender, trimesh
-    from genesis.ext.pyrender.jit_render import JITRenderer
-except Exception as e:
-    print(f"[Error]: {e}\n")
+from genesis.ext import pyrender, trimesh
+from genesis.ext.pyrender.jit_render import JITRenderer
 from genesis.utils.misc import tensor_to_array
 
 

--- a/genesis/vis/visualizer.py
+++ b/genesis/vis/visualizer.py
@@ -5,7 +5,6 @@ from genesis.repr_base import RBC
 
 from .camera import Camera
 from .rasterizer import Rasterizer
-from .rasterizer_context import RasterizerContext
 from .viewer import DummyViewerLock, Viewer
 
 
@@ -23,6 +22,11 @@ class Visualizer(RBC):
             gs.logger.warning(f"Headless rendering not yet supported on {gs.platform}.")
             self._context = None
         else:
+            try:
+                from .rasterizer_context import RasterizerContext
+
+            except Exception as e:
+                raise ImportError("Onscreen rendering not working on this machine.") from e
             self._context = RasterizerContext(vis_options)
 
         # try to connect to display


### PR DESCRIPTION
## Description

Although Offscreen (aka. headless) would work fine without 'RasterizerContext', it is not the case for onscreen rendering. As a result, printing a warning in case of import error within 'RasterizerContext' does not seem appropriate. Instead, it makes more sense to guard import of 'RasterizerContext' where it is actually needed, and trigger an exception if it fails. This way, the error will only be reported when necessary, and whole traceback will be printed.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/773

## Motivation and Context

The warning is currently not clear: the root cause is not reported, and which feature is relying on it is not mentioned.

## How Has This Been / Can This Be Tested?

Since the error is triggered on my environment, all I had to do was running the tutorial to test whether it was fixing the issue.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
