### PR TITLE
[BUG FIX] Better handling of rendering import failure (cont'd).

### DIFF
--- a/genesis/vis/rasterizer.py
+++ b/genesis/vis/rasterizer.py
@@ -4,12 +4,6 @@ import gc
 import numpy as np
 
 import genesis as gs
-
-try:
-    from genesis.ext import pyrender
-    from genesis.ext.pyrender.constants import RenderFlags
-except:
-    pass
 from genesis.repr_base import RBC
 
 
@@ -26,6 +20,8 @@ class Rasterizer(RBC):
             return
 
         if self._offscreen:
+            from genesis.ext import pyrender
+
             # if environment variable is set, use the platform specified, otherwise some platform-specific default
             platform = os.environ.get("PYOPENGL_PLATFORM", "egl" if gs.platform == "Linux" else "pyglet")
             self._renderer = pyrender.OffscreenRenderer(
@@ -35,6 +31,8 @@ class Rasterizer(RBC):
         self.visualizer = self._context.visualizer
 
     def add_camera(self, camera):
+        from genesis.ext import pyrender
+
         self._camera_nodes[camera.uid] = self._context.add_node(
             pyrender.PerspectiveCamera(
                 yfov=np.deg2rad(camera.fov),

--- a/genesis/vis/viewer.py
+++ b/genesis/vis/viewer.py
@@ -3,10 +3,7 @@ import numpy as np
 import genesis as gs
 import genesis.utils.geom as gu
 
-try:
-    from genesis.ext import pyrender
-except:
-    print("Failed to import pyrender. Rendering will not work.")
+from genesis.ext import pyrender
 from genesis.repr_base import RBC
 from genesis.utils.tools import Rate
 
@@ -20,14 +17,6 @@ class ViewerLock:
 
     def __exit__(self, exc_type, exc_value, traceback):
         self._pyrender_viewer.render_lock.release()
-
-
-class DummyViewerLock:
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        pass
 
 
 class Viewer(RBC):


### PR DESCRIPTION
## Description

This PR removes all the logic related to partially supported rendering capability depending on the platform, which is not relevant anymore. If rendering is not working, then it is coming from the user-side, not Genesis. For this reason, importing `pyrender` no longer fails silently but rather raises an exception containing the full backtrace to help the user debugs its setup.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/26

## Motivation and Context

Let us get rid of the special logic to deal with unsupported offscreen rendering since now it works on any platform. This makes the codebase easier to maintain and ensures that the feature set is consistent across platforms. Now it is binary: either rendering is completely broken and no features can be used at all (which is a bug on the user-side, not genesis), or all of them are coming together.

## How Has This Been / Can This Be Tested?

Running the tutorial and example script `examples/tutorials/visualization.py` tweaked with `show_viewer=False` and `GUI=False` on both Windows OS and Mac OS.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.