### PR TITLE
[BUG FIX] Fix EGL device detection.

### DIFF
--- a/genesis/ext/pyrender/platforms/egl.py
+++ b/genesis/ext/pyrender/platforms/egl.py
@@ -116,10 +116,7 @@ class EGLPlatform(Platform):
 
     def __init__(self, viewport_width, viewport_height, device: EGLDevice = None):
         super(EGLPlatform, self).__init__(viewport_width, viewport_height)
-        if device is None:
-            device = get_default_device()
-
-        self._egl_device = device
+        self._egl_device = None
         self._egl_display = None
         self._egl_context = None
 
@@ -152,6 +149,7 @@ class EGLPlatform(Platform):
             eglBindAPI,
             eglCreateContext,
             EGLConfig,
+            EGLError,
         )
         from OpenGL import arrays
 
@@ -191,18 +189,39 @@ class EGLPlatform(Platform):
         num_configs = ctypes.c_long()
         configs = (EGLConfig * 1)()
 
-        # Cache DISPLAY if necessary and get an off-screen EGL display
-        orig_dpy = None
-        if "DISPLAY" in os.environ:
-            orig_dpy = os.environ["DISPLAY"]
-            del os.environ["DISPLAY"]
+        # Get the list of devices to try on
+        if self._egl_device is None:
+            if _eglQueryDevicesEXT is None:
+                devices = (EGLDevice(None),)
+            devices = query_devices()
+        else:
+            devices = (self._egl_device,)
 
-        self._egl_display = self._egl_device.get_display()
-        if orig_dpy is not None:
-            os.environ["DISPLAY"] = orig_dpy
+        # Get the first EGL device that is working
+        for i, device in enumerate(devices):
+            # Cache DISPLAY if necessary and get an off-screen EGL display
+            orig_dpy = None
+            if "DISPLAY" in os.environ:
+                orig_dpy = os.environ["DISPLAY"]
+                del os.environ["DISPLAY"]
 
-        # Initialize EGL
-        assert eglInitialize(self._egl_display, major, minor)
+            egl_display = device.get_display()
+            if orig_dpy is not None:
+                os.environ["DISPLAY"] = orig_dpy
+
+            # Initialize EGL
+            try:
+                assert eglInitialize(egl_display, major, minor)
+            except EGLError:
+                # Ignore the error unless there is no device left to check
+                if i == len(devices) - 1:
+                    raise
+
+        # Backup the device and display that will be used
+        self._egl_device = device
+        self._egl_display = egl_display
+
+        # Configure EGL
         assert eglChooseConfig(self._egl_display, config_attributes, configs, 1, num_configs)
 
         # Bind EGL to the OpenGL API

--- a/genesis/ext/pyrender/platforms/pyglet_platform.py
+++ b/genesis/ext/pyrender/platforms/pyglet_platform.py
@@ -58,7 +58,7 @@ class PygletPlatform(Platform):
             try:
                 self._window = pyglet.window.Window(config=conf, visible=False, resizable=False, width=1, height=1)
                 break
-            except pyglet.window.NoSuchConfigException as e:
+            except (pyglet.window.NoSuchConfigException, pyglet.gl.ContextException):
                 pass
 
         if not self._window:

--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -1156,7 +1156,7 @@ class Viewer(pyglet.window.Window):
                     config=conf, resizable=True, width=self._viewport_size[0], height=self._viewport_size[1]
                 )
                 break
-            except pyglet.window.NoSuchConfigException:
+            except (pyglet.window.NoSuchConfigException, pyglet.gl.ContextException):
                 pass
 
         if not self.context:


### PR DESCRIPTION
## Description

Change the default EGL device selection method, to go through all the available devices and stick to the first one that works.

## Related Issue

Related to Genesis-Embodied-AI/Genesis/issues/43

## Motivation and Context

Currently, the "first" available EGL device is being used by default if none has been specified. This is problematic has it may not be the one reported as being the "default" by EGL itself (i.e. `EGL_DEFAULT_DISPLAY`), and it may not be working at all. It would be better to go through all the available devices and stick to the first one that is actually working.

## How Has This Been / Can This Be Tested?

Running the example script `examples/tutorials/visualization.py` on both Ubuntu 24.04 via WSL2 on Windows OS, tweaked with `show_viewer=False`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
