### PR TITLE
[BUG FIX] Fix cameras causing segfault on Windows OS.

### DIFF
--- a/genesis/vis/visualizer.py
+++ b/genesis/vis/visualizer.py
@@ -113,15 +113,13 @@ class Visualizer(RBC):
         for camera in self._cameras:
             camera._build()
 
-        if (
-            len(self._cameras) > 0 and gs.platform == "Linux"
-        ):  # Non-linux system uses main thread for viewer, which hasn't been started yet here.
-            # need to update viewer once here, because otherwise camera will update scene if render is called right after build, which will lead to segfault.
+        if self._cameras:
+            # need to update viewer once here, because otherwise camera will update scene if render is called right
+            # after build, which will lead to segfault.
             if self._viewer is not None:
                 self._viewer.update()
             else:
-                # viewer creation will compile rendering kernels
-                # if viewer is not created, render here once to compile
+                # viewer creation will compile rendering kernels if viewer is not created, render here once to compile
                 if self._rasterizer is not None:
                     self._rasterizer.render_camera(self._cameras[0])
 


### PR DESCRIPTION
## Description

This PR fixes camera rendering state not being properly initialised on Windows OS, causing segfault. The same logic is now used whatever the OS when building the scene. It could be avoided on Mac OS, for which the viewer does not run in a background thread, but it does no harm either since the extra computation is only done once when building the scene.

## Related Issue

Related to Genesis-Embodied-AI/Genesis/issues/466

## Motivation and Context

Triggering a segfault on Windows OS when adding cameras to the scene is unacceptable.

## How Has This Been / Can This Be Tested?

Running the example script `examples/tutorials/visualization.py` on both Windows OS and Mac OS.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.