### PR TITLE
[BUG FIX] Bump pyglet version requirement due to breaking API changes.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "six",
     "PyOpenGL>=3.1.4",
     "freetype-py",
-    "pyglet",
+    "pyglet>=2.1",
     "libigl",
     "pygltflib == 1.16.0",
     "mujoco == 3.2.5",


### PR DESCRIPTION
## Description

Increase the minimum version requirement for `pyglet`.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/803

## Motivation and Context

`pyglet` has introduced breaking API changes since 2.1. While it would be possible to support both the new and old release by trying both APIs, I do not think it is worth it since this package is Python-only anyway, so it can be installed on any platform without issue.

## How Has This Been / Can This Be Tested?

Running the tutorial on my machine.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.