### PR TITLE
[Bug] Fix wrong camera pose on Mac OS.

### DIFF
--- a/genesis/ext/pyrender/renderer.py
+++ b/genesis/ext/pyrender/renderer.py
@@ -52,9 +52,6 @@ class Renderer(object):
 
     def __init__(self, viewport_width, viewport_height, jit, point_size=1.0):
         self.dpscale = 1
-        # Scaling needed on retina displays
-        if sys.platform == "darwin":
-            self.dpscale = 2
 
         self.viewport_width = viewport_width
         self.viewport_height = viewport_height


### PR DESCRIPTION
## Description

I suspect that `pyrender.Renderer.dpscale` parameter is not fully supported. In practice, any value different than 1.0 is causing issue when the camera pose, which cannot be set properly anymore. A quick-and-dirty "fix" consists in systematically using 1.0 by default, which is fine on any hardware including Macbook with Retina display unlike the comment states.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/650

## Motivation and Context

Not being able to set the pose of the camera properly is problematic, even so that it creates inconsistency between onscreen and offscreen rendering which is very confusing for the end-user.

## How Has This Been / Can This Be Tested?

Running the tutorial on my MacBook Pro M3 Max.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
