### PR TITLE
Add default viewer recording save filename

### DIFF
--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -61,6 +61,7 @@ from .shader_program import ShaderProgram, ShaderProgramCache
 from .trackball import Trackball
 
 pyglet.options["shadow_window"] = False
+DEFAULT_RECORDING_SAVE_FILENAME = "default-recording-save-filename.mp4"
 
 
 class Viewer(pyglet.window.Window):
@@ -556,6 +557,8 @@ class Viewer(pyglet.window.Window):
         """
         if filename is None:
             filename = self._get_save_filename(["mp4"])
+            if filename is None:
+                filename = DEFAULT_RECORDING_SAVE_FILENAME
 
         self.video_recorder.close()
         shutil.move(self.video_recorder.filename, filename)


### PR DESCRIPTION
Getting this bug while trying to save a recording from the viewer (pressing 'r'):

```
Exception in thread Thread-2 (_init_and_start_app):
Traceback (most recent call last):
  File "/opt/conda/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/opt/conda/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/conda/lib/python3.11/site-packages/genesis/ext/pyrender/viewer.py", line 1178, in _init_and_start_app
    self.dispatch_pending_events()
  File "/opt/conda/lib/python3.11/site-packages/pyglet/window/xlib/__init__.py", line 1025, in dispatch_pending_events
    EventDispatcher.dispatch_event(self, *self._event_queue.pop(0))
  File "/opt/conda/lib/python3.11/site-packages/pyglet/event.py", line 375, in dispatch_event
    self._raise_dispatch_exception(event_type, args, getattr(self, event_type), exception)
  File "/opt/conda/lib/python3.11/site-packages/pyglet/event.py", line 432, in _raise_dispatch_exception
    raise exception
  File "/opt/conda/lib/python3.11/site-packages/pyglet/event.py", line 368, in dispatch_event
    if getattr(self, event_type)(*args):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/genesis/ext/pyrender/viewer.py", line 856, in on_key_press
    self.save_video()
  File "/opt/conda/lib/python3.11/site-packages/genesis/ext/pyrender/viewer.py", line 556, in save_video
    shutil.move(self.video_recorder.filename, filename)
  File "/opt/conda/lib/python3.11/shutil.py", line 839, in move
    if os.path.isdir(dst):
       ^^^^^^^^^^^^^^^^^^
  File "<frozen genericpath>", line 42, in isdir
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```

Added a quick fix; a default recording save filename to hopefully save some people headaches in the future.