### PR TITLE
[BUG] update setup.py to fix build fails

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import builtins
 from io import open as io_open
 import os
 import sys
+import numpy as np
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext as _build_ext
 
@@ -53,6 +54,7 @@ setup(
         Extension(
             "genesis.ext.fast_simplification._simplify",
             ["genesis/ext/fast_simplification/_simplify.pyx"],
+            include_dirs=[np.get_include()],
             language="c++",
             extra_compile_args=extra_compile_args,
             define_macros=macros,
@@ -60,6 +62,7 @@ setup(
         Extension(
             "genesis.ext.fast_simplification._replay",
             ["genesis/ext/fast_simplification/_replay.pyx"],
+            include_dirs=[np.get_include()],
             language="c++",
             extra_compile_args=extra_compile_args,
             define_macros=macros,


### PR DESCRIPTION
## Description
Fix build fails for Python < 3.12 resulted by cython extensions that use numpy. After making genesis compatible with numpy 2.0, building failed for lower versions of Python.

## Related Issue
Resolves Genesis-Embodied-AI/Genesis#788

## Motivation and Context
In numpy>2.0, some C APIs (e.g. PyDataType_ELSIZE, PyDataType_FIELDS) are moved to new headers and required explicit setups (which wasn't required in numpy<2.0). Adding `include_dirs=[np.get_include()]` explicitly links to the updated numpy headers.

Source:
- [NumPy 2.0 migration guide](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html)
- [Cython for NumPy users](https://cython.readthedocs.io/en/latest/src/userguide/numpy_tutorial.html#adding-numpy-headers)

## How Has This Been / Can This Be Tested?
1. have a clean python env (using venv, conda etc)
2. clone the branch
3. pip install -e .

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


edit 1: update motivation and context for a better explanation of the solution
edit 2: update source (cython for numpy users)