### PR TITLE
[BUG] Improve rendering support on Windows OS.

### DIFF
--- a/genesis/ext/pyrender/jit_render.py
+++ b/genesis/ext/pyrender/jit_render.py
@@ -196,9 +196,16 @@ def address_to_ptr(typingctx, src):
 
 class JITRenderer:
     def __init__(self, scene, node_list, primitive_list):
+        self._forward_pass = None
+        self._shadow_mapping_pass = None
+        self._point_shadow_mapping_pass = None
+        self._read_depth_buf = None
+        self._read_color_buf = None
+        self._update_normal_flat = None
+        self._update_normal_smooth = None
+        self._update_buffer = None
         self.set_primitive(scene, node_list, primitive_list)
         self.set_light(scene, scene.light_nodes, scene.ambient_light)
-        self.gen_func_ptr()
         self.reflection_mat = np.identity(4, np.float32)
 
     def update(self, scene):
@@ -738,10 +745,11 @@ class JITRenderer:
         env_idx=-1,
     ):
         self.load_programs(renderer, flags, program_flags)
-        func = self._forward_pass
+        if self._forward_pass is None:
+            self.gen_func_ptr()
         # timer = time()
         if flags & RenderFlags.SEG:
-            func(
+            self._forward_pass(
                 self.vao_id,
                 self.program_id[(flags, program_flags)],
                 self.pose,
@@ -768,7 +776,7 @@ class JITRenderer:
                 self.gl.wrapper_instance,
             )
         else:
-            func(
+            self._forward_pass(
                 self.vao_id,
                 self.program_id[(flags, program_flags)],
                 self.pose,
@@ -798,8 +806,9 @@ class JITRenderer:
 
     def shadow_mapping_pass(self, renderer, V, P, flags, program_flags, env_idx=-1):
         self.load_programs(renderer, flags, program_flags)
-        func = self._shadow_mapping_pass
-        func(
+        if self._shadow_mapping_pass is None:
+            self.gen_func_ptr()
+        self._shadow_mapping_pass(
             self.vao_id,
             self.program_id[(flags, program_flags)],
             self.pose,
@@ -815,8 +824,9 @@ class JITRenderer:
 
     def point_shadow_mapping_pass(self, renderer, light_matrix, light_pos, flags, program_flags, env_idx=-1):
         self.load_programs(renderer, flags, program_flags)
-        func = self._point_shadow_mapping_pass
-        func(
+        if self._point_shadow_mapping_pass is None:
+            self.gen_func_ptr()
+        self._point_shadow_mapping_pass(
             self.vao_id,
             self.program_id[(flags, program_flags)],
             self.pose,
@@ -835,8 +845,12 @@ class JITRenderer:
         if primitive.normals is None:
             return None
         if primitive.indices is not None:
+            if self._update_normal_smooth is None:
+                self.gen_func_ptr()
             return self._update_normal_smooth(vertices, primitive.indices)
         else:
+            if self._update_normal_flat is None:
+                self.gen_func_ptr()
             return self._update_normal_flat(vertices.reshape((-1, 3, 3)))
 
     def update_buffer(self, buffer_updates):
@@ -850,10 +864,16 @@ class JITRenderer:
             updates[idx, 1] = 4 * len(flattened)
             updates[idx, 2] = flattened.ctypes.data
 
+        if self._update_buffer is None:
+            self.gen_func_ptr()
         self._update_buffer(updates, self.gl.wrapper_instance)
 
     def read_depth_buf(self, weight, height, z_near, z_far):
+        if self._read_depth_buf is None:
+            self.gen_func_ptr()
         return self._read_depth_buf(weight, height, z_near, z_far, self.gl.wrapper_instance)
 
     def read_color_buf(self, weight, height, rgba):
+        if self._read_color_buf is None:
+            self.gen_func_ptr()
         return self._read_color_buf(weight, height, rgba, self.gl.wrapper_instance)

--- a/genesis/ext/pyrender/numba_gl_wrapper.py
+++ b/genesis/ext/pyrender/numba_gl_wrapper.py
@@ -13,13 +13,42 @@ from numba.extending import (
 from numba.core import cgutils
 from contextlib import ExitStack
 import OpenGL.GL as GL
+from OpenGL._bytes import as_8_bit
 from OpenGL.GL import GLint, GLuint, GLvoidp, GLvoid, GLfloat, GLsizei, GLboolean, GLenum, GLsizeiptr, GLintptr
 
 
 class GLWrapper:
     def __init__(self):
         self.gl_funcs = {}
+        self._wrapper_type = None
+        self._wrapper_instance = None
 
+    def load_func(self, func_name, *signature):
+        try:
+            dll = GL.platform.PLATFORM.GL
+            func_ptr = GL.platform.ctypesloader.buildFunction(
+                GL.platform.PLATFORM.functionTypeFor(dll)(*signature),
+                func_name,
+                dll,
+            )
+        except AttributeError:
+            pointer = GL.platform.PLATFORM.getExtensionProcedure(as_8_bit(func_name))
+            func_ptr = GL.platform.PLATFORM.functionTypeFor(dll)(*signature)(pointer)
+        self.gl_funcs[func_name] = func_ptr
+
+    @property
+    def wrapper_type(self):
+        if self._wrapper_type is None:
+            self.build_wrapper()
+        return self._wrapper_type
+
+    @property
+    def wrapper_instance(self):
+        if self._wrapper_instance is None:
+            self.build_wrapper()
+        return self._wrapper_instance
+
+    def build_wrapper(self):
         load_func = self.load_func
         load_func("glGetUniformLocation", GLint, GLuint, GLvoidp)
         load_func("glUniformMatrix4fv", GLvoid, GLint, GLsizei, GLboolean, GLvoidp)
@@ -47,18 +76,6 @@ class GLWrapper:
         load_func("glBufferData", GLvoid, GLenum, GLsizeiptr, GLvoidp, GLenum)
         load_func("glBufferSubData", GLvoid, GLenum, GLintptr, GLsizeiptr, GLvoidp)
 
-        self.build_wrapper()
-
-    def load_func(self, func_name, *signature):
-        dll = GL.platform.PLATFORM.GL
-        func_ptr = GL.platform.ctypesloader.buildFunction(
-            GL.platform.PLATFORM.functionTypeFor(dll)(*signature),
-            func_name,
-            dll,
-        )
-        self.gl_funcs[func_name] = func_ptr
-
-    def build_wrapper(self):
         funcs = self.gl_funcs
         func_types = {}
         for func_name in funcs:
@@ -115,5 +132,5 @@ class GLWrapper:
         for func_name in funcs:
             make_attribute_wrapper(GLFuncType, func_name, func_name)
 
-        self.wrapper_type = glfunc_type
-        self.wrapper_instance = GLFunc()
+        self._wrapper_type = glfunc_type
+        self._wrapper_instance = GLFunc()

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -72,12 +72,7 @@ class RasterizerContext:
             n_envs=self.n_rendered_envs,
         )
 
-        if gs.platform != "Windows":
-            self.jit = JITRenderer(self._scene, [], [])
-        else:
-            from genesis.ext.pyrender.non_jit_renderer import SimpleNonJITRenderer
-
-            self.jit = SimpleNonJITRenderer(self._scene, [], [])
+        self.jit = JITRenderer(self._scene, [], [])
 
         # nodes
         self.world_frame_node = None


### PR DESCRIPTION
## Description

Add lazy-loading on OpenGL functions to postpone their initialisation after creation of the OpenGL context. This is necessary on Windows OS, where some functions depends on extensions that are not available until this point. This refactoring enables using the optimal code path for rendering on all Windows, Linux and MacOS. Ultimately, it should improve performance while being easier to maintain.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number> (TODO)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?

Running the tutorial on a native Windows x86 machine.
TODO: Check that it is still working on Mac OS.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [ ] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
