### PR TITLE
[BUG_FIX]: gs view cli fix for macOS

### DIFF
--- a/genesis/_main.py
+++ b/genesis/_main.py
@@ -78,7 +78,7 @@ class JointControlGUI:
 def get_movable_dofs(robot):
     motor_dofs = []
     motor_dof_names = []
-    
+
     if gs.platform == "macOS":
         # Flatten the nested list structure for macOS
         all_joints = []
@@ -87,9 +87,8 @@ def get_movable_dofs(robot):
                 all_joints.append(joint)
         joints_to_process = all_joints
     else:
-        # For other platforms, assume the structure is already flat
         joints_to_process = robot.joints
-    
+
     for joint in joints_to_process:
         if joint.type == gs.JOINT_TYPE.FREE:
             continue
@@ -201,7 +200,6 @@ def view(filename, collision, rotate, scale=1.0, show_link_frame=False):
         )
         gui_process.start()
 
-        # Run the main viewer in the main thread, and update scene in another thread
         def update_scene(gui_joint_positions, motor_dofs, rotate, entity, dt, stop_event):
             t = 0
             while not stop_event.is_set():
@@ -215,19 +213,15 @@ def view(filename, collision, rotate, scale=1.0, show_link_frame=False):
                     dofs_idx_local=motor_dofs,
                     zero_velocity=True,
                 )
-                # Don't call scene.visualizer.update() from this thread
-                # Let the main thread handle it
-                
-        # Start the update thread
+
         gs.tools.run_in_another_thread(
-            fn=update_scene, 
-            args=(gui_joint_positions, motor_dofs, rotate, entity, dt, stop_event)
+            fn=update_scene, args=(gui_joint_positions, motor_dofs, rotate, entity, dt, stop_event)
         )
-        
+
         # Main thread handles the viewer updates
         while scene.viewer.is_alive() and not stop_event.is_set():
             scene.visualizer.update(force=True)
-            
+
         # Clean up when viewer is closed
         stop_event.set()
         gui_process.terminate()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->
Fixes gs view cli bug.

When running `genesis view` on macOS, I encountered an error related to joints iteration in the `get_movable_dofs` function. The issue stems from a platform-specific difference in how joint data is structured:

- On macOS, the `robot.joints` property returns a nested list structure (a List of Lists), while on other platforms it appears to return a flat list.
- When the code tries to iterate through `robot.joints` and access `joint.type` directly, it fails on macOS because it's trying to access a property on a List object rather than a joint object.

- I've added special handling for macOS that flattens the nested list structure before iterating through the joints.
- For other platforms, the existing approach is maintained for backward compatibility.
- This platform-specific approach ensures the code works correctly regardless of the environment.

Then a new error arise related to : The Genesis viewer appears to be thread-bound, meaning it can only be updated from the thread that created it. This is a common limitation in GUI frameworks and visualization libraries.

The issue can be fixed by separating the responsibilities:
1. Use a separate thread for entity state updates (positions, rotations)
2. Keep all viewer updates in the main thread

I've implemented a solution that:
- Uses `run_in_another_thread` for calculations and entity state updates
- Keeps the viewer refresh cycle in the main thread
- Properly handles cleanup when the viewer is closed

## Related Issue
Resolves Genesis-Embodied-AI/Genesis#905

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If you need to test any mesh, URDF files you can finally use the gs view to render it correctly.
## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
``` bash
#on macOS after installing the environment from root
gs view genesis/assets/meshes/Airplane/airplane.obj
```
## Screenshots (if appropriate):
**Before fix:**
<img width="705" alt="Screenshot 2025-03-21 at 19 57 18" src="https://github.com/user-attachments/assets/7ccb9e07-75af-410d-bb4a-46dabd433af5" />

**After fix:**
<img width="676" alt="Screenshot 2025-03-21 at 19 15 51" src="https://github.com/user-attachments/assets/9b2b0bcf-6a2f-443d-9125-0a2044d4b9f7" />


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ✅] I read the **CONTRIBUTING** document.
- [✅ ] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [✅ ] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [✅ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [✅ ] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
