### PR TITLE
[FEATURE] Enable visualizing path

### DIFF
--- a/examples/tutorials/IK_motion_planning_grasp.py
+++ b/examples/tutorials/IK_motion_planning_grasp.py
@@ -1,11 +1,8 @@
-import os
-
-os.environ["PYOPENGL_PLATFORM"] = "glx"  # Set OpenGL platform before importing genesis
 import genesis as gs
 import numpy as np
 
 ########################## init ##########################
-gs.init(backend=gs.cpu)
+gs.init(backend=gs.gpu)
 
 ########################## create a scene ##########################
 scene = gs.Scene(

--- a/examples/tutorials/IK_motion_planning_grasp.py
+++ b/examples/tutorials/IK_motion_planning_grasp.py
@@ -1,8 +1,11 @@
+import os
+
+os.environ["PYOPENGL_PLATFORM"] = "glx"  # Set OpenGL platform before importing genesis
 import genesis as gs
 import numpy as np
 
 ########################## init ##########################
-gs.init(backend=gs.gpu)
+gs.init(backend=gs.cpu)
 
 ########################## create a scene ##########################
 scene = gs.Scene(
@@ -63,10 +66,16 @@ path = franka.plan_path(
     qpos_goal=qpos,
     num_waypoints=200,  # 2s duration
 )
+# draw the planned path
+path_debug = scene.draw_debug_path(path, franka)
+
 # execute the planned path
 for waypoint in path:
     franka.control_dofs_position(waypoint)
     scene.step()
+
+# remove the drawn path
+scene.clear_debug_object(path_debug)
 
 # allow robot to reach the last waypoint
 for i in range(100):

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 
 import genesis as gs
+import genesis.utils.geom as gu
 from genesis.engine.entities import Emitter
 from genesis.engine.simulator import Simulator
 from genesis.options import (
@@ -970,11 +971,13 @@ class Scene(RBC):
             The created debug object.
         """
         with self._visualizer.viewer_lock:
-            poss = torch.zeros(len(qposs), 3)
+            Ts = torch.zeros((len(qposs), 4, 4))
             for i, qpos in enumerate(qposs):
-                pos, _ = entity.forward_kinematics(qpos)
-                poss[i] = pos[-1]
-            return self._visualizer.context.draw_debug_points(poss, colors)
+                pos, quat = entity.forward_kinematics(qpos)
+                T = gu.quat_to_T(quat[-1])
+                T[:3, 3] = pos[-1]
+                Ts[i] = T
+            return self._visualizer.context.draw_debug_frames(Ts)
 
     @gs.assert_built
     def clear_debug_object(self, object):

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -950,7 +950,7 @@ class Scene(RBC):
             return self._visualizer.context.draw_debug_points(poss, colors)
 
     @gs.assert_built
-    def draw_debug_path(self, qposs, entity, density=0.3, frame_scaling=1.0):
+    def draw_debug_path(self, qposs, entity, link_idx=-1, density=0.3, frame_scaling=1.0):
         """
         Draws a planned joint trajectory in the scene for visualization.
 
@@ -962,6 +962,8 @@ class Scene(RBC):
             M is the number of degrees of freedom for the entity (i.e., joint dimensions).
         entity : gs.engine.entities.RigidEntity
             The rigid entity whose forward kinematics are used to compute the trajectory path.
+        link_idx : int, optional
+            The link id of the rigid entity to visualize. Defeault is -1.
         density : float, optional
             Controls the sampling density of the trajectory points to visualize. Default is 0.3.
         frame_scaling : float, optional
@@ -987,7 +989,7 @@ class Scene(RBC):
 
             for i in range(N_new):
                 pos, quat = entity.forward_kinematics(qposs[indices[i]])
-                Ts[i] = gu.trans_quat_to_T(pos[-1], quat[-1])
+                Ts[i] = gu.trans_quat_to_T(pos[link_idx], quat[link_idx])
 
             return self._visualizer.context.draw_debug_frames(
                 Ts, axis_length=frame_scaling * 0.1, origin_size=0.001, axis_radius=frame_scaling * 0.005

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -987,9 +987,7 @@ class Scene(RBC):
 
             for i in range(N_new):
                 pos, quat = entity.forward_kinematics(qposs[indices[i]])
-                T = gu.quat_to_T(quat[-1])
-                T[:3, 3] = pos[-1]
-                Ts[i] = T
+                Ts[i] = gu.trans_quat_to_T(pos[-1], quat[-1])
 
             return self._visualizer.context.draw_debug_frames(
                 Ts, axis_length=frame_scaling * 0.1, origin_size=0.001, axis_radius=frame_scaling * 0.005

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -925,6 +925,34 @@ class Scene(RBC):
             return self._visualizer.context.draw_debug_points(poss, colors)
 
     @gs.assert_built
+    def draw_debug_path(self, qposs, entity, colors=(1.0, 0.0, 0.0, 0.5)):
+        """
+        Draws a planned trajectory in the scene for visualization.
+
+        Parameters
+        ----------
+        qposs : array_like, shape (N, M)
+            The joint positions of the planned points.
+            N is the number of configurations (i.e., trajectory points).
+            M is the number of degrees of freedom for the entity (i.e., joint dimensions).
+        entity : gs.engine.entities.RigidEntity
+            The rigid entity whose forward kinematics are used to compute the trajectory path.
+        colors : array_like, shape (4,), optional
+            The color of the points in RGBA format.
+
+        Returns
+        -------
+        node : genesis.ext.pyrender.mesh.Mesh
+            The created debug object.
+        """
+        with self._visualizer.viewer_lock:
+            poss = torch.zeros(len(qposs), 3)
+            for i, qpos in enumerate(qposs):
+                pos, _ = entity.forward_kinematics(qpos)
+                poss[i] = pos[-1]
+            return self._visualizer.context.draw_debug_points(poss, colors)
+
+    @gs.assert_built
     def clear_debug_object(self, object):
         """
         Clears all the debug objects in the scene.

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -807,6 +807,30 @@ class Scene(RBC):
             return self._visualizer.context.draw_debug_frame(T, axis_length, origin_size, axis_radius)
 
     @gs.assert_built
+    def draw_debug_frames(self, Ts, axis_length=1.0, origin_size=0.015, axis_radius=0.01):
+        """
+        Draws 3-axis coordinate frames in the scene for visualization.
+
+        Parameters
+        ----------
+        Ts : array_like, shape (n, 4, 4)
+            The transformation matrices of frames.
+        axis_length : float, optional
+            The length of the axes.
+        origin_size : float, optional
+            The size of the origin point (represented as a sphere).
+        axis_radius : float, optional
+            The radius of the axes (represented as cylinders).
+
+        Returns
+        -------
+        node : genesis.ext.pyrender.mesh.Mesh
+            The created debug object.
+        """
+        with self._visualizer.viewer_lock:
+            return self._visualizer.context.draw_debug_frames(Ts, axis_length, origin_size, axis_radius)
+
+    @gs.assert_built
     def draw_debug_mesh(self, mesh, pos=np.zeros(3), T=None):
         """
         Draws a mesh in the scene for visualization.

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -682,6 +682,19 @@ class RasterizerContext:
         self.add_external_node(node, pose=T)
         return node
 
+    def draw_debug_frames(self, poses, axis_length=1.0, origin_size=0.015, axis_radius=0.01):
+        node = pyrender.Mesh.from_trimesh(
+            trimesh.creation.axis(
+                origin_size=origin_size,
+                axis_radius=axis_radius,
+                axis_length=axis_length,
+            ),
+            name=f"debug_frame_{gs.UID()}",
+            poses=poses,
+        )
+        self.add_external_node(node)
+        return node
+
     def draw_debug_mesh(self, mesh, pos=np.zeros(3), T=None):
         if T is None:
             T = gu.trans_to_T(tensor_to_array(pos))


### PR DESCRIPTION
## Description

Enable visualizing a path for rigid entities using FK.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context

Opening this PR to improve the convenience of visualizing a path.

## How Has This Been / Can This Be Tested?

I have modified `examples/tutorials/IK_motion_planning_grasp.py` to visualize the path. The example script can be used to test. (If requested, I can add a separate example script to demonstrate this feature.)

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/fe9cf40c-9ae1-4edf-af96-7be0c48708a7)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
