### PR TITLE
[FEATURE] Give user the ability to choose whether to run viewer in thread.

### DIFF
--- a/examples/render_async.py
+++ b/examples/render_async.py
@@ -1,0 +1,45 @@
+import genesis as gs
+
+
+def run_sim(scene):
+    for _ in range(200):
+        scene.step(refresh_visualizer=False)
+
+
+def main():
+    ########################## init ##########################
+    gs.init()
+
+    ########################## create a scene ##########################
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(3.5, 0.0, 2.5),
+            camera_lookat=(0.0, 0.0, 0.5),
+            camera_fov=40,
+            run_in_thread=False,
+        ),
+        show_viewer=True,
+        show_FPS=True,
+        rigid_options=gs.options.RigidOptions(
+            dt=0.01,
+            gravity=(0.0, 0.0, -10.0),
+        ),
+    )
+
+    ########################## entities ##########################
+    plane = scene.add_entity(gs.morphs.Plane())
+    r0 = scene.add_entity(
+        gs.morphs.MJCF(file="xml/franka_emika_panda/panda.xml"),
+    )
+
+    ########################## build ##########################
+    scene.build()
+
+    gs.tools.run_in_another_thread(fn=run_sim, args=(scene,))
+    scene.viewer.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -15,26 +15,8 @@ def fake_print(*args, **kwargs):
     _ti_outputs.append(output)
 
 
-if sys.platform == "darwin":
-    libc = ctypes.CDLL(None)
-    devnull = open(os.devnull, "w")
-    stderr_fileno = sys.stderr.fileno()
-    original_stderr_fileno = os.dup(stderr_fileno)
-    sys.stderr.flush()
-    libc.fflush(None)
-    libc.dup2(devnull.fileno(), stderr_fileno)
-
-
 with patch("builtins.print", fake_print):
-    import pygel3d
     import taichi as ti
-
-if sys.platform == "darwin":
-    sys.stderr.flush()
-    libc.fflush(None)
-    libc.dup2(original_stderr_fileno, stderr_fileno)
-    os.close(original_stderr_fileno)
-    devnull.close()
 
 import torch
 import numpy as np
@@ -312,6 +294,16 @@ def _gs_exit():
 
 
 ########################## shortcut imports for users ##########################
+
+if sys.platform == "darwin":
+    libc = ctypes.CDLL(None)
+    devnull = open(os.devnull, "w")
+    stderr_fileno = sys.stderr.fileno()
+    original_stderr_fileno = os.dup(stderr_fileno)
+    sys.stderr.flush()
+    libc.fflush(None)
+    libc.dup2(devnull.fileno(), stderr_fileno)
+
 from .constants import (
     IntEnum,
     JOINT_TYPE,
@@ -342,6 +334,13 @@ from .engine import states, materials, force_fields
 from .engine.scene import Scene
 from .engine.mesh import Mesh
 from .engine.entities.emitter import Emitter
+
+if sys.platform == "darwin":
+    sys.stderr.flush()
+    libc.fflush(None)
+    libc.dup2(original_stderr_fileno, stderr_fileno)
+    os.close(original_stderr_fileno)
+    devnull.close()
 
 for name, member in gs_backend.__members__.items():
     globals()[name] = member

--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -24,7 +24,9 @@ if sys.platform == "darwin":
     libc.fflush(None)
     libc.dup2(devnull.fileno(), stderr_fileno)
 
+
 with patch("builtins.print", fake_print):
+    import pygel3d
     import taichi as ti
 
 if sys.platform == "darwin":

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -701,7 +701,7 @@ class Scene(RBC):
         return self._get_state()
 
     @gs.assert_built
-    def step(self, update_visualizer=True):
+    def step(self, update_visualizer=True, refresh_visualizer=True):
         """
         Runs a simulation step forward in time.
         """
@@ -713,7 +713,7 @@ class Scene(RBC):
         self._t += 1
 
         if update_visualizer:
-            self._visualizer.update(force=False)
+            self._visualizer.update(force=False, auto=refresh_visualizer)
 
         if self._show_FPS:
             self.FPS_tracker.step()

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -2783,11 +2783,11 @@ class RigidSolver(Solver):
                     q_diff = gu.ti_transform_quat_by_quat(ctrl_quat, gu.ti_inv_quat(quat))
                     rotvec = gu.ti_quat_to_rotvec(q_diff)
 
-                    for i_d in range(dof_start + 3, l_info.dof_end):
+                    for j in ti.static(range(3)):
+                        i_d = dof_start + 3 + j
                         I_d = [i_d, i_b] if ti.static(self._options.batch_dofs_info) else i_d
                         force = (
-                            self.dofs_info[I_d].kp * rotvec[i_d - dof_start - 3]
-                            - self.dofs_info[I_d].kv * self.dofs_state[i_d, i_b].vel
+                            self.dofs_info[I_d].kp * rotvec[j] - self.dofs_info[I_d].kv * self.dofs_state[i_d, i_b].vel
                         )
 
                         self.dofs_state[i_d, i_b].qf_applied = ti.math.clamp(

--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -391,7 +391,7 @@ class Viewer(pyglet.window.Window):
         # because all access to the OpenGL context must be done from the thread that created it in the first place. As
         # a result, the logic for catching an invalid OpenGL context must be implemented at the thread-level.
         self.auto_start = auto_start
-        if self.run_in_thread:
+        if self._run_in_thread:
             self._initialized_event.clear()
             self._thread = Thread(target=self.start, daemon=True)
             self._thread.start()
@@ -535,12 +535,12 @@ class Viewer(pyglet.window.Window):
         This function will wait for the actual close, so you immediately
         manipulate the scene afterwards.
         """
-        viewer_thread = self._thread if self.run_in_thread else threading.main_thread()
+        viewer_thread = self._thread if self._run_in_thread else threading.main_thread()
         if viewer_thread != threading.current_thread():
             gs.raise_exception("This method can only be called from the thread that started the viewer.")
 
         self.on_close()
-        if self.run_in_thread:
+        if self._run_in_thread:
             while self._is_active:
                 time.sleep(1.0 / self.viewer_flags["refresh_rate"])
 
@@ -622,7 +622,7 @@ class Viewer(pyglet.window.Window):
         if depth:
             self.render_flags["depth"] = True
         self.pending_offscreen_camera = (camera_node, render_target, normal)
-        if self.run_in_thread:
+        if self._run_in_thread:
             # send_offscreen_request
             self._offscreen_event.set()
             # wait_for_offscreen
@@ -647,7 +647,7 @@ class Viewer(pyglet.window.Window):
         if self.pending_offscreen_camera is None:
             return
 
-        if self.run_in_thread:
+        if self._run_in_thread:
             self.render_lock.acquire()
 
         # Make OpenGL context current
@@ -664,7 +664,7 @@ class Viewer(pyglet.window.Window):
         self.render_flags["offscreen"] = False
         self._offscreen_result_semaphore.release()
 
-        if self.run_in_thread:
+        if self._run_in_thread:
             self.render_lock.release()
 
     def on_draw(self):
@@ -672,7 +672,7 @@ class Viewer(pyglet.window.Window):
         if self._renderer is None:
             return
 
-        if self.run_in_thread or not self.auto_start:
+        if self._run_in_thread or not self.auto_start:
             self.render_lock.acquire()
 
         # Make OpenGL context current
@@ -727,7 +727,7 @@ class Viewer(pyglet.window.Window):
                     align=caption["location"],
                 )
 
-        if self.run_in_thread or not self.auto_start:
+        if self._run_in_thread or not self.auto_start:
             self.render_lock.release()
 
     def on_resize(self, width, height):
@@ -1205,17 +1205,12 @@ class Viewer(pyglet.window.Window):
         self.activate()
 
         if auto_refresh:
-            while self._is_active:
-                try:
-                    self.refresh()
-                except AttributeError:
-                    # The graphical window has been closed
-                    self.on_close()
+            self.run()
         else:
             self.refresh()
 
     def run(self):
-        if self.run_in_thread:
+        if self._run_in_thread:
             gs.raise_exception("This method can only be called manually if the viewer is already running in thread.")
         elif threading.main_thread() != threading.current_thread():
             gs.raise_exception("This method can only be called manually from main thread on MacOS.")
@@ -1228,6 +1223,10 @@ class Viewer(pyglet.window.Window):
                 self.on_close()
 
     def refresh(self):
+        viewer_thread = self._thread if self._run_in_thread else threading.main_thread()
+        if viewer_thread != threading.current_thread():
+            gs.raise_exception("This method can only be called from the thread that started the viewer.")
+
         time_next_frame = time.time() + 1.0 / self.viewer_flags["refresh_rate"]
         while self._offscreen_event.wait(time_next_frame - time.time()):
             self.draw_offscreen()

--- a/genesis/options/vis.py
+++ b/genesis/options/vis.py
@@ -17,6 +17,8 @@ class ViewerOptions(Options):
     ----------
     res : tuple, shape (2,), optional
         The resolution of the viewer. If not set, will auto-compute using resolution of the connected display.
+    run_in_thread: bool
+        Whether to run the viewer in a background thread. This option is not supported on MacOS. True by default if available.
     refresh_rate : int
         The refresh rate of the viewer.
     max_FPS : int | None
@@ -32,6 +34,7 @@ class ViewerOptions(Options):
     """
 
     res: Optional[tuple] = None
+    run_in_thread: Optional[bool] = None
     refresh_rate: int = 60
     max_FPS: Optional[int] = 60
     camera_pos: tuple = (3.5, 0.5, 2.5)

--- a/genesis/vis/viewer.py
+++ b/genesis/vis/viewer.py
@@ -27,6 +27,7 @@ class ViewerLock:
 class Viewer(RBC):
     def __init__(self, options, context):
         self._res = options.res
+        self._run_in_thread = options.run_in_thread
         self._refresh_rate = options.refresh_rate
         self._max_FPS = options.max_FPS
         self._camera_init_pos = options.camera_pos
@@ -51,17 +52,6 @@ class Viewer(RBC):
         # set viewer camera
         self.setup_camera()
 
-        # viewer
-        if gs.platform == "Linux":
-            run_in_thread = True
-        elif gs.platform == "macOS":
-            run_in_thread = False
-            gs.logger.warning(
-                "Mac OS detected. The interactive viewer will only be responsive if a simulation is running."
-            )
-        elif gs.platform == "Windows":
-            run_in_thread = True
-
         # Try all candidate onscreen OpenGL "platforms" if none is specifically requested
         opengl_platform_orig = os.environ.get("PYOPENGL_PLATFORM")
         if opengl_platform_orig is None:
@@ -82,7 +72,7 @@ class Viewer(RBC):
                 self._pyrender_viewer = pyrender.Viewer(
                     context=self.context,
                     viewport_size=self._res,
-                    run_in_thread=run_in_thread,
+                    run_in_thread=self._run_in_thread,
                     auto_start=False,
                     view_center=self._camera_init_lookat,
                     shadow=self.context.shadow,
@@ -93,7 +83,7 @@ class Viewer(RBC):
                         "refresh_rate": self._refresh_rate,
                     },
                 )
-                if not run_in_thread:
+                if not self._run_in_thread:
                     self._pyrender_viewer.start(auto_refresh=False)
                 self._pyrender_viewer.wait_until_initialized()
                 break

--- a/genesis/vis/viewer.py
+++ b/genesis/vis/viewer.py
@@ -107,6 +107,9 @@ class Viewer(RBC):
 
         gs.logger.info(f"Viewer created. Resolution: ~<{self._res[0]}×{self._res[1]}>~, max_FPS: ~<{self._max_FPS}>~.")
 
+    def run(self):
+        self._pyrender_viewer.run()
+
     def stop(self):
         self._pyrender_viewer.close()
 
@@ -124,7 +127,7 @@ class Viewer(RBC):
         pose = gu.trans_R_to_T(pos, R)
         self._camera_node = self.context.add_node(pyrender.PerspectiveCamera(yfov=yfov), pose=pose)
 
-    def update(self):
+    def update(self, auto_refresh=True):
         if self._followed_entity is not None:
             self.update_following()
 
@@ -133,7 +136,7 @@ class Viewer(RBC):
             for buffer_id, buffer_data in buffer_updates.items():
                 self._pyrender_viewer.pending_buffer_updates[buffer_id] = buffer_data
 
-            if not self._pyrender_viewer.run_in_thread:
+            if auto_refresh and not self._pyrender_viewer.run_in_thread:
                 self._pyrender_viewer.refresh()
 
         # lock FPS

--- a/genesis/vis/visualizer.py
+++ b/genesis/vis/visualizer.py
@@ -92,9 +92,11 @@ class Visualizer(RBC):
 
         # temp fix for cam.render() segfault
         if self._viewer is not None:
-            # need to update viewer once here, because otherwise camera will update scene if render is called right after build, which will lead to segfault. TODO: this slows down visualizer.update(). Needs to remove this once the bug is fixed.
+            # need to update viewer once here, because otherwise camera will update scene if render is called right
+            # after build, which will lead to segfault.
+            # TODO: this slows down visualizer.update(). Needs to remove this once the bug is fixed.
             try:
-                self._viewer.update()
+                self._viewer.update(auto_refresh=True)
             except:
                 pass
 
@@ -121,18 +123,18 @@ class Visualizer(RBC):
             # need to update viewer once here, because otherwise camera will update scene if render is called right
             # after build, which will lead to segfault.
             if self._viewer is not None:
-                self._viewer.update()
+                self._viewer.update(auto_refresh=True)
             else:
                 # viewer creation will compile rendering kernels if viewer is not created, render here once to compile
                 self._rasterizer.render_camera(self._cameras[0])
 
-    def update(self, force=True):
+    def update(self, force=True, auto=True):
         if force:  # force update
             self.reset()
 
         if self._viewer is not None:
             if self._viewer.is_alive():
-                self._viewer.update()
+                self._viewer.update(auto_refresh=auto)
             else:
                 gs.raise_exception("Viewer closed.")
 

--- a/genesis/vis/visualizer.py
+++ b/genesis/vis/visualizer.py
@@ -58,6 +58,18 @@ class Visualizer(RBC):
                 viewer_height = (screen.height * scale) * VIEWER_DEFAULT_HEIGHT_RATIO
                 viewer_width = viewer_height / VIEWER_DEFAULT_ASPECT_RATIO
                 viewer_options.res = (int(viewer_width), int(viewer_height))
+            if viewer_options.run_in_thread is None:
+                if gs.platform == "Linux":
+                    viewer_options.run_in_thread = True
+                elif gs.platform == "macOS":
+                    viewer_options.run_in_thread = False
+                    gs.logger.warning(
+                        "Mac OS detected. The interactive viewer will only be responsive if a simulation is running."
+                    )
+                elif gs.platform == "Windows":
+                    viewer_options.run_in_thread = True
+            if gs.platform == "macOS" and viewer_options.run_in_thread:
+                gs.raise_exception("Running viewer in background thread is not supported on MacOS.")
 
             self._viewer = Viewer(viewer_options, self._context)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ genesis = [
 
 [tool.black]
 line-length = 120
+force-exclude = '''
+/(
+    genesis/ext
+)/
+'''
 
 [tool.pytest.ini_options]
 addopts = [


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description

This PR fixes several issues:
* compilation on Apple Metal. 
* silencing on libc stderr at import that was breaking Taichi tracing even after restoring pipe
* black formatter running on external dependencies

This PR adds an option to force disabling running the viewer on a background thread, and provides an example that maintains maximum performance on all platforms.

## How Has This Been / Can This Be Tested?

Running franka tutorial on Apple Silicon machine with Metal backend enabled.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
