### PR TITLE
[BUG FIX] Rely on automatic EGL device detection if not specified.

### DIFF
--- a/genesis/ext/pyrender/offscreen.py
+++ b/genesis/ext/pyrender/offscreen.py
@@ -189,8 +189,11 @@ class OffscreenRenderer(object):
         elif platform == "egl":
             from .platforms import egl
 
-            device_id = int(os.environ.get("EGL_DEVICE_ID", "0"))
-            egl_device = egl.get_device_by_index(device_id)
+            if "EGL_DEVICE_ID" in os.environ:
+                device_id = int(os.environ["EGL_DEVICE_ID"])
+                egl_device = egl.get_device_by_index(device_id)
+            else:
+                egl_device = None
             self._platform = egl.EGLPlatform(self.viewport_width, self.viewport_height, device=egl_device)
         elif platform == "osmesa":
             from .platforms.osmesa import OSMesaPlatform

--- a/genesis/ext/pyrender/platforms/egl.py
+++ b/genesis/ext/pyrender/platforms/egl.py
@@ -209,9 +209,20 @@ class EGLPlatform(Platform):
             if orig_dpy is not None:
                 os.environ["DISPLAY"] = orig_dpy
 
-            # Initialize EGL
             try:
+                # Initialize EGL
                 assert eglInitialize(egl_display, major, minor)
+
+                # Configure EGL
+                assert eglChooseConfig(egl_display, config_attributes, configs, 1, num_configs)
+
+                # Bind EGL to the OpenGL API
+                assert eglBindAPI(EGL_OPENGL_API)
+
+                # Create an EGL context
+                egl_context = eglCreateContext(egl_display, configs[0], EGL_NO_CONTEXT, context_attributes)
+
+                break
             except EGLError:
                 # Ignore the error unless there is no device left to check
                 if i == len(devices) - 1:
@@ -220,15 +231,7 @@ class EGLPlatform(Platform):
         # Backup the device and display that will be used
         self._egl_device = device
         self._egl_display = egl_display
-
-        # Configure EGL
-        assert eglChooseConfig(self._egl_display, config_attributes, configs, 1, num_configs)
-
-        # Bind EGL to the OpenGL API
-        assert eglBindAPI(EGL_OPENGL_API)
-
-        # Create an EGL context
-        self._egl_context = eglCreateContext(self._egl_display, configs[0], EGL_NO_CONTEXT, context_attributes)
+        self._egl_context = egl_context
 
         # Make it current
         self.make_current()


### PR DESCRIPTION
## Description

This PR relies on the newly introduced "robust" EGL device detection logic to choose the right device if none has been specified by the end-user, instead of forcing the device "0" in such a case.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/648
Resolves Genesis-Embodied-AI/Genesis/issues/281
Resolves Genesis-Embodied-AI/Genesis/issues/521

## Motivation and Context

The EGL device "0" is systematically preferred even if non has been specified by the end-user. This is problematic has it may not even exist, which would raise an exception.

## How Has This Been / Can This Be Tested?

Running the example script `examples/tutorials/visualization.py` for both onscreen rendering (`show_viewer=False`, `GUI=False`) and offscreen rendering (`show_viewer=True`, `GUI=True`) on several platforms:
* Ubuntu 24.04 via WSL2 on Windows OS (Intel x86 + Nvidia GPU Quadro)
* Native Windows OS (Intel x86 + Nvidia GPU Quadro)
* Native Mac OS (Apple Silicon M3 Max)
* Native Ubuntu 22.04 (Intel x86, No discrete GPU)
* Native Windows OS (Intel x86, No discrete GPU)
* Native Ubuntu 18.04 (Intel x86 + Nvidia GPU RTX)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
