### PR TITLE
[BUG FIX] Update OpenGL 4.2 detection to stick on Public API.

### DIFF
--- a/genesis/ext/pyrender/jit_render.py
+++ b/genesis/ext/pyrender/jit_render.py
@@ -360,9 +360,8 @@ class JITRenderer:
 
     def gen_func_ptr(self):
         self.gl = GLWrapper()
-        self.gl.build_wrapper()
 
-        IS_OPENGL_42_AVAILABLE = "glDrawElementsInstancedBaseInstance" in self.gl.gl_funcs
+        IS_OPENGL_42_AVAILABLE = hasattr(self.gl.wrapper_instance, "glDrawElementsInstancedBaseInstance")
         OPENGL_42_ERROR_MSG = "Seperated env rendering not supported because OpenGL 4.2 not available on this machine."
 
         @njit(


### PR DESCRIPTION
## Description

Avoid relying on private API `build_wrapper` and `gl_funcs` to detect OpenGL version. These are implementation details that may change at any point in time. Only `wrapper_type` and `wrapper_instance` are public API.

## Related Issue

Related to Genesis-Embodied-AI/Genesis/pull/813

## Motivation and Context

Even though the current implementation is working. Relying on private API is a bad practice and must be avoided.

## How Has This Been / Can This Be Tested?

Testing locally on my machine the condition check for both `glDrawElementsInstancedBaseInstance` and `glUniformMatrix4fv`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.