### PR TITLE
[FEATURE] Add support on headless rendering on Windows OS.

### DIFF
--- a/genesis/vis/rasterizer.py
+++ b/genesis/vis/rasterizer.py
@@ -25,8 +25,9 @@ class Rasterizer(RBC):
             return
 
         if self._offscreen:
-            platform = "egl"
-            if gs.platform == "macOS":
+            if gs.platform == "Linux":
+                platform = "egl"
+            else:
                 platform = "pyglet"
             self._renderer = pyrender.OffscreenRenderer(
                 pyopengl_platform=platform, seg_node_map=self._context.seg_node_map

--- a/genesis/vis/visualizer.py
+++ b/genesis/vis/visualizer.py
@@ -17,17 +17,13 @@ class Visualizer(RBC):
         self._t = -1
         self._scene = scene
 
-        # Rasterizer context is shared by viewer and rasterizer.
-        if not show_viewer and gs.platform not in ["Linux", "macOS"]:
-            gs.logger.warning(f"Headless rendering not yet supported on {gs.platform}.")
-            self._context = None
-        else:
-            try:
-                from .rasterizer_context import RasterizerContext
+        # Rasterizer context is shared by viewer and rasterizer
+        try:
+            from .rasterizer_context import RasterizerContext
 
-            except Exception as e:
-                raise ImportError("Onscreen rendering not working on this machine.") from e
-            self._context = RasterizerContext(vis_options)
+        except Exception as e:
+            raise ImportError("Offscreen rendering not working on this machine.") from e
+        self._context = RasterizerContext(vis_options)
 
         # try to connect to display
         try:


### PR DESCRIPTION
## Description

Enable headless rendering on Windows OS. Relying on `pyglet` instead of `egl` because efficiency only really matters on Linux, and EGL is not working out-of-the-box on Windows OS. This limitation could be addressed in a subsequent PR.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/466

## Motivation and Context

Headless rendering is currently disabled on Windows because many other features it requires to work properly were previously broken. It is not straightforward to enable it back.

## How Has This Been / Can This Be Tested?

Running the example script `examples/tutorials/visualization.py` on both Windows OS and Mac OS, tweaked with `show_viewer=False` and `GUI=False`.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
