### PR TITLE
[MISC] Enhance create_frame with color_alpha, rework mesh creation

### DIFF
--- a/examples/tutorials/IK_motion_planning_grasp.py
+++ b/examples/tutorials/IK_motion_planning_grasp.py
@@ -64,7 +64,7 @@ path = franka.plan_path(
     num_waypoints=200,  # 2s duration
 )
 # draw the planned path
-path_debug = scene.draw_debug_path(path, franka)
+path_debug = scene.draw_debug_path(path, franka, link_idx=end_effector.idx)
 
 # execute the planned path
 for waypoint in path:

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -736,7 +736,13 @@ def apply_transform(matrix, positions, normals=None):
 
 
 def create_frame(
-    origin_radius=0.012, axis_radius=0.005, axis_length=1.0, head_radius=0.01, head_length=0.03, sections=12, color_alpha=1.0
+    origin_radius=0.012,
+    axis_radius=0.005,
+    axis_length=1.0,
+    head_radius=0.01,
+    head_length=0.03,
+    sections=12,
+    color_alpha=1.0,
 ):
     origin = create_sphere(radius=origin_radius, subdivisions=2, color=(1.0, 1.0, 1.0, color_alpha))
 

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -736,17 +736,17 @@ def apply_transform(matrix, positions, normals=None):
 
 
 def create_frame(
-    origin_radius=0.012, axis_radius=0.005, axis_length=1.0, head_radius=0.01, head_length=0.03, sections=12
+    origin_radius=0.012, axis_radius=0.005, axis_length=1.0, head_radius=0.01, head_length=0.03, sections=12, color_alpha=1.0
 ):
-    origin = create_sphere(radius=origin_radius, subdivisions=2)
+    origin = create_sphere(radius=origin_radius, subdivisions=2, color=(1.0, 1.0, 1.0, color_alpha))
 
     x = create_arrow(
         length=axis_length,
         radius=axis_radius,
         l_ratio=head_length / axis_length,
         r_ratio=head_radius / axis_radius,
-        body_color=(0.7, 0.0, 0.0, 1.0),
-        head_color=(0.7, 0.7, 0.7, 1.0),
+        body_color=(1.0, 0.0, 0.0, color_alpha),
+        head_color=(0.7, 0.7, 0.7, color_alpha),
         sections=sections,
     )
     y = create_arrow(
@@ -754,8 +754,8 @@ def create_frame(
         radius=axis_radius,
         l_ratio=head_length / axis_length,
         r_ratio=head_radius / axis_radius,
-        body_color=(0.0, 0.7, 0.0, 1.0),
-        head_color=(0.7, 0.7, 0.7, 1.0),
+        body_color=(0.0, 1.0, 0.0, color_alpha),
+        head_color=(0.7, 0.7, 0.7, color_alpha),
         sections=sections,
     )
     z = create_arrow(
@@ -763,8 +763,8 @@ def create_frame(
         radius=axis_radius,
         l_ratio=head_length / axis_length,
         r_ratio=head_radius / axis_radius,
-        body_color=(0.0, 0.0, 0.7, 1.0),
-        head_color=(0.7, 0.7, 0.7, 1.0),
+        body_color=(0.0, 0.0, 1.0, color_alpha),
+        head_color=(0.7, 0.7, 0.7, color_alpha),
         sections=sections,
     )
 

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -709,7 +709,7 @@ class RasterizerContext:
         color_alpha=0.99,
     ):
         node = pyrender.Mesh.from_trimesh(
-            mu.create_rame(
+            mu.create_frame(
                 origin_radius=origin_size,
                 axis_radius=axis_radius,
                 axis_length=axis_length,

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -670,27 +670,57 @@ class RasterizerContext:
             self.add_external_node(node, pose=pose)
             return node
 
-    def draw_debug_frame(self, T, axis_length=1.0, origin_size=0.015, axis_radius=0.01):
+    def draw_debug_frame(
+        self,
+        T,
+        axis_length=1.0,
+        origin_size=0.015,
+        axis_radius=0.01,
+        head_radius=0.0,
+        head_length=0.0,
+        sections=12,
+        color_alpha=0.99,
+    ):
         node = pyrender.Mesh.from_trimesh(
-            trimesh.creation.axis(
-                origin_size=origin_size,
+            mu.create_frame(
+                origin_radius=origin_size,
                 axis_radius=axis_radius,
                 axis_length=axis_length,
+                head_radius=head_radius,
+                head_length=head_length,
+                sections=sections,
+                color_alpha=color_alpha,
             ),
             name=f"debug_frame_{gs.UID()}",
+            smooth=True,
         )
         self.add_external_node(node, pose=T)
         return node
 
-    def draw_debug_frames(self, poses, axis_length=1.0, origin_size=0.015, axis_radius=0.01):
+    def draw_debug_frames(
+        self,
+        Ts,
+        axis_length=1.0,
+        origin_size=0.015,
+        axis_radius=0.01,
+        head_radius=0.0,
+        head_length=0.0,
+        sections=12,
+        color_alpha=0.99,
+    ):
         node = pyrender.Mesh.from_trimesh(
-            trimesh.creation.axis(
-                origin_size=origin_size,
+            mu.create_rame(
+                origin_radius=origin_size,
                 axis_radius=axis_radius,
                 axis_length=axis_length,
+                head_radius=head_radius,
+                head_length=head_length,
+                sections=sections,
+                color_alpha=color_alpha,
             ),
             name=f"debug_frame_{gs.UID()}",
-            poses=poses,
+            poses=Ts,
+            smooth=True,
         )
         self.add_external_node(node)
         return node

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -676,8 +676,8 @@ class RasterizerContext:
         axis_length=1.0,
         origin_size=0.015,
         axis_radius=0.01,
-        head_radius=1e-8,
-        head_length=1e-8,
+        head_radius=0.0,
+        head_length=0.0,
         sections=12,
         color_alpha=0.99,
     ):
@@ -703,8 +703,8 @@ class RasterizerContext:
         axis_length=1.0,
         origin_size=0.015,
         axis_radius=0.01,
-        head_radius=1e-8,
-        head_length=1e-8,
+        head_radius=0.0,
+        head_length=0.0,
         sections=12,
         color_alpha=0.99,
     ):

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -676,8 +676,8 @@ class RasterizerContext:
         axis_length=1.0,
         origin_size=0.015,
         axis_radius=0.01,
-        head_radius=0.0,
-        head_length=0.0,
+        head_radius=1e-8,
+        head_length=1e-8,
         sections=12,
         color_alpha=0.99,
     ):
@@ -703,8 +703,8 @@ class RasterizerContext:
         axis_length=1.0,
         origin_size=0.015,
         axis_radius=0.01,
-        head_radius=0.0,
-        head_length=0.0,
+        head_radius=1e-8,
+        head_length=1e-8,
         sections=12,
         color_alpha=0.99,
     ):


### PR DESCRIPTION
## Description

Added `color_alpha` arg for `mu.create_frame` and replaced `trimesh.creation.axis` with `mu.create_frame` for drawing frames in `engine/scene.py` 

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context

Previously, the debug frames cast shadow as mentioned in [this comment of #815 ](https://github.com/Genesis-Embodied-AI/Genesis/pull/815#issuecomment-2712626765). This pr introduce color_alpha in `gu.create_frame` to make debug frames transparent.

## How Has This Been / Can This Be Tested?

```python
import time
import numpy as np
import genesis as gs


gs.init(backend=gs.gpu)
viewer_options = gs.options.ViewerOptions(
    camera_pos=(5.0, -5.0, 2.5),
    camera_lookat=(0.0, 0.0, 0.0),
    camera_fov=40,
    max_FPS=200,
)
scene = gs.Scene(
    viewer_options=viewer_options,
    show_viewer=True,
)
scene.add_entity(morph=gs.morphs.Plane())
scene.build()

Ts = np.zeros((10, 4, 4))
for i in range(10):
    T = np.eye(4)
    T[:3, 3] = [1, 0, 0.5 + i * 0.1]
    Ts[i] = T
frames = scene.draw_debug_frames(
    Ts=np.array(Ts), axis_length=0.25, origin_size=0.0125, axis_radius=0.01
)

time.sleep(5.0)

scene.clear_debug_object(frames)

```


## Screenshots (if appropriate):
color_alpha=1.0:
![Screenshot from 2025-03-18 09-57-08](https://github.com/user-attachments/assets/9f7bca48-02a7-4ddd-a78f-e429445b9438)
color_alpha=0.99:
![Screenshot from 2025-03-18 09-54-47](https://github.com/user-attachments/assets/8196ef58-93d0-47c0-95cb-3a6afa50bc3e)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
