### PR TITLE
[BUG FIX] Avoid unnecessary array copies and improve support of Numpy 2.X.

### DIFF
--- a/genesis/ext/fast_simplification/simplify.py
+++ b/genesis/ext/fast_simplification/simplify.py
@@ -110,9 +110,7 @@ def simplify(
 
     """
 
-    if not isinstance(points, np.ndarray):
-        points = np.array(points, dtype=np.float64)
-    points = points.astype(np.float64, copy=False)
+    points = np.asarray(points, dtype=np.float64)
     if not isinstance(triangles, np.ndarray):
         triangles = np.array(triangles, dtype=np.int32)
 
@@ -128,8 +126,7 @@ def simplify(
 
     n_faces = triangles.shape[0]
 
-    if not triangles.flags.c_contiguous:
-        triangles = np.ascontiguousarray(triangles)
+    triangles = np.ascontiguousarray(triangles)
 
     if triangles.dtype == np.int32:
         load = _simplify.load_int32
@@ -203,8 +200,8 @@ def simplify_mesh(mesh, target_reduction=None, target_count=None, agg=7, verbose
     n_faces = mesh.n_cells
     _simplify.load_from_vtk(
         mesh.n_points,
-        mesh.points.astype(np.float64, copy=False),
-        mesh.faces.astype(np.int32, copy=False),
+        mesh.points.astype(np.float64, order="C", copy=False),
+        mesh.faces.astype(np.int32, order="C", copy=False),
         n_faces,
     )
 

--- a/genesis/ext/pyrender/jit_render.py
+++ b/genesis/ext/pyrender/jit_render.py
@@ -866,7 +866,7 @@ class JITRenderer:
         updates = np.zeros((len(buffer_updates), 3), dtype=np.int64)
         flattened_list = []
         for idx, (id, data) in enumerate(buffer_updates.items()):
-            flattened = np.ascontiguousarray(data.flatten().astype(np.float32))
+            flattened = data.astype(np.float32, order="C", copy=False).reshape((-1,))
             flattened_list.append(flattened)
 
             updates[idx, 0] = id

--- a/genesis/ext/pyrender/non_jit_renderer.py
+++ b/genesis/ext/pyrender/non_jit_renderer.py
@@ -632,7 +632,7 @@ class SimpleNonJITRenderer:
         for buffer_id, data in buffer_updates.items():
             if buffer_id >= 0:  # Valid buffer ID check
                 # Flatten and ensure data is contiguous
-                flattened = np.ascontiguousarray(data.flatten().astype(np.float32))
+                flattened = data.astype(np.float32, order="C", copy=False).reshape((-1,))
                 buffer_size = 4 * len(flattened)  # 4 bytes per float32
 
                 # Bind buffer and update its data

--- a/genesis/ext/pyrender/texture.py
+++ b/genesis/ext/pyrender/texture.py
@@ -185,7 +185,7 @@ class Texture(object):
         width = self.width
         height = self.height
         if self.source is not None:
-            data = np.ascontiguousarray(np.flip(self.source, axis=0).flatten())
+            data = np.flip(self.source, axis=0).reshape((-1,))
             width = self.source.shape[1]
             height = self.source.shape[0]
 

--- a/genesis/ext/pyrender/utils.py
+++ b/genesis/ext/pyrender/utils.py
@@ -41,7 +41,7 @@ def format_color_array(value, shape):
         value = np.column_stack((value, np.ones((value.shape[0], nc))))
     elif value.shape[1] > shape[1]:
         value = value[:, : shape[1]]
-    return value.astype(np.float32)
+    return value.astype(np.float32, order="C", copy=False)
 
 
 def format_texture_source(texture, target_channels="RGB"):

--- a/genesis/ext/trimesh/geometry.py
+++ b/genesis/ext/trimesh/geometry.py
@@ -176,7 +176,7 @@ def triangulate_quads(quads, dtype=np.int64):
 
         if len(quads.shape) == 2 and quads.shape[1] == 4:
             # if they are just quads stack and return
-            return np.vstack((quads[:, [0, 1, 2]], quads[:, [2, 3, 0]])).astype(dtype)
+            return np.vstack((quads[:, [0, 1, 2]], quads[:, [2, 3, 0]]), dtype=dtype)
     except ValueError:
         # new numpy raises an error for sequences
         pass

--- a/genesis/ext/trimesh/grouping.py
+++ b/genesis/ext/trimesh/grouping.py
@@ -198,7 +198,7 @@ def hashable_rows(data, digits=None):
     # reshape array into magical data type that is weird but hashable
     dtype = np.dtype((np.void, as_int.dtype.itemsize * as_int.shape[1]))
     # make sure result is contiguous and flat
-    hashable = np.ascontiguousarray(as_int).view(dtype).reshape(-1)
+    hashable = np.ascontiguousarray(as_int).view(dtype).reshape((-1,))
     return hashable
 
 

--- a/genesis/ext/trimesh/transformations.py
+++ b/genesis/ext/trimesh/transformations.py
@@ -252,7 +252,7 @@ def translation_from_matrix(matrix):
     True
 
     """
-    return np.array(matrix, copy=False)[:3, 3].copy()
+    return np.asarray(matrix)[:3, 3].copy()
 
 
 def reflection_matrix(point, normal):
@@ -293,7 +293,7 @@ def reflection_from_matrix(matrix):
     True
 
     """
-    M = np.array(matrix, dtype=np.float64, copy=False)
+    M = np.asarray(matrix, dtype=np.float64)
     # normal: unit eigenvector corresponding to eigenvalue -1
     w, V = np.linalg.eig(M[:3, :3])
     i = np.where(abs(np.real(w) + 1.0) < 1e-8)[0]
@@ -376,7 +376,7 @@ def rotation_matrix(angle, direction, point=None):
 
     # if point is specified, rotation is not around origin
     if point is not None:
-        point = np.array(point[:3], dtype=np.float64, copy=False)
+        point = np.asarray(point[:3], dtype=np.float64)
         M[:3, 3] = point - np.dot(M[:3, :3], point)
 
     # return symbolic angles as sympy Matrix objects
@@ -399,7 +399,7 @@ def rotation_from_matrix(matrix):
     True
 
     """
-    R = np.array(matrix, dtype=np.float64, copy=False)
+    R = np.asarray(matrix, dtype=np.float64)
     R33 = R[:3, :3]
     # direction: unit eigenvector of R33 corresponding to eigenvalue of 1
     w, W = np.linalg.eig(R33.T)
@@ -478,7 +478,7 @@ def scale_from_matrix(matrix):
     True
 
     """
-    M = np.array(matrix, dtype=np.float64, copy=False)
+    M = np.asarray(matrix, dtype=np.float64)
     M33 = M[:3, :3]
     factor = np.trace(M33) - 2.0
     try:
@@ -533,11 +533,11 @@ def projection_matrix(point, normal, direction=None, perspective=None, pseudo=Fa
 
     """
     M = np.identity(4)
-    point = np.array(point[:3], dtype=np.float64, copy=False)
+    point = np.asarray(point[:3], dtype=np.float64)
     normal = unit_vector(normal[:3])
     if perspective is not None:
         # perspective projection
-        perspective = np.array(perspective[:3], dtype=np.float64, copy=False)
+        perspective = np.asarray(perspective[:3], dtype=np.float64)
         M[0, 0] = M[1, 1] = M[2, 2] = np.dot(perspective - point, normal)
         M[:3, :3] -= np.outer(perspective, normal)
         if pseudo:
@@ -550,7 +550,7 @@ def projection_matrix(point, normal, direction=None, perspective=None, pseudo=Fa
         M[3, 3] = np.dot(perspective, normal)
     elif direction is not None:
         # parallel projection
-        direction = np.array(direction[:3], dtype=np.float64, copy=False)
+        direction = np.asarray(direction[:3], dtype=np.float64)
         scale = np.dot(direction, normal)
         M[:3, :3] -= np.outer(direction, normal) / scale
         M[:3, 3] = direction * (np.dot(point, normal) / scale)
@@ -593,7 +593,7 @@ def projection_from_matrix(matrix, pseudo=False):
     True
 
     """
-    M = np.array(matrix, dtype=np.float64, copy=False)
+    M = np.asarray(matrix, dtype=np.float64)
     M33 = M[:3, :3]
     w, V = np.linalg.eig(M)
     i = np.where(abs(np.real(w) - 1.0) < 1e-8)[0]
@@ -738,7 +738,7 @@ def shear_from_matrix(matrix):
     True
 
     """
-    M = np.array(matrix, dtype=np.float64, copy=False)
+    M = np.asarray(matrix, dtype=np.float64)
     M33 = M[:3, :3]
     # normal: cross independent eigenvectors corresponding to the eigenvalue 1
     w, V = np.linalg.eig(M33)
@@ -1089,8 +1089,8 @@ def superimposition_matrix(v0, v1, scale=False, usesvd=True):
     True
 
     """
-    v0 = np.array(v0, dtype=np.float64, copy=False)[:3]
-    v1 = np.array(v1, dtype=np.float64, copy=False)[:3]
+    v0 = np.asarray(v0, dtype=np.float64)[:3]
+    v1 = np.asarray(v1, dtype=np.float64)[:3]
     return affine_matrix_from_points(v0, v1, shear=False, scale=scale, usesvd=usesvd)
 
 
@@ -1186,7 +1186,7 @@ def euler_from_matrix(matrix, axes="sxyz"):
     j = _NEXT_AXIS[i + parity]
     k = _NEXT_AXIS[i - parity + 1]
 
-    M = np.array(matrix, dtype=np.float64, copy=False)[:3, :3]
+    M = np.asarray(matrix, dtype=np.float64)[:3, :3]
     if repetition:
         sy = math.sqrt(M[i, j] * M[i, j] + M[i, k] * M[i, k])
         if sy > _EPS:
@@ -1385,7 +1385,7 @@ def quaternion_from_matrix(matrix, isprecise=False):
     True
 
     """
-    M = np.array(matrix, dtype=np.float64, copy=False)[:4, :4]
+    M = np.asarray(matrix, dtype=np.float64)[:4, :4]
     if isprecise:
         q = np.empty((4,))
         t = np.trace(M)
@@ -1740,7 +1740,7 @@ def arcball_constrain_to_axis(point, axis):
 
 def arcball_nearest_axis(point, axes):
     """Return axis, which arc is nearest to point."""
-    point = np.array(point, dtype=np.float64, copy=False)
+    point = np.asarray(point, dtype=np.float64)
     nearest = None
     mx = -1.0
     for axis in axes:
@@ -1860,7 +1860,7 @@ def unit_vector(data, axis=None, out=None):
             return data
     else:
         if out is not data:
-            out[:] = np.array(data, copy=False)
+            out[:] = np.asarray(data)
         data = out
     length = np.atleast_1d(np.sum(data * data, axis))
     np.sqrt(length, length)
@@ -1931,8 +1931,8 @@ def angle_between_vectors(v0, v1, directed=True, axis=0):
     True
 
     """
-    v0 = np.array(v0, dtype=np.float64, copy=False)
-    v1 = np.array(v1, dtype=np.float64, copy=False)
+    v0 = np.asarray(v0, dtype=np.float64)
+    v1 = np.asarray(v1, dtype=np.float64)
     dot = np.sum(v0 * v1, axis=axis)
     dot /= vector_norm(v0, axis=axis) * vector_norm(v1, axis=axis)
     return np.arccos(dot if directed else np.fabs(dot))
@@ -2154,7 +2154,7 @@ def transform_points(points, matrix, translate=True):
 
     # quickly check to see if we've been passed an identity matrix
     if np.abs(matrix - _IDENTITY[: dim + 1, : dim + 1]).max() < 1e-8:
-        return np.ascontiguousarray(points.copy())
+        return points.copy(order="C")
 
     if translate:
         # apply translation and rotation

--- a/genesis/ext/trimesh/voxel/runlength.py
+++ b/genesis/ext/trimesh/voxel/runlength.py
@@ -342,8 +342,7 @@ def rle_to_rle(rle, dtype=np.int64):
 
 
 def _unsorted_gatherer(indices, sorted_gather_fn):
-    if not isinstance(indices, np.ndarray):
-        indices = np.array(indices, copy=False)
+    indices = np.asarray(indices)
     order = np.argsort(indices)
     ordered_indices = indices[order]
 
@@ -590,8 +589,7 @@ def brle_reverse(brle_data):
 
 def rle_reverse(rle_data):
     """Get the rle encoding of the reversed dense array."""
-    if not isinstance(rle_data, np.ndarray):
-        rle_data = np.array(rle_data, copy=False)
+    rle_data = np.asarray(rle_data)
     rle_data = np.reshape(rle_data, (-1, 2))
     rle_data = rle_data[-1::-1]
     return np.reshape(rle_data, (-1,))

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -840,11 +840,8 @@ class RasterizerContext:
 
     def seg_idxc_rgb_arr_to_idxc_arr(self, seg_idxc_rgb_arr):
         # Combine the RGB components into a single integer
-        seg_idxc_arr = np.array(
-            seg_idxc_rgb_arr[..., 0] * 256 * 256 + seg_idxc_rgb_arr[..., 1] * 256 + seg_idxc_rgb_arr[..., 2],
-            dtype=int,
-        )
-        return seg_idxc_arr
+        seg_idxc_rgb_arr = seg_idxc_rgb_arr.astype(np.int64, copy=False)
+        return seg_idxc_rgb_arr[..., 0] * (256 * 256) + seg_idxc_rgb_arr[..., 1] * 256 + seg_idxc_rgb_arr[..., 2]
 
     def colorize_seg_idxc_arr(self, seg_idxc_arr):
         return self.seg_idxc_to_color[seg_idxc_arr]


### PR DESCRIPTION
## Description

This PR fixes compatibility issues with numpy 2.X. Besides, flattening and data type casting has been refactored to avoid unnecessary copies whenever possible, and limit them to a single one per operation otherwise. Before this PR, flattening was systematically copied the original data (because it is what `flatten` does). Same for `astype()` without passing the optional argument `copy=False`. As a result, the original data was systematically copied twice if both flattened and casted were performed. 

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/789

## Motivation and Context

Numpy 2.X introduces breaking changes. The codebase needs to be updated accordingly to support Numpy 2.X without breaking backward compatibility. Among the notable changes:
* Type promotion logic has changed and is now strict. In particular, operation that would cause overflow no longer causes "unsafe" data type casting to store the result, e.g multiple a int8 array by 256 raises an exception instead of promoting the data type to np.int16 or np.int32 as it was previously the case.
* `np.array(..., copy=False)` now behaves differently. As stated in the migration doc, `np.asarray` should have been preferred in the first place anyway.

## How Has This Been / Can This Be Tested?

Running the example script `examples/tutorials/visualization.py` on both Windows OS and Mac OS.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x ] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.