### PR TITLE
[FEATURE] Add support of compound joints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
           docker run -u ci:ci --gpus all --rm -v ${{ github.workspace }}:/app cuda11_py11:latest \
           bash -c "cd /app && \
           sudo bash ./.github/workflows/setup_env.sh && \
-          pip install 'mujoco==3.2.5' && \
           pip install -e . && \
           pytest -v tests"
 

--- a/examples/rigid/set_phys_attr.py
+++ b/examples/rigid/set_phys_attr.py
@@ -31,6 +31,7 @@ def main():
             # NOTE: Batching dofs/links info to set different physical attributes across environments (in parallel)
             #       By default, both are False as it's faster and thus only turn this on if necessary
             batch_dofs_info=True,
+            batch_joints_info=True,
             batch_links_info=True,
         ),
     )

--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -167,7 +167,7 @@ def init(
     elif gs.logger.level == _logging.INFO:
         taichi_kwargs.update(log_level=ti.INFO)
     elif gs.logger.level == _logging.DEBUG:
-        taichi_kwargs.update(log_level=ti.TRACE if debug else ti.DEBUG)
+        taichi_kwargs.update(log_level=ti.INFO)
     if debug:
         if backend == gs_backend.cpu:
             taichi_kwargs.update(cpu_max_num_threads=1)

--- a/genesis/assets/xml/walker.xml
+++ b/genesis/assets/xml/walker.xml
@@ -1,0 +1,88 @@
+<mujoco model="planar walker">
+
+  <asset>
+    <texture name="grid" type="2d" builtin="checker" rgb1=".1 .2 .3" rgb2=".2 .3 .4" width="300" height="300" mark="edge" markrgb=".2 .3 .4"/>
+    <material name="grid" texture="grid" texrepeat="1 1" texuniform="true" reflectance=".2"/>
+    <material name="self" rgba=".7 .5 .3 1"/>
+    <material name="site" rgba=".5 .5 .5 .3"/>
+  </asset>
+
+  <option timestep="0.005" iterations="2" ls_iterations="5">
+    <flag eulerdamp="disable"/>
+  </option>
+
+  <custom>
+    <numeric data="4" name="max_contact_points"/>
+    <numeric data="4" name="max_geom_pairs"/>
+  </custom>
+
+  <statistic extent="2" center="0 0 1"/>
+
+  <default>
+    <joint damping=".1" armature="0.01" limited="true" solimplimit="0 .99 .01"/>
+    <geom contype="1" conaffinity="0" friction=".7 .1 .1"/>
+    <motor ctrlrange="-1 1" ctrllimited="true"/>
+    <site size="0.01"/>
+    <default class="walker">
+      <geom material="self" type="capsule"/>
+      <joint axis="0 -1 0"/>
+    </default>
+  </default>
+
+  <worldbody>
+    <geom name="floor" type="plane" conaffinity="1" pos="248 0 0" size="250 .8 .2" material="grid" zaxis="0 0 1"/>
+    <body name="torso" pos="0 0 1.3" childclass="walker">
+      <light name="light" pos="0 0 2" mode="trackcom"/>
+      <camera name="side" pos="0 -2 .7" euler="60 0 0" mode="trackcom"/>
+      <camera name="back" pos="-2 0 .5" xyaxes="0 -1 0 1 0 3" mode="trackcom"/>
+      <joint name="rootz" axis="0 0 1" type="slide" limited="false" armature="0" damping="0"/>
+      <joint name="rootx" axis="1 0 0" type="slide" limited="false" armature="0" damping="0"/>
+      <joint name="rooty" axis="0 1 0" type="hinge" limited="false" armature="0" damping="0"/>
+      <!-- <joint name="rootz_vel" axis="0 0 1" type="slide" limited="false" armature="0" damping="0"/>
+      <joint name="rooty_vel" axis="0 1 0" type="slide" limited="false" armature="0" damping="0"/>
+      <joint name="rootx_vel" axis="1 0 0" type="slide" limited="false" armature="0" damping="0"/>
+      <joint name="rootz_ang" axis="0 0 1" type="hinge" limited="false" armature="0" damping="0"/>
+      <joint name="rooty_ang" axis="0 1 0" type="hinge" limited="false" armature="0" damping="0"/>
+      <joint name="rootx_ang" axis="1 0 0" type="hinge" limited="false" armature="0" damping="0"/> -->
+      <!-- <freejoint/> -->
+      <geom name="torso" size="0.07 0.3"/>
+      <body name="right_thigh" pos="0 -.05 -0.3">
+        <joint name="right_hip" range="-20 100"/>
+        <geom name="right_thigh" pos="0 0 -0.225" size="0.05 0.225"/>
+        <body name="right_leg" pos="0 0 -0.7">
+          <joint name="right_knee" pos="0 0 0.25" range="-150 0"/>
+          <geom name="right_leg" size="0.04 0.25"/>
+          <body name="right_foot" pos="0.06 0 -0.25">
+            <joint name="right_ankle" pos="-0.06 0 0" range="-45 45"/>
+            <geom name="right_foot" zaxis="1 0 0" size="0.05 0.1"/>
+          </body>
+        </body>
+      </body>
+      <body name="left_thigh" pos="0 .05 -0.3" >
+        <joint name="left_hip" range="-20 100"/>
+        <geom name="left_thigh" pos="0 0 -0.225" size="0.05 0.225"/>
+        <body name="left_leg" pos="0 0 -0.7">
+          <joint name="left_knee" pos="0 0 0.25" range="-150 0"/>
+          <geom name="left_leg" size="0.04 0.25"/>
+          <body name="left_foot" pos="0.06 0 -0.25">
+            <joint name="left_ankle" pos="-0.06 0 0" range="-45 45"/>
+            <geom name="left_foot" zaxis="1 0 0" size="0.05 0.1"/>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+
+  <sensor>
+    <subtreelinvel name="torso_subtreelinvel" body="torso"/>
+  </sensor>
+
+  <actuator>
+    <motor name="right_hip" joint="right_hip" gear="100"/>
+    <motor name="right_knee" joint="right_knee" gear="50"/>
+    <motor name="right_ankle" joint="right_ankle" gear="20"/>
+    <motor name="left_hip" joint="left_hip" gear="100"/>
+    <motor name="left_knee" joint="left_knee" gear="50"/>
+    <motor name="left_ankle" joint="left_ankle" gear="20"/>
+  </actuator>
+</mujoco>

--- a/genesis/constants.py
+++ b/genesis/constants.py
@@ -42,7 +42,6 @@ class JOINT_TYPE(IntEnum):
     PRISMATIC = 2
     SPHERICAL = 3
     FREE = 4
-    PLANAR = 5
 
 
 class EQUALITY_TYPE(IntEnum):

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1,3 +1,5 @@
+from itertools import chain
+
 import numpy as np
 import taichi as ti
 import torch
@@ -151,59 +153,50 @@ class RigidEntity(Entity):
         else:
             gs.raise_exception("Unsupported primitive shape")
 
-        vmesh = gs.Mesh.from_trimesh(tmesh, surface=surface)
-        mesh = gs.Mesh.from_trimesh(tmesh, surface=gs.surfaces.Collision())
-
-        link = self._add_link(
-            name=f"{link_name_prefix}_baselink",
-            pos=np.array(morph.pos),
-            quat=np.array(morph.quat),
-            inertial_pos=gu.zero_pos(),
-            inertial_quat=gu.identity_quat(),
-            inertial_i=None,
-            inertial_mass=None,
-            parent_idx=-1,
-            invweight=None,
-        )
-        self._add_joint(
-            name=f"{link_name_prefix}_baselink_joint",
-            n_qs=n_qs,
-            n_dofs=n_dofs,
-            type=joint_type,
-            pos=gu.zero_pos(),
-            quat=gu.identity_quat(),
-            dofs_motion_ang=gu.default_dofs_motion_ang(n_dofs),
-            dofs_motion_vel=gu.default_dofs_motion_vel(n_dofs),
-            dofs_limit=gu.default_dofs_limit(n_dofs),
-            dofs_invweight=gu.default_dofs_invweight(n_dofs),
-            dofs_stiffness=gu.default_dofs_stiffness(n_dofs),
-            dofs_sol_params=gu.default_solver_params(n_dofs),
-            dofs_damping=gu.free_dofs_damping(n_dofs),
-            dofs_armature=gu.free_dofs_armature(n_dofs),
-            dofs_kp=gu.default_dofs_kp(n_dofs),
-            dofs_kv=gu.default_dofs_kv(n_dofs),
-            dofs_force_range=gu.default_dofs_force_range(n_dofs),
-            init_qpos=init_qpos,
-        )
-
         # contains one visual geom (vgeom) and one collision geom (geom)
+        g_infos = []
         if morph.visualization:
-            link._add_vgeom(
-                vmesh=vmesh,
-                init_pos=gu.zero_pos(),
-                init_quat=gu.identity_quat(),
+            g_infos.append(
+                dict(
+                    contype=0,
+                    conaffinity=0,
+                    vmesh=gs.Mesh.from_trimesh(tmesh, surface=surface),
+                )
             )
         if morph.collision:
-            link._add_geom(
-                mesh=mesh,
-                init_pos=gu.zero_pos(),
-                init_quat=gu.identity_quat(),
-                type=geom_type,
-                friction=gu.default_friction() if self.material.friction is None else self.material.friction,
-                sol_params=gu.default_solver_params(n=1)[0],
-                data=geom_data,
-                needs_coup=self.material.needs_coup,
+            g_infos.append(
+                dict(
+                    contype=1,
+                    conaffinity=1,
+                    mesh=gs.Mesh.from_trimesh(tmesh, surface=gs.surfaces.Collision()),
+                    type=geom_type,
+                    data=geom_data,
+                    sol_params=gu.default_solver_params(n=1)[0],
+                )
             )
+
+        link, (joint,) = self._add_by_info(
+            l_info=dict(
+                name=f"{link_name_prefix}_baselink",
+                pos=np.array(morph.pos),
+                quat=np.array(morph.quat),
+                inertial_pos=gu.zero_pos(),
+                inertial_quat=gu.identity_quat(),
+                parent_idx=-1,
+            ),
+            j_infos=[
+                dict(
+                    name=f"{link_name_prefix}_baselink_joint",
+                    n_qs=n_qs,
+                    n_dofs=n_dofs,
+                    type=joint_type,
+                    init_qpos=init_qpos,
+                )
+            ],
+            g_infos=g_infos,
+            morph=morph,
+            surface=surface,
+        )
 
     def _load_mesh(self, morph, surface):
         if morph.fixed:
@@ -217,114 +210,102 @@ class RigidEntity(Entity):
             n_qs = 7
             n_dofs = 6
             init_qpos = np.concatenate([morph.pos, morph.quat])
-        link_name = morph.file.split("/")[-1].replace(".", "_")
-
-        link = self._add_link(
-            name=f"{link_name}_baselink",
-            pos=np.array(morph.pos),
-            quat=np.array(morph.quat),
-            inertial_pos=None,
-            inertial_quat=gu.identity_quat(),
-            inertial_i=None,
-            inertial_mass=None,
-            parent_idx=-1,
-            invweight=None,
-        )
-        self._add_joint(
-            name=f"{link_name}_baselink_joint",
-            n_qs=n_qs,
-            n_dofs=n_dofs,
-            type=joint_type,
-            pos=gu.zero_pos(),
-            quat=gu.identity_quat(),
-            dofs_motion_ang=gu.default_dofs_motion_ang(n_dofs),
-            dofs_motion_vel=gu.default_dofs_motion_vel(n_dofs),
-            dofs_limit=gu.default_dofs_limit(n_dofs),
-            dofs_invweight=gu.default_dofs_invweight(n_dofs),
-            dofs_stiffness=gu.default_dofs_stiffness(n_dofs),
-            dofs_sol_params=gu.default_solver_params(n_dofs),
-            dofs_damping=gu.free_dofs_damping(n_dofs),
-            dofs_armature=gu.free_dofs_armature(n_dofs),
-            dofs_kp=gu.default_dofs_kp(n_dofs),
-            dofs_kv=gu.default_dofs_kv(n_dofs),
-            dofs_force_range=gu.default_dofs_force_range(n_dofs),
-            init_qpos=init_qpos,
-        )
 
         vmeshes, meshes = mu.parse_visual_and_col_mesh(morph, surface)
 
+        g_infos = []
         if morph.visualization:
             for vmesh in vmeshes:
-                link._add_vgeom(
-                    vmesh=vmesh,
-                    init_pos=gu.zero_pos(),
-                    init_quat=gu.identity_quat(),
+                g_infos.append(
+                    dict(
+                        contype=0,
+                        conaffinity=0,
+                        vmesh=vmesh,
+                    )
                 )
-
         if morph.collision:
             for mesh in meshes:
-                link._add_geom(
-                    mesh=mesh,
-                    init_pos=gu.zero_pos(),
-                    init_quat=gu.identity_quat(),
-                    type=gs.GEOM_TYPE.MESH,
-                    friction=gu.default_friction() if self.material.friction is None else self.material.friction,
-                    sol_params=gu.default_solver_params(n=1)[0],
-                    needs_coup=self.material.needs_coup,
+                g_infos.append(
+                    dict(
+                        contype=1,
+                        conaffinity=1,
+                        mesh=mesh,
+                        type=gs.GEOM_TYPE.MESH,
+                        sol_params=gu.default_solver_params(n=1)[0],
+                    )
                 )
 
-    def _load_terrain(self, morph, surface):
-        link = self._add_link(
-            name="baselink",
-            pos=np.array(morph.pos),
-            quat=np.array(morph.quat),
-            inertial_pos=None,
-            inertial_quat=gu.identity_quat(),
-            inertial_i=None,
-            inertial_mass=None,
-            parent_idx=-1,
-            invweight=None,
+        link_name = morph.file.rsplit("/", 1)[-1].replace(".", "_")
+
+        link, (joint,) = self._add_by_info(
+            l_info=dict(
+                name=f"{link_name}_baselink",
+                pos=np.array(morph.pos),
+                quat=np.array(morph.quat),
+                inertial_pos=gu.zero_pos(),
+                inertial_quat=gu.identity_quat(),
+                parent_idx=-1,
+            ),
+            j_infos=[
+                dict(
+                    name=f"{link_name}_baselink_joint",
+                    n_qs=n_qs,
+                    n_dofs=n_dofs,
+                    type=joint_type,
+                    init_qpos=init_qpos,
+                )
+            ],
+            g_infos=g_infos,
+            morph=morph,
+            surface=surface,
         )
-        self._add_joint(
-            name="joint_baselink",
-            n_qs=0,
-            n_dofs=0,
-            type=gs.JOINT_TYPE.FIXED,
-            pos=gu.zero_pos(),
-            quat=gu.identity_quat(),
-            dofs_motion_ang=gu.default_dofs_motion_ang(0),
-            dofs_motion_vel=gu.default_dofs_motion_vel(0),
-            dofs_limit=gu.default_dofs_limit(0),
-            dofs_invweight=gu.default_dofs_invweight(0),
-            dofs_stiffness=gu.default_dofs_stiffness(0),
-            dofs_sol_params=gu.default_solver_params(0),
-            dofs_damping=gu.free_dofs_damping(0),
-            dofs_armature=gu.free_dofs_armature(0),
-            dofs_kp=gu.default_dofs_kp(0),
-            dofs_kv=gu.default_dofs_kv(0),
-            dofs_force_range=gu.default_dofs_force_range(0),
-            init_qpos=np.zeros(0),
+
+    def _load_terrain(self, morph, surface):
+        link, (joint,) = self._add_by_info(
+            l_info=dict(
+                name="baselink",
+                pos=np.array(morph.pos),
+                quat=np.array(morph.quat),
+                inertial_pos=None,
+                inertial_quat=gu.identity_quat(),
+                inertial_i=None,
+                inertial_mass=None,
+                parent_idx=-1,
+                invweight=None,
+            ),
+            j_infos=[
+                dict(
+                    name="joint_baselink",
+                    n_qs=0,
+                    n_dofs=0,
+                    type=gs.JOINT_TYPE.FIXED,
+                )
+            ],
+            morph=morph,
+            surface=surface,
         )
 
         vmesh, mesh, self.terrain_hf = tu.parse_terrain(morph, surface)
         self.terrain_scale = np.array([morph.horizontal_scale, morph.vertical_scale])
 
+        g_infos = []
         if morph.visualization:
-            link._add_vgeom(
-                vmesh=vmesh,
-                init_pos=gu.zero_pos(),
-                init_quat=gu.identity_quat(),
+            g_infos.append(
+                dict(
+                    contype=0,
+                    conaffinity=0,
+                    vmesh=vmesh,
+                )
             )
-
         if morph.collision:
-            link._add_geom(
-                mesh=mesh,
-                init_pos=gu.zero_pos(),
-                init_quat=gu.identity_quat(),
-                type=gs.GEOM_TYPE.TERRAIN,
-                friction=gu.default_friction() if self.material.friction is None else self.material.friction,
-                sol_params=gu.default_solver_params(n=1)[0],
-                needs_coup=self.material.needs_coup,
+            g_infos.append(
+                dict(
+                    contype=1,
+                    conaffinity=1,
+                    mesh=mesh,
+                    type=gs.GEOM_TYPE.TERRAIN,
+                    sol_params=gu.default_solver_params(n=1)[0],
+                )
             )
 
     def _load_MJCF(self, morph, surface):
@@ -337,32 +318,36 @@ class RigidEntity(Entity):
             gs.logger.warning("(MJCF) Tendon not supported")
 
         # Parse all geometries grouped by parent joint (or world)
-        world_g_info, *links_g_info = mju.parse_geoms(mj, morph.scale, morph.convexify, surface, morph.file)
+        world_g_info, *links_g_infos = mju.parse_geoms(mj, morph.scale, morph.convexify, surface, morph.file)
 
         # Parse all bodies (links and joints)
-        (l_world_info, *l_infos), (j_world_info, *j_infos) = mju.parse_links(mj, morph.scale)
-        l_infos, j_infos, links_g_info, ordered_links_idx = uu._order_links(l_infos, j_infos, links_g_info)
+        (world_l_info, *l_infos), (world_j_info, *links_j_infos) = mju.parse_links(mj, morph.scale)
+        l_infos, links_j_infos, links_g_infos, ordered_links_idx = uu._order_links(
+            l_infos, links_j_infos, links_g_infos
+        )
 
         # Add all bodies to this entity
-        all_infos = list(zip(l_infos, j_infos, links_g_info))
+        all_infos = list(zip(l_infos, links_j_infos, links_g_infos))
         if world_g_info:
             # Only take into account the world if it features at least one geometry
-            all_infos.append((l_world_info, j_world_info, world_g_info))
-        for l_info, j_info, link_g_info in all_infos:
-            if l_info["parent_idx"] < 0 and j_info["type"] != gs.JOINT_TYPE.FIXED:  # base link
-                if morph.pos is not None:
-                    l_info["pos"] = np.array(morph.pos)
-                    gs.logger.warning("Overriding base link's pos with user provided value in morph.")
-                if morph.quat is not None:
-                    l_info["quat"] = np.array(morph.quat)
-                    gs.logger.warning("Overriding base link's quat with user provided value in morph.")
+            all_infos.append((world_l_info, world_j_info, world_g_info))
+        for l_info, link_j_infos, link_g_infos in all_infos:
+            if l_info["parent_idx"] < 0:
+                for j_info in link_j_infos:
+                    if j_info["type"] != gs.JOINT_TYPE.FIXED:  # base link
+                        if morph.pos is not None:
+                            l_info["pos"] = np.array(morph.pos)
+                            gs.logger.warning("Overriding base link's pos with user provided value in morph.")
+                        if morph.quat is not None:
+                            l_info["quat"] = np.array(morph.quat)
+                            gs.logger.warning("Overriding base link's quat with user provided value in morph.")
 
-                if j_info["type"] == gs.JOINT_TYPE.FREE:
-                    # in this case, l_info['pos'] and l_info['quat'] are actually not used in solver, but this initial
-                    # value will be reflected
-                    j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
+                    if j_info["type"] == gs.JOINT_TYPE.FREE:
+                        # in this case, l_info['pos'] and l_info['quat'] are actually not used in solver,
+                        # but this initial value will be reflected
+                        j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
 
-            self._add_by_info(l_info, j_info, link_g_info, morph, surface)
+            self._add_by_info(l_info, link_j_infos, link_g_infos, morph, surface)
 
         for i_e in range(mj.neq):
             e_info = mju.parse_equality(mj, i_e, morph.scale, ordered_links_idx)
@@ -396,66 +381,10 @@ class RigidEntity(Entity):
                     # in this case, l_info['pos'] and l_info['quat'] are actually not used in solver, but this initial value will be reflected in init_qpos
                     j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
 
-            self._add_by_info(l_info, j_info, l_info["g_infos"], morph, surface)
-
-    def _add_by_info(self, l_info, j_info, g_infos, morph, surface):
-        link = self._add_link(
-            name=l_info["name"],
-            pos=l_info["pos"],
-            quat=l_info["quat"],
-            inertial_pos=l_info["inertial_pos"] if not morph.recompute_inertia else None,
-            inertial_quat=l_info["inertial_quat"],
-            inertial_i=l_info["inertial_i"] if not morph.recompute_inertia else None,
-            inertial_mass=l_info["inertial_mass"] if not morph.recompute_inertia else None,
-            parent_idx=l_info["parent_idx"] + self._link_start if l_info["parent_idx"] >= 0 else l_info["parent_idx"],
-            invweight=l_info["invweight"],
-        )
-        self._add_joint(
-            name=j_info["name"],
-            n_qs=j_info["n_qs"],
-            n_dofs=j_info["n_dofs"],
-            type=j_info["type"],
-            pos=j_info["pos"],
-            quat=j_info["quat"],
-            dofs_motion_ang=j_info["dofs_motion_ang"],
-            dofs_motion_vel=j_info["dofs_motion_vel"],
-            dofs_limit=j_info["dofs_limit"],
-            dofs_invweight=j_info["dofs_invweight"],
-            dofs_stiffness=j_info["dofs_stiffness"],
-            dofs_sol_params=j_info["dofs_sol_params"],
-            dofs_damping=j_info["dofs_damping"],
-            dofs_armature=j_info["dofs_armature"],
-            dofs_kp=j_info["dofs_kp"],
-            dofs_kv=j_info["dofs_kv"],
-            dofs_force_range=j_info["dofs_force_range"],
-            init_qpos=j_info["init_qpos"],
-        )
-
-        # geoms
-        for g_info in g_infos:
-            is_col = bool(g_info["contype"] or g_info["conaffinity"])
-            if is_col and morph.collision:
-                link._add_geom(
-                    mesh=g_info["mesh"],
-                    init_pos=g_info["pos"],
-                    init_quat=g_info["quat"],
-                    type=g_info["type"],
-                    friction=g_info["friction"] if self.material.friction is None else self.material.friction,
-                    sol_params=g_info["sol_params"],
-                    data=g_info["data"],
-                    needs_coup=self.material.needs_coup,
-                    contype=g_info["contype"],
-                    conaffinity=g_info["conaffinity"],
-                )
-            if not is_col and morph.visualization:
-                link._add_vgeom(
-                    vmesh=g_info["mesh"],
-                    init_pos=g_info["pos"],
-                    init_quat=g_info["quat"],
-                )
+            self._add_by_info(l_info, (j_info,), l_info["g_infos"], morph, surface)
 
     def _build(self):
-        assert self.n_links == self.n_joints
+        assert self.n_links == len(self.joints)
         for link in self._links:
             link._build()
 
@@ -480,7 +409,7 @@ class RigidEntity(Entity):
         # compute joint limit in q space
         q_limit_lower = []
         q_limit_upper = []
-        for joint in self._joints:
+        for joint in chain.from_iterable(self._joints):
             if joint.type == gs.JOINT_TYPE.FREE:
                 q_limit_lower.append(joint.dofs_limit[:3, 0])
                 q_limit_lower.append(-np.ones(4))  # quaternion lower bound
@@ -524,22 +453,25 @@ class RigidEntity(Entity):
             dtype=gs.ti_float, shape=self._solver._batch_shape((self.n_dofs, self._IK_error_dim))
         )
 
-    def _add_link(
-        self,
-        name,
-        pos,
-        quat,
-        inertial_pos,
-        inertial_quat,
-        inertial_i,
-        inertial_mass,
-        parent_idx,
-        invweight,
-    ):
+    def _add_by_info(self, l_info, j_infos, g_infos, morph, surface):
+        if len(j_infos) > 1 and any(j_info["type"] in (gs.JOINT_TYPE.FREE, gs.JOINT_TYPE.FIXED) for j_info in j_infos):
+            raise ValueError(
+                "Compounding joints of types 'FREE' or 'FIXED' with any other joint on the same body not supported"
+            )
+
+        if isinstance(morph, gs.options.morphs.FileMorph) and morph.recompute_inertia:
+            l_info.update(inertial_pos=None, inertial_quat=None, inertial_i=None, inertial_mass=None)
+
+        parent_idx = l_info["parent_idx"]
+        if parent_idx >= 0:
+            parent_idx += self._link_start
+
         link = RigidLink(
             entity=self,
-            name=name,
+            name=l_info["name"],
             idx=self.n_links + self._link_start,
+            joint_start=self.n_joints + self._joint_start,
+            n_joints=len(j_infos),
             geom_start=self.n_geoms + self._geom_start,
             cell_start=self.n_cells + self._cell_start,
             vert_start=self.n_verts + self._vert_start,
@@ -549,74 +481,97 @@ class RigidEntity(Entity):
             vgeom_start=self.n_vgeoms + self._vgeom_start,
             vvert_start=self.n_vverts + self._vvert_start,
             vface_start=self.n_vfaces + self._vface_start,
-            pos=pos,
-            quat=quat,
-            inertial_pos=inertial_pos,
-            inertial_quat=inertial_quat,
-            inertial_i=inertial_i,
-            inertial_mass=inertial_mass,
+            pos=l_info["pos"],
+            quat=l_info["quat"],
+            inertial_pos=l_info.get("inertial_pos"),
+            inertial_quat=l_info.get("inertial_quat"),
+            inertial_i=l_info.get("inertial_i"),
+            inertial_mass=l_info.get("inertial_mass"),
             parent_idx=parent_idx,
-            invweight=invweight,
+            invweight=l_info.get("invweight"),
             visualize_contact=self.visualize_contact,
         )
         self._links.append(link)
-        return link
 
-    def _add_joint(
-        self,
-        name,
-        n_qs,
-        n_dofs,
-        type,
-        pos,
-        quat,
-        dofs_motion_ang,
-        dofs_motion_vel,
-        dofs_limit,
-        dofs_invweight,
-        dofs_stiffness,
-        dofs_sol_params,
-        dofs_damping,
-        dofs_armature,
-        dofs_kp,
-        dofs_kv,
-        dofs_force_range,
-        init_qpos,
-    ):
-        if (
-            len(np.array(dofs_sol_params).shape) == 2
-            and np.array(dofs_sol_params).shape[0] == 1
-            and (dofs_sol_params[0][3] >= 1.0 or dofs_sol_params[0][2] >= dofs_sol_params[0][3])
-        ):
-            gs.logger.warning(f"Joint {name}'s sol_params {dofs_sol_params[0]} look not right, change to default.")
-            dofs_sol_params = gu.default_solver_params(1)
+        joints = gs.List()
+        self._joints.append(joints)
+        for j_info in j_infos:
+            n_dofs = j_info["n_dofs"]
 
-        joint = RigidJoint(
-            entity=self,
-            name=name,
-            idx=self.n_joints + self._joint_start,
-            q_start=self.n_qs + self._q_start,
-            dof_start=self.n_dofs + self._dof_start,
-            n_qs=n_qs,
-            n_dofs=n_dofs,
-            type=type,
-            pos=pos,
-            quat=quat,
-            dofs_motion_ang=dofs_motion_ang,
-            dofs_motion_vel=dofs_motion_vel,
-            dofs_limit=dofs_limit,
-            dofs_invweight=dofs_invweight,
-            dofs_stiffness=dofs_stiffness,
-            dofs_sol_params=dofs_sol_params,
-            dofs_damping=dofs_damping,
-            dofs_armature=dofs_armature,
-            dofs_kp=dofs_kp,
-            dofs_kv=dofs_kv,
-            dofs_force_range=dofs_force_range,
-            init_qpos=init_qpos,
-        )
-        self._joints.append(joint)
-        return joint
+            sol_params = np.array(j_info.get("sol_params", gu.default_solver_params(1)), copy=True)
+            dofs_sol_params = np.array(j_info.get("dofs_sol_params", gu.default_solver_params(n_dofs)), copy=True)
+            for _sol_params in (sol_params, dofs_sol_params):
+                if (
+                    len(_sol_params.shape) == 2
+                    and _sol_params.shape[0] == 1
+                    and (_sol_params[0][3] >= 1.0 or _sol_params[0][2] >= _sol_params[0][3])
+                ):
+                    gs.logger.warning(f"Joint {name}'s sol_params {_sol_params[0]} look not right, change to default.")
+                    _sol_params[:] = gu.default_solver_params(len(_sol_params))
+
+            dofs_motion_ang = j_info.get("dofs_motion_ang")
+            if dofs_motion_ang is None:
+                dofs_motion_ang = gu.default_dofs_motion_ang(n_dofs)
+            dofs_motion_vel = j_info.get("dofs_motion_vel")
+            if dofs_motion_vel is None:
+                dofs_motion_vel = gu.default_dofs_motion_vel(n_dofs)
+
+            joint = RigidJoint(
+                entity=self,
+                name=j_info["name"],
+                idx=self.n_joints + self._joint_start,
+                q_start=self.n_qs + self._q_start,
+                dof_start=self.n_dofs + self._dof_start,
+                n_qs=j_info["n_qs"],
+                n_dofs=n_dofs,
+                type=j_info["type"],
+                pos=j_info.get("pos", gu.zero_pos()),
+                quat=j_info.get("quat", gu.identity_quat()),
+                init_qpos=j_info.get("init_qpos", np.zeros(n_dofs)),
+                sol_params=sol_params,
+                dofs_motion_ang=dofs_motion_ang,
+                dofs_motion_vel=dofs_motion_vel,
+                dofs_limit=j_info.get("dofs_limit", gu.default_dofs_limit(n_dofs)),
+                dofs_invweight=j_info.get("dofs_invweight", gu.default_dofs_invweight(n_dofs)),
+                dofs_stiffness=j_info.get("dofs_stiffness", gu.default_dofs_stiffness(n_dofs)),
+                dofs_sol_params=dofs_sol_params,
+                dofs_damping=j_info.get("dofs_damping", gu.free_dofs_damping(n_dofs)),
+                dofs_armature=j_info.get("dofs_armature", gu.free_dofs_armature(n_dofs)),
+                dofs_kp=j_info.get("dofs_kp", gu.default_dofs_kp(n_dofs)),
+                dofs_kv=j_info.get("dofs_kv", gu.default_dofs_kv(n_dofs)),
+                dofs_force_range=j_info.get("dofs_force_range", gu.default_dofs_force_range(n_dofs)),
+            )
+            joints.append(joint)
+
+        # geoms
+        for g_info in g_infos:
+            is_col = g_info["contype"] or g_info["conaffinity"]
+            friction = g_info.get("friction", self.material.friction)
+            if friction is None:
+                friction = gu.default_friction()
+            g_info.setdefault("pos", gu.zero_pos())
+            g_info.setdefault("quat", gu.identity_quat())
+            if morph.collision and is_col:
+                link._add_geom(
+                    mesh=g_info["mesh"],
+                    init_pos=g_info["pos"],
+                    init_quat=g_info["quat"],
+                    type=g_info["type"],
+                    friction=friction,
+                    sol_params=g_info["sol_params"],
+                    data=g_info.get("data"),
+                    needs_coup=self.material.needs_coup,
+                    contype=g_info["contype"],
+                    conaffinity=g_info["conaffinity"],
+                )
+            if morph.visualization and not is_col:
+                link._add_vgeom(
+                    vmesh=g_info["vmesh"],
+                    init_pos=g_info["pos"],
+                    init_quat=g_info["quat"],
+                )
+
+        return link, joints
 
     def _add_equality(
         self, name, type, link1_idx, link2_idx, anchor1_pos, anchor2_pos, rel_pose, torque_scale, sol_params
@@ -695,47 +650,19 @@ class RigidEntity(Entity):
             l_info = self._solver.links_info[I_l]
             l_state = self._solver.links_state[i_l, i_b]
 
-            if l_info.joint_type == gs.JOINT_TYPE.FIXED:
-                pass
+            dof_offset = 0
+            for i_j in range(l_info.joint_start, l_info.joint_end):
+                I_j = [i_j, i_b] if ti.static(self._options.batch_joints_info) else i_j
+                j_info = self.joints_info[I_j]
 
-            elif l_info.joint_type == gs.JOINT_TYPE.REVOLUTE:
-                i_d = l_info.dof_start
-                I_d = [i_d, i_b] if ti.static(self.solver._options.batch_dofs_info) else i_d
-                i_d_jac = i_d - self._dof_start
-                rotation = gu.ti_transform_by_quat(self._solver.dofs_info[I_d].motion_ang, l_state.quat)
-                translation = rotation.cross(tgt_link_pos - l_state.pos)
+                if j_info.type == gs.JOINT_TYPE.FIXED:
+                    pass
 
-                self._jacobian[0, i_d_jac, i_b] = translation[0] * pos_mask[0]
-                self._jacobian[1, i_d_jac, i_b] = translation[1] * pos_mask[1]
-                self._jacobian[2, i_d_jac, i_b] = translation[2] * pos_mask[2]
-                self._jacobian[3, i_d_jac, i_b] = rotation[0] * rot_mask[0]
-                self._jacobian[4, i_d_jac, i_b] = rotation[1] * rot_mask[1]
-                self._jacobian[5, i_d_jac, i_b] = rotation[2] * rot_mask[2]
-
-            elif l_info.joint_type == gs.JOINT_TYPE.PRISMATIC:
-                i_d = l_info.dof_start
-                I_d = [i_d, i_b] if ti.static(self.solver._options.batch_dofs_info) else i_d
-                i_d_jac = i_d - self._dof_start
-                translation = gu.ti_transform_by_quat(self._solver.dofs_info[I_d].motion_vel, l_state.quat)
-
-                self._jacobian[0, i_d_jac, i_b] = translation[0] * pos_mask[0]
-                self._jacobian[1, i_d_jac, i_b] = translation[1] * pos_mask[1]
-                self._jacobian[2, i_d_jac, i_b] = translation[2] * pos_mask[2]
-
-            elif l_info.joint_type == gs.JOINT_TYPE.FREE:
-                # translation
-                for i_d_ in range(3):
-                    i_d = l_info.dof_start + i_d_
-                    i_d_jac = i_d - self._dof_start
-
-                    self._jacobian[i_d_, i_d_jac, i_b] = 1.0 * pos_mask[i_d_]
-
-                # rotation
-                for i_d_ in range(3):
-                    i_d = l_info.dof_start + i_d_ + 3
-                    i_d_jac = i_d - self._dof_start
+                elif j_info.type == gs.JOINT_TYPE.REVOLUTE:
+                    i_d = j_info.dof_start
                     I_d = [i_d, i_b] if ti.static(self.solver._options.batch_dofs_info) else i_d
-                    rotation = self._solver.dofs_info[I_d].motion_ang
+                    i_d_jac = i_d + dof_offset - self._dof_start
+                    rotation = gu.ti_transform_by_quat(self._solver.dofs_info[I_d].motion_ang, l_state.quat)
                     translation = rotation.cross(tgt_link_pos - l_state.pos)
 
                     self._jacobian[0, i_d_jac, i_b] = translation[0] * pos_mask[0]
@@ -744,6 +671,41 @@ class RigidEntity(Entity):
                     self._jacobian[3, i_d_jac, i_b] = rotation[0] * rot_mask[0]
                     self._jacobian[4, i_d_jac, i_b] = rotation[1] * rot_mask[1]
                     self._jacobian[5, i_d_jac, i_b] = rotation[2] * rot_mask[2]
+
+                elif j_info.type == gs.JOINT_TYPE.PRISMATIC:
+                    i_d = j_info.dof_start
+                    I_d = [i_d, i_b] if ti.static(self.solver._options.batch_dofs_info) else i_d
+                    i_d_jac = i_d + dof_offset - self._dof_start
+                    translation = gu.ti_transform_by_quat(self._solver.dofs_info[I_d].motion_vel, l_state.quat)
+
+                    self._jacobian[0, i_d_jac, i_b] = translation[0] * pos_mask[0]
+                    self._jacobian[1, i_d_jac, i_b] = translation[1] * pos_mask[1]
+                    self._jacobian[2, i_d_jac, i_b] = translation[2] * pos_mask[2]
+
+                elif j_info.type == gs.JOINT_TYPE.FREE:
+                    # translation
+                    for i_d_ in ti.static(range(3)):
+                        i_d = j_info.dof_start + i_d_
+                        i_d_jac = i_d + dof_offset - self._dof_start
+
+                        self._jacobian[i_d_, i_d_jac, i_b] = 1.0 * pos_mask[i_d_]
+
+                    # rotation
+                    for i_d_ in ti.static(range(3)):
+                        i_d = j_info.dof_start + i_d_ + 3
+                        i_d_jac = i_d + dof_offset - self._dof_start
+                        I_d = [i_d, i_b] if ti.static(self.solver._options.batch_dofs_info) else i_d
+                        rotation = self._solver.dofs_info[I_d].motion_ang
+                        translation = rotation.cross(tgt_link_pos - l_state.pos)
+
+                        self._jacobian[0, i_d_jac, i_b] = translation[0] * pos_mask[0]
+                        self._jacobian[1, i_d_jac, i_b] = translation[1] * pos_mask[1]
+                        self._jacobian[2, i_d_jac, i_b] = translation[2] * pos_mask[2]
+                        self._jacobian[3, i_d_jac, i_b] = rotation[0] * rot_mask[0]
+                        self._jacobian[4, i_d_jac, i_b] = rotation[1] * rot_mask[1]
+                        self._jacobian[5, i_d_jac, i_b] = rotation[2] * rot_mask[2]
+
+                dof_offset = dof_offset + j_info.n_dofs
 
             i_l = l_info.parent_idx
 
@@ -1273,27 +1235,29 @@ class RigidEntity(Entity):
                             i_l = links_idx_by_dofs[_i_l]
                             I_l = [i_l, i_b] if ti.static(self.solver._options.batch_links_info) else i_l
                             l_info = self._solver.links_info[I_l]
-                            I_dof_start = (
-                                [l_info.dof_start, i_b]
-                                if ti.static(self.solver._options.batch_dofs_info)
-                                else l_info.dof_start
-                            )
-                            dof_info = self._solver.dofs_info[I_dof_start]
-                            q_start = l_info.q_start
 
-                            if l_info.joint_type == gs.JOINT_TYPE.FREE:
-                                pass
+                            for i_j in range(l_info.joint_start, l_info.joint_end):
+                                I_j = [i_j, i_b] if ti.static(self._options.batch_joints_info) else i_j
+                                j_info = self.joints_info[I_j]
 
-                            elif (
-                                l_info.joint_type == gs.JOINT_TYPE.REVOLUTE
-                                or l_info.joint_type == gs.JOINT_TYPE.PRISMATIC
-                            ):
-                                if ti.math.isinf(dof_info.limit[0]) or ti.math.isinf(dof_info.limit[1]):
+                                I_dof_start = (
+                                    [j_info.dof_start, i_b]
+                                    if ti.static(self.solver._options.batch_dofs_info)
+                                    else j_info.dof_start
+                                )
+                                dof_info = self._solver.dofs_info[I_dof_start]
+                                q_start = j_info.q_start
+
+                                if j_info.type == gs.JOINT_TYPE.FREE:
                                     pass
-                                else:
-                                    self._solver.qpos[q_start, i_b] = dof_info.limit[0] + ti.random() * (
-                                        dof_info.limit[1] - dof_info.limit[0]
-                                    )
+
+                                elif j_info.type == gs.JOINT_TYPE.REVOLUTE or j_info.type == gs.JOINT_TYPE.PRISMATIC:
+                                    if ti.math.isinf(dof_info.limit[0]) or ti.math.isinf(dof_info.limit[1]):
+                                        pass
+                                    else:
+                                        self._solver.qpos[q_start, i_b] = dof_info.limit[0] + ti.random() * (
+                                            dof_info.limit[1] - dof_info.limit[0]
+                                        )
                     else:
                         pass  # When respect_joint_limit=False, we can simply continue from the last solution
 
@@ -1585,13 +1549,13 @@ class RigidEntity(Entity):
         """
 
         if name is not None:
-            for joint in self._joints:
+            for joint in chain.from_iterable(self._joints):
                 if joint.name == name:
                     return joint
             gs.raise_exception(f"Joint not found for name: {name}.")
 
         elif uid is not None:
-            for joint in self._joints:
+            for joint in chain.from_iterable(self._joints):
                 if uid in str(joint.uid):
                     return joint
             gs.raise_exception(f"Joint not found for uid: {uid}.")
@@ -2619,15 +2583,14 @@ class RigidEntity(Entity):
     @property
     def init_qpos(self):
         """The initial qpos of the entity."""
-        return np.concatenate([joint.init_qpos for joint in self._joints])
+        return np.concatenate([joint.init_qpos for joint in chain.from_iterable(self._joints)])
 
     @property
     def n_qs(self):
         """The number of `q` (generalized coordinates) of the entity."""
         if self._is_built:
             return self._n_qs
-        else:
-            return sum([joint.n_qs for joint in self._joints])
+        return sum(joint.n_qs for joint in chain.from_iterable(self._joints))
 
     @property
     def n_links(self):
@@ -2637,45 +2600,44 @@ class RigidEntity(Entity):
     @property
     def n_joints(self):
         """The number of `RigidJoint` in the entity."""
-        return len(self._joints)
+        return sum(map(len, self._joints))
 
     @property
     def n_dofs(self):
         """The number of degrees of freedom (DOFs) of the entity."""
         if self._is_built:
             return self._n_dofs
-        else:
-            return sum([joint.n_dofs for joint in self._joints])
+        return sum(joint.n_dofs for joint in chain.from_iterable(self._joints))
 
     @property
     def n_geoms(self):
         """The number of `RigidGeom` in the entity."""
-        return sum([link.n_geoms for link in self._links])
+        return sum(link.n_geoms for link in self._links)
 
     @property
     def n_cells(self):
         """The number of sdf cells in the entity."""
-        return sum([link.n_cells for link in self._links])
+        return sum(link.n_cells for link in self._links)
 
     @property
     def n_verts(self):
         """The number of vertices (from collision geom `RigidGeom`) in the entity."""
-        return sum([link.n_verts for link in self._links])
+        return sum(link.n_verts for link in self._links)
 
     @property
     def n_faces(self):
         """The number of faces (from collision geom `RigidGeom`) in the entity."""
-        return sum([link.n_faces for link in self._links])
+        return sum(link.n_faces for link in self._links)
 
     @property
     def n_edges(self):
         """The number of edges (from collision geom `RigidGeom`) in the entity."""
-        return sum([link.n_edges for link in self._links])
+        return sum(link.n_edges for link in self._links)
 
     @property
     def n_vgeoms(self):
         """The number of vgeoms (visual geoms - `RigidVisGeom`) in the entity."""
-        return sum([link.n_vgeoms for link in self._links])
+        return sum(link.n_vgeoms for link in self._links)
 
     @property
     def n_vverts(self):
@@ -2713,6 +2675,11 @@ class RigidEntity(Entity):
         return self._link_start
 
     @property
+    def gravity_compensation(self):
+        """Apply a force to compensate gravity. A value of 1 will make a zero-gravity behavior. Default to 0"""
+        return self.material.gravity_compensation
+
+    @property
     def link_start(self):
         """The index of the entity's first RigidLink in the scene."""
         return self._link_start
@@ -2723,14 +2690,19 @@ class RigidEntity(Entity):
         return self._link_start + self.n_links
 
     @property
+    def joint_start(self):
+        """The index of the entity's first RigidJoint in the scene."""
+        return self._joint_start
+
+    @property
+    def joint_end(self):
+        """The index of the entity's last RigidJoint in the scene *plus one*."""
+        return self._joint_start + self.n_joints
+
+    @property
     def dof_start(self):
         """The index of the entity's first degree of freedom (DOF) in the scene."""
         return self._dof_start
-
-    @property
-    def gravity_compensation(self):
-        """Apply a force to compensate gravity. A value of 1 will make a zero-gravity behavior. Default to 0"""
-        return self.material.gravity_compensation
 
     @property
     def dof_end(self):
@@ -2812,7 +2784,7 @@ class RigidEntity(Entity):
     @property
     def base_joint(self):
         """The base joint of the entity"""
-        return self._joints[0]
+        return self._joints[0][0]
 
     @property
     def n_equalities(self):

--- a/genesis/engine/entities/rigid_entity/rigid_joint.py
+++ b/genesis/engine/entities/rigid_entity/rigid_joint.py
@@ -24,6 +24,8 @@ class RigidJoint(RBC):
         type,
         pos,
         quat,
+        init_qpos,
+        sol_params,
         dofs_motion_ang,
         dofs_motion_vel,
         dofs_limit,
@@ -35,7 +37,6 @@ class RigidJoint(RBC):
         dofs_kp,
         dofs_kv,
         dofs_force_range,
-        init_qpos,
     ):
         self._name = name
         self._entity = entity
@@ -51,6 +52,7 @@ class RigidJoint(RBC):
         self._pos = pos
         self._quat = quat
         self._init_qpos = init_qpos
+        self._sol_params = sol_params
 
         self._dofs_motion_ang = dofs_motion_ang
         self._dofs_motion_vel = dofs_motion_vel
@@ -95,16 +97,19 @@ class RigidJoint(RBC):
 
             p_pos = ti.Vector.zero(gs.ti_float, 3)
             p_quat = gu.ti_identity_quat()
-
             if i_p != -1:
                 p_pos = self._solver.links_state[i_p, i_b].pos
                 p_quat = self._solver.links_state[i_p, i_b].quat
 
             tmp_pos, tmp_quat = gu.ti_transform_pos_quat_by_trans_quat(l_info.pos, l_info.quat, p_pos, p_quat)
 
-            joint_pos, joint_quat = gu.ti_transform_pos_quat_by_trans_quat(
-                l_info.joint_pos, l_info.joint_quat, tmp_pos, tmp_quat
-            )
+            for i_j in range(l_info.joint_start, l_info.joint_start + self._idx + 1):
+                I_j = [i_j, i_b] if ti.static(self._solver._options.batch_joints_info) else i_j
+                j_info = self._solver.joints_info[I_j]
+
+                joint_pos, joint_quat = gu.ti_transform_pos_quat_by_trans_quat(
+                    j_info.pos, gu.ti_identity_quat(), tmp_pos, tmp_quat
+                )
 
             for i in ti.static(range(3)):
                 tensor[i_b, i] = joint_pos[i]
@@ -137,9 +142,13 @@ class RigidJoint(RBC):
 
             tmp_pos, tmp_quat = gu.ti_transform_pos_quat_by_trans_quat(l_info.pos, l_info.quat, p_pos, p_quat)
 
-            joint_pos, joint_quat = gu.ti_transform_pos_quat_by_trans_quat(
-                l_info.joint_pos, l_info.joint_quat, tmp_pos, tmp_quat
-            )
+            for i_j in range(l_info.joint_start, l_info.joint_start + self._idx + 1):
+                I_j = [i_j, i_b] if ti.static(self._solver._options.batch_joints_info) else i_j
+                j_info = self._solver.joints_info[I_j]
+
+                joint_pos, joint_quat = gu.ti_transform_pos_quat_by_trans_quat(
+                    j_info.pos, gu.ti_identity_quat(), tmp_pos, tmp_quat
+                )
 
             for i in ti.static(range(4)):
                 tensor[i_b, i] = joint_quat[i]
@@ -238,6 +247,13 @@ class RigidJoint(RBC):
         Returns the initial quaternion of the joint in the world frame.
         """
         return self._quat
+
+    @property
+    def sol_params(self):
+        """
+        Retruns the solver parameters of the joint.
+        """
+        return self._sol_params
 
     @property
     def q_start(self):

--- a/genesis/engine/solvers/rigid/constraint_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/constraint_solver_decomp.py
@@ -296,41 +296,45 @@ class ConstraintSolver:
             for i_l in range(self._solver.n_links):
                 I_l = [i_l, i_b] if ti.static(self._solver._options.batch_links_info) else i_l
                 l_info = self._solver.links_info[I_l]
-                if l_info.joint_type == gs.JOINT_TYPE.REVOLUTE or l_info.joint_type == gs.JOINT_TYPE.PRISMATIC:
-                    i_q = l_info.q_start
-                    i_d = l_info.dof_start
-                    I_d = [i_d, i_b] if ti.static(self._solver._options.batch_dofs_info) else i_d
-                    pos_min = self._solver.qpos[i_q, i_b] - self._solver.dofs_info[I_d].limit[0]
-                    pos_max = self._solver.dofs_info[I_d].limit[1] - self._solver.qpos[i_q, i_b]
-                    pos = min(min(pos_min, pos_max), 0)
 
-                    side = ((pos_min < pos_max) * 2 - 1) * (pos < 0)
+                for i_j in range(l_info.joint_start, l_info.joint_end):
+                    I_j = [i_j, i_b] if ti.static(self._solver._options.batch_joints_info) else i_j
+                    j_info = self._solver.joints_info[I_j]
 
-                    jac = side
-                    jac_qvel = jac * self._solver.dofs_state[i_d, i_b].vel
-                    imp, aref = gu.imp_aref(self._solver.dofs_info[I_d].sol_params, pos, jac_qvel, pos)
-                    diag = self._solver.dofs_info[I_d].invweight * (pos < 0) * (1 - imp) / (imp + gs.EPS)
-                    aref = aref * (pos < 0)
-                    if pos < 0:
-                        n_con = self.n_constraints[i_b]
-                        self.n_constraints[i_b] = n_con + 1
-                        self.diag[n_con, i_b] = diag
-                        self.aref[n_con, i_b] = aref
+                    if j_info.type == gs.JOINT_TYPE.REVOLUTE or j_info.type == gs.JOINT_TYPE.PRISMATIC:
+                        i_q = j_info.q_start
+                        i_d = j_info.dof_start
+                        I_d = [i_d, i_b] if ti.static(self._solver._options.batch_dofs_info) else i_d
+                        pos_delta_min = self._solver.qpos[i_q, i_b] - self._solver.dofs_info[I_d].limit[0]
+                        pos_delta_max = self._solver.dofs_info[I_d].limit[1] - self._solver.qpos[i_q, i_b]
+                        pos_delta = min(pos_delta_min, pos_delta_max)
 
-                        if ti.static(self.sparse_solve):
-                            for i_d2_ in range(self.jac_n_relevant_dofs[n_con, i_b]):
-                                i_d2 = self.jac_relevant_dofs[n_con, i_d2_, i_b]
-                                self.jac[n_con, i_d2, i_b] = gs.ti_float(0.0)
-                        else:
-                            for i_d2 in range(self._solver.n_dofs):
-                                self.jac[n_con, i_d2, i_b] = gs.ti_float(0.0)
-                        self.jac[n_con, i_d, i_b] = jac
+                        if pos_delta < 0:
+                            jac = (pos_delta_min < pos_delta_max) * 2 - 1
+                            jac_qvel = jac * self._solver.dofs_state[i_d, i_b].vel
+                            imp, aref = gu.imp_aref(j_info.sol_params, pos_delta, jac_qvel, pos_delta)
+                            diag = self._solver.dofs_info[I_d].invweight * (1 - imp) / (imp + gs.EPS)
+                            aref = aref
 
-                        if ti.static(self.sparse_solve):
-                            self.jac_n_relevant_dofs[n_con, i_b] = 1
-                            self.jac_relevant_dofs[n_con, 0, i_b] = i_d
+                            n_con = self.n_constraints[i_b]
+                            self.n_constraints[i_b] = n_con + 1
+                            self.diag[n_con, i_b] = diag
+                            self.aref[n_con, i_b] = aref
 
-                        self.efc_D[n_con, i_b] = 1 / ti.max(gs.EPS, diag)
+                            if ti.static(self.sparse_solve):
+                                for i_d2_ in range(self.jac_n_relevant_dofs[n_con, i_b]):
+                                    i_d2 = self.jac_relevant_dofs[n_con, i_d2_, i_b]
+                                    self.jac[n_con, i_d2, i_b] = gs.ti_float(0.0)
+                            else:
+                                for i_d2 in range(self._solver.n_dofs):
+                                    self.jac[n_con, i_d2, i_b] = gs.ti_float(0.0)
+                            self.jac[n_con, i_d, i_b] = jac
+
+                            if ti.static(self.sparse_solve):
+                                self.jac_n_relevant_dofs[n_con, i_b] = 1
+                                self.jac_relevant_dofs[n_con, 0, i_b] = i_d
+
+                            self.efc_D[n_con, i_b] = 1 / ti.max(gs.EPS, diag)
 
     @ti.func
     def _func_nt_hessian_incremental(self, i_b):

--- a/genesis/engine/solvers/rigid/constraint_solver_decomp_island.py
+++ b/genesis/engine/solvers/rigid/constraint_solver_decomp_island.py
@@ -231,44 +231,48 @@ class ConstraintSolverIsland:
             for i_l in range(e_info.link_start, e_info.link_end):
                 I_l = [i_l, i_b] if ti.static(self._solver._options.batch_links_info) else i_l
                 l_info = self._solver.links_info[I_l]
-                if l_info.joint_type == gs.JOINT_TYPE.REVOLUTE or l_info.joint_type == gs.JOINT_TYPE.PRISMATIC:
 
-                    i_q = l_info.q_start
-                    i_d = l_info.dof_start
-                    I_d = [i_d, i_b] if ti.static(self._solver._options.batch_dofs_info) else i_d
-                    pos_min = self._solver.qpos[i_q, i_b] - self._solver.dofs_info[I_d].limit[0]
-                    pos_max = self._solver.dofs_info[I_d].limit[1] - self._solver.qpos[i_q, i_b]
-                    pos = min(min(pos_min, pos_max), 0)
+                for i_j in range(l_info.joint_start, l_info.joint_end):
+                    I_j = [i_j, i_b] if ti.static(self._solver._options.batch_joints_info) else i_j
+                    j_info = self._solver.joints_info[I_j]
 
-                    side = ((pos_min < pos_max) * 2 - 1) * (pos < 0)
+                    if j_info.type == gs.JOINT_TYPE.REVOLUTE or j_info.type == gs.JOINT_TYPE.PRISMATIC:
+                        i_q = j_info.q_start
+                        i_d = j_info.dof_start
+                        I_d = [i_d, i_b] if ti.static(self._solver._options.batch_dofs_info) else i_d
+                        pos_min = self._solver.qpos[i_q, i_b] - self._solver.dofs_info[I_d].limit[0]
+                        pos_max = self._solver.dofs_info[I_d].limit[1] - self._solver.qpos[i_q, i_b]
+                        pos = min(min(pos_min, pos_max), 0)
 
-                    jac = side
-                    jac_qvel = jac * self._solver.dofs_state[i_d, i_b].vel
-                    imp, aref = gu.imp_aref(self._solver.dofs_info[I_d].sol_params, pos, jac_qvel, pos)
-                    diag = self._solver.dofs_info[I_d].invweight * (pos < 0) * (1 - imp) / (imp + gs.EPS)
-                    aref = aref * (pos < 0)
-                    if pos < 0:
-                        n_con = self.n_constraints[i_b]
-                        self.n_constraints[i_b] = n_con + 1
-                        self.diag[n_con, i_b] = diag
-                        self.aref[n_con, i_b] = aref
+                        side = ((pos_min < pos_max) * 2 - 1) * (pos < 0)
 
-                        # TODO?
-                        if ti.static(self.sparse_solve):
-                            for i_d2_ in range(self.jac_n_relevant_dofs[n_con, i_b]):
-                                i_d2 = self.jac_relevant_dofs[n_con, i_d2_, i_b]
-                                self.jac[n_con, i_d2, i_b] = gs.ti_float(0.0)
-                            pass
-                        else:
-                            for i_d2 in range(self._solver.n_dofs):
-                                self.jac[n_con, i_d2, i_b] = gs.ti_float(0.0)
-                        self.jac[n_con, i_d, i_b] = jac
+                        jac = side
+                        jac_qvel = jac * self._solver.dofs_state[i_d, i_b].vel
+                        imp, aref = gu.imp_aref(self._solver.dofs_info[I_d].sol_params, pos, jac_qvel, pos)
+                        diag = self._solver.dofs_info[I_d].invweight * (pos < 0) * (1 - imp) / (imp + gs.EPS)
+                        aref = aref * (pos < 0)
+                        if pos < 0:
+                            n_con = self.n_constraints[i_b]
+                            self.n_constraints[i_b] = n_con + 1
+                            self.diag[n_con, i_b] = diag
+                            self.aref[n_con, i_b] = aref
 
-                        if ti.static(self.sparse_solve):
-                            self.jac_n_relevant_dofs[n_con, i_b] = 1
-                            self.jac_relevant_dofs[n_con, 0, i_b] = i_d
+                            # TODO?
+                            if ti.static(self.sparse_solve):
+                                for i_d2_ in range(self.jac_n_relevant_dofs[n_con, i_b]):
+                                    i_d2 = self.jac_relevant_dofs[n_con, i_d2_, i_b]
+                                    self.jac[n_con, i_d2, i_b] = gs.ti_float(0.0)
+                                pass
+                            else:
+                                for i_d2 in range(self._solver.n_dofs):
+                                    self.jac[n_con, i_d2, i_b] = gs.ti_float(0.0)
+                            self.jac[n_con, i_d, i_b] = jac
 
-                        self.efc_D[n_con, i_b] = 1 / ti.max(gs.EPS, diag)
+                            if ti.static(self.sparse_solve):
+                                self.jac_n_relevant_dofs[n_con, i_b] = 1
+                                self.jac_relevant_dofs[n_con, 0, i_b] = i_d
+
+                            self.efc_D[n_con, i_b] = 1 / ti.max(gs.EPS, diag)
 
     @ti.func
     def _func_nt_hessian_incremental(self, island, i_b):

--- a/genesis/options/solvers.py
+++ b/genesis/options/solvers.py
@@ -190,6 +190,7 @@ class RigidOptions(Options):
 
     # batching info
     batch_links_info: Optional[bool] = False
+    batch_joints_info: Optional[bool] = False
     batch_dofs_info: Optional[bool] = False
 
     # constraint solver

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -38,132 +38,45 @@ def parse_link(mj, i_l, scale):
     l_info["parent_idx"] = int(mj.body_parentid[i_l] - 1)
     l_info["invweight"] = float(mj.body_invweight0[i_l, 0])
 
-    l_info["pos"] *= scale
-    l_info["inertial_pos"] *= scale
-    l_info["inertial_mass"] *= scale**3
-    l_info["inertial_i"] *= scale**5
-    l_info["invweight"] /= scale**3
-
-    # mj.jnt =================================
-    def add_actuator(j_info, i_j=None):
-        # mj.actuator
-        n_dofs = j_info["n_dofs"]
-        j_info["dofs_kp"] = gu.default_dofs_kp(n_dofs)
-        j_info["dofs_kv"] = gu.default_dofs_kv(n_dofs)
-        j_info["dofs_force_range"] = gu.default_dofs_force_range(n_dofs)
-
-        if i_j is not None:
-            for i_a in range(len(mj.actuator_trnid)):
-                if mj.actuator_trnid[i_a, 0] == i_j:
-                    trntype = mujoco.mjtTrn(mj.actuator_trntype[i_a])
-                    if trntype != mujoco.mjtTrn.mjTRN_JOINT:
-                        gs.logger.warning(f"(MJCF) Actuator type '{trntype}' not supported")
-                        break
-                    if mj.actuator_dyntype[i_a] != mujoco.mjtDyn.mjDYN_NONE:
-                        gs.logger.warning(f"(MJCF) Actuator internal dynamics not supported")
-                        break
-                    gaintype = mujoco.mjtGain(mj.actuator_gaintype[i_a])
-                    if gaintype != mujoco.mjtGain.mjGAIN_FIXED:
-                        gs.logger.warning(f"(MJCF) Actuator control gain of type '{gaintype}' not supported")
-                        break
-                    biastype = mujoco.mjtBias(mj.actuator_biastype[i_a])
-                    if biastype not in (mujoco.mjtBias.mjBIAS_NONE, mujoco.mjtBias.mjBIAS_AFFINE):
-                        gs.logger.warning(f"(MJCF) Actuator control bias of type '{biastype}' not supported")
-                        break
-                    if n_dofs > 1 and not (mj.actuator_gear[i_a, :n_dofs] == 1.0).all():
-                        gs.logger.warning("(MJCF) Actuator transmission gear is only supported of 1DoF joints")
-                        break
-
-                    if biastype == mujoco.mjtBias.mjBIAS_NONE:
-                        # Direct-drive
-                        actuator_kp = 0.0
-                        actuator_kv = 0.0
-                    else:  # this must be affine
-                        # PD control
-                        gainprm = mj.actuator_gainprm[i_a]
-                        biasprm = mj.actuator_biasprm[i_a]
-                        if gainprm[0] != -biasprm[1] or gainprm[1:].any() or biasprm[0]:
-                            gs.logger.warning("(MJCF) Actuator gain and bias cannot be reduced to PD control")
-                            break
-                        actuator_kp, actuator_kv = biasprm[1:3]
-
-                    gear = mj.actuator_gear[i_a, 0]
-                    j_info["dofs_kp"] = np.tile(-gear * actuator_kp, (n_dofs,))
-                    j_info["dofs_kv"] = np.tile(-gear * actuator_kv, (n_dofs,))
-                    if mj.actuator_forcelimited[i_a] or mj.actuator_ctrllimited[i_a]:
-                        j_info["dofs_force_range"] = np.tile(
-                            np.minimum(np.tile(mj.actuator_forcerange[i_a], n_dofs), gear * mj.actuator_ctrlrange[i_a]),
-                            (n_dofs, 1),
-                        )
-                    break
-
-        return j_info
-
-    def add_more_joint_info(j_info, qpos0_offset=0, dof_offset=0):
-        qpos0_off = qpos0_offset
-        d_off = dof_offset
-
-        n_dofs = j_info["n_dofs"]
-        j_info["dofs_damping"] = mj.dof_damping[d_off : (d_off + n_dofs)]
-        j_info["dofs_invweight"] = mj.dof_invweight0[d_off : (d_off + n_dofs)]
-        j_info["dofs_armature"] = mj.dof_armature[d_off : (d_off + n_dofs)]
-
-        if (mj.dof_frictionloss[d_off : (d_off + n_dofs)] > 0.0).any():
-            gs.logger.warning("(MJCF) Joint Coulomb friction not supported.")
-
-        j_info["init_qpos"] = mj.qpos0[qpos0_off : (qpos0_off + j_info["n_qs"])]
-
-        # apply scale
-        j_info["pos"] *= scale
-
-        return j_info
-
     jnt_adr = mj.body_jntadr[i_l]
     jnt_num = mj.body_jntnum[i_l]
 
-    final_joint_list = []
-    if jnt_adr == -1:  # fixed joint
+    j_infos = []
+    for i_j in range(jnt_adr, jnt_adr + max(jnt_num, 1)):
         j_info = dict()
-        j_info["dofs_motion_ang"] = np.zeros((0, 3))
-        j_info["dofs_motion_vel"] = np.zeros((0, 3))
-        j_info["dofs_limit"] = np.zeros((0, 2))
-        j_info["dofs_stiffness"] = np.zeros((0))
-        j_info["dofs_sol_params"] = np.zeros((0, 7))
 
-        j_info["name"] = l_info["name"]
-        j_info["type"] = gs.JOINT_TYPE.FIXED
-        j_info["pos"] = np.array([0.0, 0.0, 0.0])
-        j_info["quat"] = np.array([1.0, 0.0, 0.0, 0.0])
-        j_info["n_qs"] = 0
-        j_info["n_dofs"] = 0
+        # Parsing joint parameters that are type-specific
+        if i_j == -1:
+            j_info["dofs_motion_ang"] = np.zeros((0, 3))
+            j_info["dofs_motion_vel"] = np.zeros((0, 3))
+            j_info["dofs_limit"] = np.zeros((0, 2))
+            j_info["dofs_stiffness"] = np.zeros((0))
 
-        j_info = add_more_joint_info(add_actuator(j_info))
-        final_joint_list.append(j_info)
-    else:
-        j_info_list = []
-        for i_j in range(jnt_adr, jnt_adr + jnt_num):
-            j_info = dict()
-            j_info["quat"] = np.array([1.0, 0.0, 0.0, 0.0])
+            j_info["name"] = l_info["name"]
+            j_info["type"] = gs.JOINT_TYPE.FIXED
+            j_info["pos"] = np.array([0.0, 0.0, 0.0])
+            j_info["n_qs"] = 0
+            j_info["n_dofs"] = 0
+        else:
             name_start = mj.name_jntadr[i_j]
             if i_j + 1 < mj.njnt:
                 name_end = mj.name_jntadr[i_j + 1]
             else:
                 name_end = mj.name_geomadr[0]
             j_info["name"] = mj.names[name_start:name_end].decode("utf-8").replace("\x00", "")
+
             j_info["pos"] = mj.jnt_pos[i_j]
 
             mj_type = mj.jnt_type[i_j]
             mj_stiffness = mj.jnt_stiffness[i_j]
             mj_limit = mj.jnt_range[i_j] if mj.jnt_limited[i_j] == 1 else np.array([-np.inf, np.inf])
             mj_axis = mj.jnt_axis[i_j]
-            mj_sol_params = np.concatenate((mj.jnt_solref[i_j], mj.jnt_solimp[i_j]))
 
             if mj_type == mujoco.mjtJoint.mjJNT_HINGE:
                 j_info["dofs_motion_ang"] = np.array([mj_axis])
                 j_info["dofs_motion_vel"] = np.zeros((1, 3))
                 j_info["dofs_limit"] = np.array([mj_limit])
                 j_info["dofs_stiffness"] = np.array([mj_stiffness])
-                j_info["dofs_sol_params"] = np.array([mj_sol_params])
 
                 j_info["type"] = gs.JOINT_TYPE.REVOLUTE
                 j_info["n_qs"] = 1
@@ -174,7 +87,6 @@ def parse_link(mj, i_l, scale):
                 j_info["dofs_motion_vel"] = np.array([mj_axis])
                 j_info["dofs_limit"] = np.array([mj_limit])
                 j_info["dofs_stiffness"] = np.array([mj_stiffness])
-                j_info["dofs_sol_params"] = np.array([mj_sol_params])
 
                 j_info["type"] = gs.JOINT_TYPE.PRISMATIC
                 j_info["n_qs"] = 1
@@ -188,10 +100,9 @@ def parse_link(mj, i_l, scale):
                 j_info["dofs_motion_vel"] = np.zeros((3, 3))
                 j_info["dofs_limit"] = np.tile([-np.inf, np.inf], (3, 1))
                 j_info["dofs_stiffness"] = np.repeat(mj_stiffness[None], 3, axis=0)
-                j_info["dofs_sol_params"] = np.repeat(mj_sol_params[None], 3, axis=0)
 
                 j_info["type"] = gs.JOINT_TYPE.SPHERICAL
-                j_info["n_qs"] = 3
+                j_info["n_qs"] = 4
                 j_info["n_dofs"] = 3
 
             elif mj_type == mujoco.mjtJoint.mjJNT_FREE:
@@ -202,7 +113,6 @@ def parse_link(mj, i_l, scale):
                 j_info["dofs_motion_vel"] = np.eye(6, 3)
                 j_info["dofs_limit"] = np.tile([-np.inf, np.inf], (6, 1))
                 j_info["dofs_stiffness"] = np.zeros(6)
-                j_info["dofs_sol_params"] = np.repeat(mj_sol_params[None], 6, axis=0)
 
                 j_info["type"] = gs.JOINT_TYPE.FREE
                 j_info["n_qs"] = 7
@@ -211,49 +121,95 @@ def parse_link(mj, i_l, scale):
             else:
                 gs.raise_exception(f"Unsupported MJCF joint type: {mj_type}")
 
-            j_info_list.append(add_actuator(j_info, i_j))
+        # Parsing joint parameters that are type-agnostic
+        mj_jnt_offset = i_j if i_j != -1 else 0
+        mj_dof_offset = mj.jnt_dofadr[i_j] if i_j != -1 else 0
+        mj_qpos_offset = mj.jnt_qposadr[i_j] if i_j != -1 else 0
+        n_dofs = j_info["n_dofs"]
+        j_info["quat"] = np.array([1.0, 0.0, 0.0, 0.0])
+        j_info["init_qpos"] = np.array(mj.qpos0[mj_qpos_offset : (mj_qpos_offset + j_info["n_qs"])])
+        j_info["dofs_damping"] = mj.dof_damping[mj_dof_offset : (mj_dof_offset + n_dofs)]
+        j_info["dofs_invweight"] = mj.dof_invweight0[mj_dof_offset : (mj_dof_offset + n_dofs)]
+        j_info["dofs_armature"] = mj.dof_armature[mj_dof_offset : (mj_dof_offset + n_dofs)]
+        j_info["sol_params"] = np.concatenate(
+            (
+                mj.jnt_solref[mj_jnt_offset : (mj_jnt_offset + 1)],
+                mj.jnt_solimp[mj_jnt_offset : (mj_jnt_offset + 1)],
+            ),
+            axis=1,
+        )
+        j_info["dofs_sol_params"] = np.concatenate(
+            (
+                mj.dof_solref[mj_dof_offset : (mj_dof_offset + n_dofs)],
+                mj.dof_solimp[mj_dof_offset : (mj_dof_offset + n_dofs)],
+            ),
+            axis=1,
+        )
 
-        j_info = dict()
-        j_info["n_qs"] = sum([j["n_qs"] for j in j_info_list])
-        j_info["n_dofs"] = sum([j["n_dofs"] for j in j_info_list])
-        j_info["dofs_motion_ang"] = np.concatenate([j["dofs_motion_ang"] for j in j_info_list], axis=0)
-        j_info["dofs_motion_vel"] = np.concatenate([j["dofs_motion_vel"] for j in j_info_list], axis=0)
-        j_info["dofs_limit"] = np.concatenate([j["dofs_limit"] for j in j_info_list], axis=0)
-        j_info["dofs_stiffness"] = np.concatenate([j["dofs_stiffness"] for j in j_info_list], axis=0)
-        j_info["dofs_sol_params"] = np.concatenate([j["dofs_sol_params"] for j in j_info_list], axis=0)
+        if (mj.dof_frictionloss[mj_dof_offset : (mj_dof_offset + n_dofs)] > 0.0).any():
+            gs.logger.warning("(MJCF) Joint Coulomb friction not supported.")
 
-        j_info["dofs_kp"] = np.concatenate([j["dofs_kp"] for j in j_info_list], axis=0)
-        j_info["dofs_kv"] = np.concatenate([j["dofs_kv"] for j in j_info_list], axis=0)
-        j_info["dofs_force_range"] = np.concatenate([j["dofs_force_range"] for j in j_info_list], axis=0)
+        # Parsing actuator parameters
+        j_info["dofs_kp"] = np.zeros((n_dofs,), dtype=gs.np_float)
+        j_info["dofs_kv"] = np.zeros((n_dofs,), dtype=gs.np_float)
+        j_info["dofs_force_range"] = np.zeros((n_dofs, 2), dtype=gs.np_float)
 
-        if j_info["n_dofs"] == 1:
-            j_info["type"] = j_info_list[0]["type"]
-        elif j_info["n_dofs"] == 2:
-            j_info["type"] = gs.JOINT_TYPE.PLANAR
-        elif j_info["n_dofs"] == 3:
-            j_info["type"] = gs.JOINT_TYPE.SPHERICAL
-        elif j_info["n_dofs"] == 6:
-            j_info["type"] = gs.JOINT_TYPE.FREE
+        for i_a in range(len(mj.actuator_trnid)):
+            if mj.actuator_trnid[i_a, 0] == i_j:
+                trntype = mujoco.mjtTrn(mj.actuator_trntype[i_a])
+                if trntype != mujoco.mjtTrn.mjTRN_JOINT:
+                    gs.logger.warning(f"(MJCF) Actuator type '{trntype}' not supported")
+                    break
+                if mj.actuator_dyntype[i_a] != mujoco.mjtDyn.mjDYN_NONE:
+                    gs.logger.warning(f"(MJCF) Actuator internal dynamics not supported")
+                    break
+                gaintype = mujoco.mjtGain(mj.actuator_gaintype[i_a])
+                if gaintype != mujoco.mjtGain.mjGAIN_FIXED:
+                    gs.logger.warning(f"(MJCF) Actuator control gain of type '{gaintype}' not supported")
+                    break
+                biastype = mujoco.mjtBias(mj.actuator_biastype[i_a])
+                if biastype not in (mujoco.mjtBias.mjBIAS_NONE, mujoco.mjtBias.mjBIAS_AFFINE):
+                    gs.logger.warning(f"(MJCF) Actuator control bias of type '{biastype}' not supported")
+                    break
+                if n_dofs > 1 and not (mj.actuator_gear[i_a, :n_dofs] == 1.0).all():
+                    gs.logger.warning("(MJCF) Actuator transmission gear is only supported of 1DoF joints")
+                    break
 
-        j_info["n_qpos0"] = j_info["n_qs"]
-        if j_info["type"] == gs.JOINT_TYPE.SPHERICAL and len(j_info_list) == 1:
-            # for real ball joint, mujoco uses quaternion for qpos0
-            # however, we could merge multiple hinge joints into a single ball joint
-            # in this case, we need to use xyz for qpos0
-            j_info["n_qpos0"] = 4
+                if biastype == mujoco.mjtBias.mjBIAS_NONE:
+                    # Direct-drive
+                    actuator_kp = 0.0
+                    actuator_kv = 0.0
+                else:  # this must be affine
+                    # PD control
+                    gainprm = mj.actuator_gainprm[i_a]
+                    biasprm = mj.actuator_biasprm[i_a]
+                    if gainprm[0] != -biasprm[1] or gainprm[1:].any() or biasprm[0]:
+                        gs.logger.warning("(MJCF) Actuator gain and bias cannot be reduced to PD control")
+                        break
+                    actuator_kp, actuator_kv = biasprm[1:3]
 
-        j_info["quat"] = j_info_list[0]["quat"]
-        j_info["pos"] = j_info_list[0]["pos"]
-        j_info["name"] = j_info_list[0]["name"]
+                gear = mj.actuator_gear[i_a, 0]
+                j_info["dofs_kp"] = np.tile(-gear * actuator_kp, (n_dofs,))
+                j_info["dofs_kv"] = np.tile(-gear * actuator_kv, (n_dofs,))
+                if mj.actuator_forcelimited[i_a] or mj.actuator_ctrllimited[i_a]:
+                    j_info["dofs_force_range"] = np.tile(
+                        np.minimum(np.tile(mj.actuator_forcerange[i_a], n_dofs), gear * mj.actuator_ctrlrange[i_a]),
+                        (n_dofs, 1),
+                    )
+                break
 
-        final_joint_list.append(j_info)
+        j_infos.append(j_info)
 
-    if len(mj.jnt_qposadr) == 0:
-        j_info = add_more_joint_info(final_joint_list[0], 0, 0)
-    else:
-        j_info = add_more_joint_info(final_joint_list[0], mj.jnt_qposadr[jnt_adr], mj.jnt_dofadr[jnt_adr])
+    # Applying scale
+    l_info["pos"] *= scale
+    l_info["inertial_pos"] *= scale
+    l_info["inertial_mass"] *= scale**3
+    l_info["inertial_i"] *= scale**5
+    l_info["invweight"] /= scale**3
+    for j_info in j_infos:
+        j_info["pos"] *= scale
 
-    return l_info, j_info
+    return l_info, j_infos
 
 
 def parse_links(mj, scale):
@@ -430,7 +386,6 @@ def parse_geom(mj, i_g, scale, convexify, surface, xml_path):
         "type": gs_type,
         "pos": mj_geom.pos * scale,
         "quat": mj_geom.quat,
-        "mesh": mesh,
         "contype": mj_geom.contype[0],
         "conaffinity": mj_geom.conaffinity[0],
         "is_convex": convexify,
@@ -438,6 +393,10 @@ def parse_geom(mj, i_g, scale, convexify, surface, xml_path):
         "friction": mj_geom.friction[0],
         "sol_params": np.concatenate((mj_geom.solref, mj_geom.solimp)),
     }
+    if is_col:
+        info["mesh"] = mesh
+    else:
+        info["vmesh"] = mesh
 
     return info
 
@@ -476,14 +435,15 @@ def parse_geoms(mj, scale, convexify, surface, xml_path):
         is_all_col = all(g_info["contype"] or g_info["conaffinity"] for g_info in link_g_info)
         if is_all_col:
             for g_info in link_g_info.copy():
-                mesh = g_info["mesh"]
+                g_info = g_info.copy()
+                mesh = g_info.pop("mesh")
                 vmesh = gs.Mesh(
                     mesh=mesh.trimesh,
                     surface=surface,
                     uvs=mesh.uvs,
                     metadata=mesh.metadata,
                 )
-                g_info = {**g_info, "mesh": mesh, "contype": 0, "conaffinity": 0}
+                g_info = {**g_info, "vmesh": vmesh, "contype": 0, "conaffinity": 0}
                 link_g_info.append(g_info)
 
     return links_g_info

--- a/genesis/utils/urdf.py
+++ b/genesis/utils/urdf.py
@@ -127,10 +127,13 @@ def parse_urdf(morph, surface):
                         "data": None,
                         "pos": geom.origin[:3, 3].copy(),
                         "quat": gu.R_to_quat(geom.origin[:3, :3]),
-                        "mesh": mesh,
                         "contype": geom_is_col,
                         "conaffinity": geom_is_col,
                     }
+                    if geom_is_col:
+                        g_info["mesh"] = mesh
+                    else:
+                        g_info["vmesh"] = mesh
                     l_info["g_infos"].append(g_info)
             else:
                 # Each geometry primitive is one RigidGeom in genesis.
@@ -170,10 +173,13 @@ def parse_urdf(morph, surface):
                     "data": geom_data,
                     "pos": geom.origin[:3, 3],
                     "quat": gu.R_to_quat(geom.origin[:3, :3]),
-                    "mesh": mesh,
                     "contype": geom_is_col,
                     "conaffinity": geom_is_col,
                 }
+                if geom_is_col:
+                    g_info["mesh"] = mesh
+                else:
+                    g_info["vmesh"] = mesh
                 l_info["g_infos"].append(g_info)
 
     #########################  non-base joints and links #########################
@@ -263,8 +269,8 @@ def parse_urdf(morph, surface):
             gs.raise_exception(f"Unsupported URDF joint type: {joint.joint_type}")
 
         # TODO: parse these
-
         j_info["dofs_invweight"] = gu.default_dofs_invweight(j_info["n_dofs"])
+        j_info["sol_params"] = gu.default_solver_params(1)
         j_info["dofs_sol_params"] = gu.default_solver_params(j_info["n_dofs"])
         j_info["dofs_kp"] = gu.default_dofs_kp(j_info["n_dofs"])
         j_info["dofs_kv"] = gu.default_dofs_kv(j_info["n_dofs"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pygltflib == 1.16.0",
     # * Mujoco 3.3 made Native CCD an opt-out option instead of opt-in,
     #   which requires setting the disableflags 'mjDSBL_NATIVECCD'.
-    "mujoco >= 3.2.5, < 3.4.0",
+    "mujoco >= 3.3.0, < 3.4.0",
     "pycollada",
     "opencv-python",
     "lxml",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+from itertools import chain
 from enum import Enum
 
 import pytest
@@ -83,8 +84,7 @@ def mj_sim(xml_path, gs_solver, gs_integrator):
     model.opt.disableflags &= ~np.uint32(mujoco.mjtDisableBit.mjDSBL_EULERDAMP)
     model.opt.disableflags &= ~np.uint32(mujoco.mjtDisableBit.mjDSBL_REFSAFE)
     model.opt.disableflags &= ~np.uint32(mujoco.mjtDisableBit.mjDSBL_GRAVITY)
-    if hasattr(mujoco.mjtDisableBit, "mjDSBL_NATIVECCD"):
-        model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_NATIVECCD
+    model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_NATIVECCD
     model.opt.enableflags |= mujoco.mjtEnableBit.mjENBL_MULTICCD
     data = mujoco.MjData(model)
 
@@ -130,7 +130,7 @@ def gs_sim(xml_path, gs_solver, gs_integrator, show_viewer, mj_sim):
     )
 
     # Joint damping is not properly supported in Genesis for now
-    for joint in gs_robot.joints:
+    for joint in chain.from_iterable(gs_robot.joints):
         joint.dofs_damping[:] = 0.0
 
     scene.build()

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -111,6 +111,19 @@ def test_simple_kinematic_chain(gs_sim, mj_sim):
     simulate_and_check_mujoco_consistency(gs_sim, mj_sim, num_steps=200)
 
 
+@pytest.mark.parametrize("xml_path", ["xml/walker.xml"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu], indirect=True)
+def test_walker(gs_sim, mj_sim):
+    (gs_robot,) = gs_sim.entities
+    qpos = np.zeros((gs_robot.n_qs,))
+    qpos[2] += 0.5
+    qvel = np.random.rand(gs_robot.n_dofs) * 0.2
+    # Cannot simulate any longer because collision detection is very sensitive
+    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos, qvel, num_steps=90)
+
+
 def test_nonconvex_collision(show_viewer):
     scene = gs.Scene(show_viewer=show_viewer, show_FPS=False)
     tank = scene.add_entity(
@@ -132,7 +145,7 @@ def test_nonconvex_collision(show_viewer):
     )
     scene.build()
     ball.set_dofs_velocity(np.random.rand(ball.n_dofs) * 0.8)
-    for i in range(1400):
+    for i in range(1500):
         scene.step()
     qvel = scene.sim.rigid_solver.dofs_state.vel.to_numpy()[:, 0]
-    np.testing.assert_allclose(qvel, 0, atol=0.05)
+    np.testing.assert_allclose(qvel, 0, atol=0.1)


### PR DESCRIPTION
## Description

This PR gets rid of joint fusing completely in order to keep the original joint composition. First, this was confusing end-user that were trying to access data related to the original joints for their application. Second, it was impossible to support specifying different joint pose, as they cannot be fixed into one time-independent joint.

## Related Issue

Related to Genesis-Embodied-AI/Genesis/issues/461
Resolves Genesis-Embodied-AI/Genesis/issues/762
Supersedes Genesis-Embodied-AI/Genesis/pull/792
Resolves Genesis-Embodied-AI/Genesis/discussions/837

## Motivation and Context

Chaining multiple basic 1DoF joints is the standard approach in Mujoco for implementing complex N-DoF joints, including spherical joints. Currently, only chaining multiple DoFs is supported in Genesis, which is not the same as chaining multiple joints as it is not possible to specify individual pose offset between them. Anyway, chaining multiple DoF is not strictly equivalent to a single N-DoF joint in the general case.

## How Has This Been / Can This Be Tested?

Going through the various assets that are shipping with Genesis.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.