### PR TITLE
WIP: [MISC] Refactor MJCF file parsing.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -364,6 +364,21 @@ class RigidEntity(Entity):
                 "when calling `scene.add_entity`."
             )
 
+        # Duplicating collision geometries as visual for bodies not having dedicated visual geometries
+        for link_g_info in links_g_info:
+            is_all_col = all(g_info["contype"] or g_info["conaffinity"] for g_info in link_g_info)
+            if is_all_col:
+                for g_info in link_g_info.copy():
+                    mesh = g_info["mesh"]
+                    vmesh = gs.Mesh(
+                        mesh=mesh.trimesh,
+                        surface=surface,
+                        uvs=mesh.uvs,
+                        metadata=mesh.metadata,
+                    )
+                    g_info = {**g_info, "mesh": mesh, "contype": 0, "conaffinity": 0}
+                    link_g_info.append(g_info)
+
         l_infos = []
         j_infos = []
 

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -336,70 +336,17 @@ class RigidEntity(Entity):
         if mj.ntendon:
             gs.logger.warning("(MJCF) Tendon not supported")
 
-        links_g_info = [list() for _ in range(n_links)]
-        world_g_info = []
+        # Parse all geometries grouped by parent joint (or world)
+        world_g_info, *links_g_info = mju.parse_geoms(mj, morph.scale, morph.convexify, surface, morph.file)
 
-        # assign geoms to link
-        is_any_col = False
-        for i_g in range(n_geoms):
-            if mj.geom_bodyid[i_g] < 0:
-                continue
-
-            # address geoms directly attached to worldbody (0)
-            elif mj.geom_bodyid[i_g] == 0:
-                g_info = mju.parse_geom(mj, i_g, morph.scale, morph.convexify, surface, morph.file)
-                if g_info is not None:
-                    world_g_info.append(g_info)
-
-            else:
-                g_info = mju.parse_geom(mj, i_g, morph.scale, morph.convexify, surface, morph.file)
-                if g_info is not None:
-                    link_idx = mj.geom_bodyid[i_g] - 1
-                    links_g_info[link_idx].append(g_info)
-                    is_any_col |= g_info["contype"] or g_info["conaffinity"]
-
-        if is_any_col and surface.vis_mode != "collision":
-            gs.logger.info(
-                "Collision meshes are not visualized by default. To visualize them, please use `vis_mode='collision'` "
-                "when calling `scene.add_entity`."
-            )
-
-        # Duplicating collision geometries as visual for bodies not having dedicated visual geometries
-        for link_g_info in links_g_info:
-            is_all_col = all(g_info["contype"] or g_info["conaffinity"] for g_info in link_g_info)
-            if is_all_col:
-                for g_info in link_g_info.copy():
-                    mesh = g_info["mesh"]
-                    vmesh = gs.Mesh(
-                        mesh=mesh.trimesh,
-                        surface=surface,
-                        uvs=mesh.uvs,
-                        metadata=mesh.metadata,
-                    )
-                    g_info = {**g_info, "mesh": mesh, "contype": 0, "conaffinity": 0}
-                    link_g_info.append(g_info)
-
-        l_infos = []
-        j_infos = []
-
-        q_offset, dof_offset, qpos0_offset = 0, 0, 0
-
-        for i_l in range(n_links):
-            l_info, j_info = mju.parse_link(mj, i_l + 1, q_offset, dof_offset, qpos0_offset, morph.scale)
-
-            l_infos.append(l_info)
-            j_infos.append(j_info)
-
-            q_offset += j_info["n_qs"]
-            dof_offset += j_info["n_dofs"]
-            qpos0_offset += j_info["n_qpos0"]
+        # Parse all bodies (links and joints)
+        (l_world_info, *l_infos), (j_world_info, *j_infos) = mju.parse_links(mj, morph.scale)
 
         l_infos, j_infos, links_g_info, ordered_links_idx = uu._order_links(l_infos, j_infos, links_g_info)
-        for i_l in range(len(l_infos)):
-            l_info = l_infos[i_l]
-            j_info = j_infos[i_l]
-
-            if l_info["parent_idx"] < 0:  # base link
+        for l_info, j_info, link_g_info in zip(
+            (*l_infos, l_world_info), (*j_infos, j_world_info), (*links_g_info, world_g_info)
+        ):
+            if l_info["parent_idx"] < 0 and j_info["type"] != gs.JOINT_TYPE.FIXED:  # base link
                 if morph.pos is not None:
                     l_info["pos"] = np.array(morph.pos)
                     gs.logger.warning("Overriding base link's pos with user provided value in morph.")
@@ -408,20 +355,11 @@ class RigidEntity(Entity):
                     gs.logger.warning("Overriding base link's quat with user provided value in morph.")
 
                 if j_info["type"] == gs.JOINT_TYPE.FREE:
-                    # in this case, l_info['pos'] and l_info['quat'] are actually not used in solver, but this initial value will be reflected
+                    # in this case, l_info['pos'] and l_info['quat'] are actually not used in solver, but this initial
+                    # value will be reflected
                     j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
 
-            self._add_by_info(l_info, j_info, links_g_info[i_l], morph, surface)
-
-        if world_g_info:
-            l_world_info, j_world_info = mju.parse_link(mj, 0, q_offset, dof_offset, qpos0_offset, morph.scale)
-            if morph.pos is not None:
-                l_world_info["pos"] = np.array(morph.pos)
-                gs.logger.warning("Overriding base link's pos with user provided value in morph.")
-            if morph.quat is not None:
-                l_world_info["quat"] = np.array(morph.quat)
-                gs.logger.warning("Overriding base link's quat with user provided value in morph.")
-            self._add_by_info(l_world_info, j_world_info, world_g_info, morph, surface)
+            self._add_by_info(l_info, j_info, link_g_info, morph, surface)
 
         for i_e in range(mj.neq):
             e_info = mju.parse_equality(mj, i_e, morph.scale, ordered_links_idx)
@@ -704,6 +642,8 @@ class RigidEntity(Entity):
     def get_jacobian(self, link):
         """
         Get the Jacobian matrix for a target link.
+
+        FIXME: Which jacobian are we talking about ? Presumably {w}_J_{O_i}
 
         Parameters
         ----------

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -376,7 +376,7 @@ class RigidEntity(Entity):
                     sol_params=e_info["sol_params"],
                 )
             else:
-                gs.logger.warning(f"(MJCF) Equality type '{e_info["type"]}' not supported for now.")
+                gs.logger.warning(f"(MJCF) Equality type '{e_info['type']}' not supported for now.")
 
     def _load_URDF(self, morph, surface):
         l_infos, j_infos = uu.parse_urdf(morph, surface)

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -179,8 +179,8 @@ class RigidLink(RBC):
         sol_params,
         center_init=None,
         needs_coup=False,
-        contype=0xFFFFFFFF,
-        conaffinity=0xFFFFFFFF,
+        contype=1,
+        conaffinity=1,
         data=None,
     ):
         geom = RigidGeom(


### PR DESCRIPTION
## Description

This PR refactor MCJF file parsing to allow more powerful post-processing. This is used to trigger more warnings related to unsupported Mujoco features, more specifically:
* log 1 info when enabling collision detection and visualisation of collision meshes is not enabled
* log 1 warning for "all" Mujoco features that are enabled in MJCF files but not implemented in Genesis

Besides, this collision geometries are now duplicated as visual for bodies not having dedicated visual geometries.

## Related Issue

Related to Genesis-Embodied-AI/Genesis/issues/157
Resolves Genesis-Embodied-AI/Genesis/issues/548
Related to Genesis-Embodied-AI/Genesis/issues/461
Related to Genesis-Embodied-AI/Genesis/issues/287
Resolves Genesis-Embodied-AI/Genesis/issues/603

## Motivation and Context

Some Mujoco features that are enabled in MJCF files but missing in Genesis are silently ignored. This is problematic because this would have an effect on the dynamics of the system, without the end-user being aware of it. At this stage, a warning should be reported every time a feature is ignored. Indeed, implementing all the missing features will take time and may not even be desirable. 

## How Has This Been / Can This Be Tested?

Going through the various assets that are shipping with Genesis.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
