### PR TITLE
[BUG FIX] Fix screen resolution detection for high-DPI display.

### DIFF
--- a/genesis/vis/visualizer.py
+++ b/genesis/vis/visualizer.py
@@ -1,5 +1,4 @@
-import screeninfo
-
+import pyglet
 import genesis as gs
 from genesis.repr_base import RBC
 
@@ -27,21 +26,21 @@ class Visualizer(RBC):
 
         # try to connect to display
         try:
-            monitor = screeninfo.get_monitors()[0]
+            display = pyglet.display.get_display()
+            screen = display.get_default_screen()
             self._connected_to_display = True
         except Exception:
             self._connected_to_display = False
 
         if show_viewer:
-            if not self.connected_to_display:
+            if not self._connected_to_display:
                 gs.raise_exception("No display detected. Use `show_viewer=False` for headless mode.")
-                self._connected_to_display = False
 
             if viewer_options.res is None:
-                viewer_size_ratio = 0.5
+                viewer_size_ratio = screen.get_scale() * 0.5
                 viewer_options.res = (
-                    int(monitor.height * viewer_size_ratio / 0.75),
-                    int(monitor.height * viewer_size_ratio),
+                    int(screen.height * viewer_size_ratio / 0.75),
+                    int(screen.height * viewer_size_ratio),
                 )
 
             self._viewer = Viewer(viewer_options, self._context)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "opencv-python",
     "lxml",
     "tetgen >= 0.6.4",
-    "screeninfo",
     "PyGEL3D", # might need to use PyGEL3D == 0.1.0 for MacOS (M1)
     "moviepy >= 2.0.0",
     "numba",


### PR DESCRIPTION
## Description

This PR replaces `screeninfo` by `pyglet` to get the physical screen resolution.

## Motivation and Context

The screen resolution is not properly detected by `screeninfo` on High-DPI and Mac Retina display. Anyway, relying on `screeninfo` can be avoided in the first place since `pyglet` is already part of the requirements (dragged by Pyrender, which is not going anywhere soon). 

## How Has This Been / Can This Be Tested?

Running the tutorial on my MacBook Pro M3 Max.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.