### PR TITLE
[BUG] Fix segfault when resizing window on Mac OS.

### DIFF
--- a/genesis/ext/pyrender/renderer.py
+++ b/genesis/ext/pyrender/renderer.py
@@ -171,6 +171,11 @@ class Renderer(object):
                             self._point_shadow_mapping_pass(scene, ln, flags, env_idx=env_idx)
                         else:
                             self._shadow_mapping_pass(scene, ln, flags, env_idx=env_idx)
+                        # FIXME: Resizing window causes segfault if shadow framebuffer is not unbound beforehand.
+                        # Since there is no way to catch this even soon enough, the only alternative is to unbind the
+                        # shadow buffer after use systematically... Even though it is clearly sub-optimal, it is not a
+                        # big deal in practice since it takes about 10us to create + delete a framebuffer.
+                        self._delete_shadow_framebuffer()
 
             # Make forward pass
             # forward_pass_start = time()

--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -800,7 +800,7 @@ class Viewer(pyglet.window.Window):
                 self._message_text = "Fullscreen Off"
 
         # H toggles shadows
-        elif symbol == pyglet.window.key.H and sys.platform != "darwin":
+        elif symbol == pyglet.window.key.H:
             self.render_flags["shadows"] = not self.render_flags["shadows"]
             if self.render_flags["shadows"]:
                 self._message_text = "Shadows On"


### PR DESCRIPTION
## Description

Trying the resize the interactive window on Mac OS is causing segfault if shadows are enabled. The root cause is not clear, but systematically unbinding the frame buffer associated with the shadow map after use is sufficient to fix the issue. The overhead it induces is every minimal (< 10us) and only affects onscreen rendering, so it is not a big deal in the first place. Incidentally, enabling/disabling shadows is now working fine on Mac OS.

## Motivation and Context

Triggering a segfault on Mac OS when trying to resize the interactive viewer is unacceptable. While it would be possible to disable resizable window on Mac OS, I do believe that being this feature is a common expectation.

## How Has This Been / Can This Be Tested?

Running the tutorial on my MacBook Pro M3 Max.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [ ] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.