### PR TITLE
[BUG FIX] Improve loading of MJCF visual meshes.

### DIFF
--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -60,7 +60,7 @@ def init(
     global platform
     platform = get_platform()
     if backend is None:
-        if debug or platform == "macOS":
+        if debug:
             backend = gs_backend.cpu
         else:
             backend = gs_backend.gpu
@@ -83,7 +83,7 @@ def init(
     if backend not in GS_ARCH[platform]:
         raise_exception(f"backend ~~<{backend}>~~ not supported for platform ~~<{platform}>~~")
     if backend == gs_backend.metal:
-        logger.warning("Beware Apple Metal backend is partially broken.")
+        logger.info("Beware Apple Metal backend may be unstable.")
 
     # get default device and compute total device memory
     global device

--- a/genesis/utils/misc.py
+++ b/genesis/utils/misc.py
@@ -127,6 +127,7 @@ def get_device(backend: gs_backend):
             device_name = device_property.name
             total_mem = device_property.total_memory / 1024**3
         else:  # pytorch tensors on cpu
+            gs.logger.warning("Vulkan support only available on Intel XPU device. Falling back to CPU.")
             device, device_name, total_mem, _ = get_device(gs_backend.cpu)
 
     elif backend == gs_backend.gpu:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 from itertools import chain
 from enum import Enum
 
+import psutil
 import pytest
 import pyglet
 import numpy as np
@@ -17,6 +18,15 @@ def pytest_make_parametrize_id(config, val, argname):
     if isinstance(val, Enum):
         return val.name
     return f"{val}"
+
+
+def pytest_xdist_auto_num_workers(config):
+    if config.option.numprocesses == "auto":
+        physical_core_count = psutil.cpu_count(logical=False)
+        _, _, ram_memory, _ = gs.utils.get_device(gs.cpu)
+        _, _, vram_memory, _ = gs.utils.get_device(gs.gpu)
+        return min(int(ram_memory / 4.0), int(vram_memory / 1.0), physical_core_count)
+    return config.option.numprocesses
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
## Description

This PR parses the group field of geometries to decide whether or not a visual geometry should be added for a given collision geometry.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/140
Related to Genesis-Embodied-AI/Genesis/issues/205

## Motivation and Context

Currently, collision meshes are not rendered by default, unless there is no visual geometry associated with a given body. This is not enough to replicate the behaviour of Mujoco. It is also necessary to take into account the visual group of each geometry (1 and 2 are rendered by default).

## How Has This Been / Can This Be Tested?

Load metaworld 'sawyer_pick_place_v2.xml' asset as described in the issue, along the existing franka and ur5e assets.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.