### PR TITLE
[BUG FIX] Improve debug and high-precision mode.

### DIFF
--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -1,4 +1,10 @@
 # import taichi while suppressing its output
+import os
+import sys
+import ctypes
+import atexit
+import logging as _logging
+import traceback
 from unittest.mock import patch
 
 _ti_outputs = []
@@ -9,14 +15,24 @@ def fake_print(*args, **kwargs):
     _ti_outputs.append(output)
 
 
+if sys.platform == "darwin":
+    libc = ctypes.CDLL(None)
+    devnull = open(os.devnull, "w")
+    stderr_fileno = sys.stderr.fileno()
+    sys.stderr.flush()
+    libc.fflush(None)
+    libc.dup2(devnull.fileno(), stderr_fileno)
+
 with patch("builtins.print", fake_print):
     import taichi as ti
 
-import os
-import sys
+if sys.platform == "darwin":
+    sys.stderr.flush()
+    libc.fflush(None)
+    libc.dup2(sys.__stderr__.fileno(), stderr_fileno)
+    devnull.close()
+
 import torch
-import atexit
-import traceback
 import numpy as np
 
 from .constants import GS_ARCH, TI_ARCH
@@ -27,7 +43,6 @@ from .utils import set_random_seed, get_platform, get_device
 
 _initialized = False
 backend = None
-first_init = True
 exit_callbacks = []
 global_scene_list = set()
 
@@ -39,7 +54,7 @@ def init(
     debug=False,
     eps=1e-12,
     logging_level=None,
-    backend=gs_backend.gpu,
+    backend=None,
     theme="dark",
     logger_verbose_time=False,
 ):
@@ -55,27 +70,34 @@ def init(
     global _theme
     _theme = theme
 
+    # Dealing with default backend
+    global platform
+    platform = get_platform()
+    if backend is None:
+        if debug or platform == "macOS":
+            backend = gs_backend.cpu
+        else:
+            backend = gs_backend.gpu
+
     # verbose repr
     global _verbose
     _verbose = False
 
     # genesis.logger
     global logger
-    global first_init
-    if first_init:
-        logger = Logger(logging_level, debug, logger_verbose_time)
-        atexit.register(_gs_exit)
+    if logging_level is None:
+        logging_level = _logging.DEBUG if debug else _logging.INFO
+    logger = Logger(logging_level, logger_verbose_time)
+    atexit.register(_gs_exit)
 
-        # greeting message
-        _display_greeting(logger.INFO_length)
-
-        first_init = False
+    # greeting message
+    _display_greeting(logger.INFO_length)
 
     # genesis.backend
-    global platform
-    platform = get_platform()
     if backend not in GS_ARCH[platform]:
         raise_exception(f"backend ~~<{backend}>~~ not supported for platform ~~<{platform}>~~")
+    if backend == gs_backend.metal:
+        logger.warning("Beware Apple Metal backend is partially broken.")
 
     # get default device and compute total device memory
     global device
@@ -86,14 +108,6 @@ def init(
     logger.info(
         f"Running on ~~<[{device_name}]>~~ with backend ~~<{backend}>~~. Device memory: ~~<{total_mem:.2f}>~~ GB."
     )
-
-    # init taichi
-    with patch("builtins.print", fake_print):
-        # force_scalarize_matrix=True for speeding up kernel compilation
-        ti.init(arch=TI_ARCH[platform][backend], debug=debug, force_scalarize_matrix=True)
-
-    for ti_output in _ti_outputs:
-        logger.debug(ti_output)
 
     # dtype
     global ti_float
@@ -143,11 +157,46 @@ def init(
     global EPS
     EPS = eps
 
-    # seed
+    taichi_kwargs = {}
+    if debug:
+        if backend == gs_backend.cpu:
+            taichi_kwargs.update(
+                cpu_max_num_threads=1,
+            )
+        else:
+            logger.warning("CPU backend is strongly recommended in debug mode.")
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+        torch.use_deterministic_algorithms(True)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+        logger.info("Beware running Genesis in debug mode dramatically reduces runtime speed.")
+
     if seed is not None:
         global SEED
         SEED = seed
         set_random_seed(SEED)
+        taichi_kwargs.update(
+            random_seed=seed,
+        )
+
+    # init taichi
+    with patch("builtins.print", fake_print):
+        ti.init(
+            arch=TI_ARCH[platform][backend],
+            # debug is not working on Apple Silicon CPU (causes segfault)
+            debug=False if platform == "macOS" and backend == gs_backend.cpu else debug,
+            check_out_of_bound=debug,
+            # force_scalarize_matrix=True for speeding up kernel compilation
+            force_scalarize_matrix=not debug,
+            advanced_optimization=not debug,
+            fast_math=not debug,
+            default_ip=ti_int,
+            default_fp=ti_float,
+            **taichi_kwargs,
+        )
+
+    for ti_output in _ti_outputs:
+        logger.debug(ti_output)
 
     global exit_callbacks
     exit_callbacks = []

--- a/genesis/logging/logger.py
+++ b/genesis/logging/logger.py
@@ -1,3 +1,4 @@
+import sys
 import logging
 import threading
 from contextlib import contextmanager
@@ -60,35 +61,16 @@ class GenesisFormatter(logging.Formatter):
 
 
 class Logger:
-    def __init__(self, logging_level, debug, verbose_time):
-        if logging_level is None:
-            if debug:
-                logging_level = logging.DEBUG
-            else:
-                logging_level = logging.INFO
-
-        elif logging_level == "debug":
-            logging_level = logging.DEBUG
-
-        elif logging_level == "info":
-            logging_level = logging.INFO
-
-        elif logging_level == "warning":
-            logging_level = logging.WARNING
-
-        elif logging_level == "error":
-            logging_level = logging.ERROR
-
-        else:
-            # we cannot use gs.raise_exception here because it relies on the logger
-            raise Exception("Unsupported logging_level.")
+    def __init__(self, logging_level, verbose_time):
+        if isinstance(logging_level, str):
+            logging_level = logging_level.upper()
 
         self._logger = logging.getLogger("genesis")
         self._logger.setLevel(logging_level)
 
         self._formatter = GenesisFormatter(verbose_time)
 
-        self._handler = logging.StreamHandler()
+        self._handler = logging.StreamHandler(sys.stdout)
         self._handler.setLevel(logging_level)
         self._handler.setFormatter(self._formatter)
         self._logger.addHandler(self._handler)

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -296,7 +296,7 @@ def parse_geom(mj, i_g, scale, convexify, surface, xml_path):
                 tmesh.visual = visual
 
     elif mj_geom.type == mujoco.mjtGeom.mjGEOM_MESH:
-        mj_mesh = mj.mesh(mj_geom.dataid)
+        mj_mesh = mj.mesh(int(mj_geom.dataid))
 
         vert_start = int(mj_mesh.vertadr)
         vert_num = int(mj_mesh.vertnum)


### PR DESCRIPTION
## Description

* Silence OpenGL dynamics library loading between Taichi and Mujoco Viewer on MacOS, that should be harmless but very confusing for the end-user, especially when an actually bug happens latter. 
* Prefer CPU over GPU in debug mode, and Apple Silicon machines as Metal support is partially broken. 
* Fix high-precision computation that was only partially enforced.
* Use deterministic algorithms and disable parallel computations in Debug mode
* Always disable Taichi debug mode on Apple Silicon with CPU backend as it causes segfault

## Related Issue

Related to Genesis-Embodied-AI/Genesis/issues/555
Related to Genesis-Embodied-AI/Genesis/issues/368
Related to Genesis-Embodied-AI/Genesis/issues/165
Related to Genesis-Embodied-AI/Genesis/issues/32

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.