### PR TITLE
[BUG FIX] go2 locomotion code compatible with `rsl-rl-lib==2.2.4`

### DIFF
--- a/examples/locomotion/go2_backflip.py
+++ b/examples/locomotion/go2_backflip.py
@@ -103,7 +103,7 @@ class BackflipEnv(Go2Env):
     def step(self, actions):
         super().step(actions)
         self.get_observations()
-        return self.obs_buf, None, self.rew_buf, self.reset_buf, self.extras
+        return self.obs_buf, self.rew_buf, self.reset_buf, self.extras
 
 
 def main():
@@ -138,7 +138,7 @@ def main():
     with torch.no_grad():
         while True:
             actions = policy(obs)
-            obs, _, rews, dones, infos = env.step(actions)
+            obs, rews, dones, infos = env.step(actions)
 
 
 if __name__ == "__main__":

--- a/examples/locomotion/go2_env.py
+++ b/examples/locomotion/go2_env.py
@@ -181,12 +181,12 @@ class Go2Env:
         self.last_actions[:] = self.actions[:]
         self.last_dof_vel[:] = self.dof_vel[:]
 
-        self.extras['observations']['critic'] = self.obs_buf
+        self.extras["observations"]["critic"] = self.obs_buf
 
         return self.obs_buf, self.rew_buf, self.reset_buf, self.extras
 
     def get_observations(self):
-        self.extras['observations']['critic'] = self.obs_buf
+        self.extras["observations"]["critic"] = self.obs_buf
         return self.obs_buf, self.extras
 
     def get_privileged_observations(self):

--- a/examples/locomotion/go2_env.py
+++ b/examples/locomotion/go2_env.py
@@ -111,6 +111,7 @@ class Go2Env:
             dtype=gs.tc_float,
         )
         self.extras = dict()  # extra information for logging
+        self.extras["observations"] = dict()
 
     def _resample_commands(self, envs_idx):
         self.commands[envs_idx, 0] = gs_rand_float(*self.command_cfg["lin_vel_x_range"], (len(envs_idx),), self.device)
@@ -180,10 +181,13 @@ class Go2Env:
         self.last_actions[:] = self.actions[:]
         self.last_dof_vel[:] = self.dof_vel[:]
 
-        return self.obs_buf, None, self.rew_buf, self.reset_buf, self.extras
+        self.extras['observations']['critic'] = self.obs_buf
+
+        return self.obs_buf, self.rew_buf, self.reset_buf, self.extras
 
     def get_observations(self):
-        return self.obs_buf
+        self.extras['observations']['critic'] = self.obs_buf
+        return self.obs_buf, self.extras
 
     def get_privileged_observations(self):
         return None

--- a/examples/locomotion/go2_eval.py
+++ b/examples/locomotion/go2_eval.py
@@ -39,7 +39,7 @@ def main():
     with torch.no_grad():
         while True:
             actions = policy(obs)
-            obs, _, rews, dones, infos = env.step(actions)
+            obs, rews, dones, infos = env.step(actions)
 
 
 if __name__ == "__main__":

--- a/examples/locomotion/go2_train.py
+++ b/examples/locomotion/go2_train.py
@@ -33,7 +33,7 @@ def get_train_cfg(exp_name, max_iterations):
             "actor_hidden_dims": [512, 256, 128],
             "critic_hidden_dims": [512, 256, 128],
             "init_noise_std": 1.0,
-            "class_name": "ActorCritic"
+            "class_name": "ActorCritic",
         },
         "runner": {
             "checkpoint": -1,
@@ -142,7 +142,7 @@ def main():
     parser.add_argument("--max_iterations", type=int, default=101)
     args = parser.parse_args()
 
-    gs.init()
+    gs.init(logging_level="warning")
 
     log_dir = f"logs/{args.exp_name}"
     env_cfg, obs_cfg, reward_cfg, command_cfg = get_cfgs()

--- a/examples/locomotion/go2_train.py
+++ b/examples/locomotion/go2_train.py
@@ -13,6 +13,7 @@ def get_train_cfg(exp_name, max_iterations):
 
     train_cfg_dict = {
         "algorithm": {
+            "class_name": "PPO",
             "clip_param": 0.2,
             "desired_kl": 0.01,
             "entropy_coef": 0.01,
@@ -32,24 +33,23 @@ def get_train_cfg(exp_name, max_iterations):
             "actor_hidden_dims": [512, 256, 128],
             "critic_hidden_dims": [512, 256, 128],
             "init_noise_std": 1.0,
+            "class_name": "ActorCritic"
         },
         "runner": {
-            "algorithm_class_name": "PPO",
             "checkpoint": -1,
             "experiment_name": exp_name,
             "load_run": -1,
             "log_interval": 1,
             "max_iterations": max_iterations,
-            "num_steps_per_env": 24,
-            "policy_class_name": "ActorCritic",
             "record_interval": -1,
             "resume": False,
             "resume_path": None,
             "run_name": "",
-            "runner_class_name": "runner_class_name",
-            "save_interval": 100,
         },
         "runner_class_name": "OnPolicyRunner",
+        "num_steps_per_env": 24,
+        "save_interval": 100,
+        "empirical_normalization": None,
         "seed": 1,
     }
 
@@ -139,10 +139,10 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-e", "--exp_name", type=str, default="go2-walking")
     parser.add_argument("-B", "--num_envs", type=int, default=4096)
-    parser.add_argument("--max_iterations", type=int, default=100)
+    parser.add_argument("--max_iterations", type=int, default=101)
     args = parser.parse_args()
 
-    gs.init(logging_level="warning")
+    gs.init()
 
     log_dir = f"logs/{args.exp_name}"
     env_cfg, obs_cfg, reward_cfg, command_cfg = get_cfgs()
@@ -152,16 +152,16 @@ def main():
         shutil.rmtree(log_dir)
     os.makedirs(log_dir, exist_ok=True)
 
+    pickle.dump(
+        [env_cfg, obs_cfg, reward_cfg, command_cfg, train_cfg],
+        open(f"{log_dir}/cfgs.pkl", "wb"),
+    )
+
     env = Go2Env(
         num_envs=args.num_envs, env_cfg=env_cfg, obs_cfg=obs_cfg, reward_cfg=reward_cfg, command_cfg=command_cfg
     )
 
     runner = OnPolicyRunner(env, train_cfg, log_dir, device="cuda:0")
-
-    pickle.dump(
-        [env_cfg, obs_cfg, reward_cfg, command_cfg, train_cfg],
-        open(f"{log_dir}/cfgs.pkl", "wb"),
-    )
 
     runner.learn(num_learning_iterations=args.max_iterations, init_at_random_ep_len=True)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->

This PR fixes code compatible bug with the latest version of RL library, `rsl-rl-lib==2.2.4`.

- The latest `rsl-rl-lib` gets `obs` and `extras` as the return of `get_observation()` function. However, the previous code returns only `obs` variable. 
```
Traceback (most recent call last):
  File "G:\Genesis_local\examples\locomotion\go2_train.py", line 170, in <module>
    main()
  File "G:\Genesis_local\examples\locomotion\go2_train.py", line 159, in main
    runner = OnPolicyRunner(env, train_cfg, log_dir, device="cuda:0")
  File "C:\Users\Admin\.conda\envs\Genesis\lib\site-packages\rsl_rl\runners\on_policy_runner.py", line 32, in __init__
    obs, extras = self.env.get_observations()
ValueError: too many values to unpack (expected 2)

Process finished with exit code 1
```

I changed below code to make compatible with the lastest library code.

- Add `self.extras` in `get_observations` function.
```
# examples/locomotion/go2_env.py#L188-L191
def get_observations(self):
    self.extras['observations']['critic'] = self.obs_buf
    return self.obs_buf, self.extras
```
- Set the critic observation with `sef.obs_buf` in `get_observations` and `step` functions. The latest `rsl-rl` library gets critic observation from the extras in `learn` function.

This is minor changes on configuration save and load.
- Saves the config pickle (`cfgs.pkl`) file before the `OnPolicyRunner` initialization. The `train_cfg["policy"]["class_name"]` is removed from the dict on initialization.
- Add parameters `empirical_normalization` and `num_steps_per_env` to compatible with the latest library.
- Change the default value of `--max_iterations` to 101 in `go2_train.py` since the train iteration starts from 0.

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Motivation and Context
- The bug on the example could higher the barrier to this project.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

```
# training
python examples/locomotion/go2_train.py
```

After running the train code, check the `logs/go-2walking` directory is created. After the train is end, there should be `cfgs.pkl` and `model_100.pt` files exist in the directory.

```
# evaluation
python examples/locomotion/go2_eval.py -e go2-walking -v --ckpt 100
```

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/553f5445-598c-4292-a005-9f87914624bb)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I read the **CONTRIBUTING** document.
- [X] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [X] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [X] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [X] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
