### PR TITLE
[BUG FIX] better handling saved terrain

### DIFF
--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -642,6 +642,10 @@ class Terrain(Morph):
         The types of subterrains to generate. If a string, it will be repeated for all subterrains. If a 2D list, it should have the same shape as `n_subterrains`.
     height_field : array-like, optional
         The height field to generate the terrain. If specified, all other configurations will be ignored. Defaults to None.
+    name : str, optional
+        The name of the terrain to save
+    from_stored : str, optional
+        The path of the stored terrain to load
     """
 
     is_free: bool = False

--- a/genesis/utils/terrain.py
+++ b/genesis/utils/terrain.py
@@ -33,7 +33,7 @@ def parse_terrain(morph: Terrain, surface):
     """
 
     if morph.from_stored is not None:
-        terrain_dir = os.path.join(get_assets_dir(), f"terrain/{morph.name}")
+        terrain_dir = os.path.join(os.path.join(get_assets_dir(), f"terrain/{morph.name}"), morph.from_stored)
         os.makedirs(terrain_dir, exist_ok=True)
 
         tmesh = trimesh.load(os.path.join(terrain_dir, "tmesh.stl"))


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Previously, morphs.from_stored str path was not used. 

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?

run `examples/rigid/terrain_height_field.py` and uncomment `from_stored` line and pass the actual path. 
In the example, the `from_stored` treated like bool but the original doc is saying `from_stored` should be str representing saved asset dir path.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
