### PR TITLE
[BUGFIX] IS_OPENGL_42_AVAILABLE condition bug

### DIFF
--- a/genesis/ext/pyrender/jit_render.py
+++ b/genesis/ext/pyrender/jit_render.py
@@ -360,8 +360,9 @@ class JITRenderer:
 
     def gen_func_ptr(self):
         self.gl = GLWrapper()
+        self.gl.build_wrapper()
 
-        IS_OPENGL_42_AVAILABLE = hasattr(self.gl, "glDrawElementsInstancedBaseInstance")
+        IS_OPENGL_42_AVAILABLE = "glDrawElementsInstancedBaseInstance" in self.gl.gl_funcs.keys()
         OPENGL_42_ERROR_MSG = "Seperated env rendering not supported because OpenGL 4.2 not available on this machine."
 
         @njit(

--- a/genesis/ext/pyrender/jit_render.py
+++ b/genesis/ext/pyrender/jit_render.py
@@ -362,7 +362,7 @@ class JITRenderer:
         self.gl = GLWrapper()
         self.gl.build_wrapper()
 
-        IS_OPENGL_42_AVAILABLE = "glDrawElementsInstancedBaseInstance" in self.gl.gl_funcs.keys()
+        IS_OPENGL_42_AVAILABLE = "glDrawElementsInstancedBaseInstance" in self.gl.gl_funcs
         OPENGL_42_ERROR_MSG = "Seperated env rendering not supported because OpenGL 4.2 not available on this machine."
 
         @njit(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

fix for IS_OPENGL_42_AVAILABLE condition.

## Related Issue

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
current method raised error for tiled rendering even with OpenGL >= 4.2 is installed

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
