### PR TITLE
[BUG FIX] Fix viewer crash when canceling save dialog.

### DIFF
--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -559,11 +559,13 @@ class Viewer(pyglet.window.Window):
             a file dialog will be opened to ask the user where
             to save the video file.
         """
+        self.video_recorder.close()
         if filename is None:
             filename = self._get_save_filename(["mp4"])
-
-        self.video_recorder.close()
-        shutil.move(self.video_recorder.filename, filename)
+        if filename is None:
+            os.remove(self.video_recorder.filename)
+        else:
+            shutil.move(self.video_recorder.filename, filename)
 
     def on_close(self):
         """Exit the event loop when the window is closed."""
@@ -1021,7 +1023,7 @@ class Viewer(pyglet.window.Window):
         except Exception:
             return None
 
-        if filename == ():
+        if not filename:
             return None
         return filename
 


### PR DESCRIPTION
## Description

This PR fixes handling of cancelled dialog when asked to choose a file path for saving pictures or videos of the viewer. When it happens, nothing is saved and simulation resumes flawlessly instead of picking some random default location. I think this behaviour is closer to what the user would expect.

## Related Issue

Supersedes Genesis-Embodied-AI/Genesis/pull/834

## Motivation and Context

Currently, when saving pictures and videos of the viewer, closing the file dialog without closing any file crashes the viewer, which is not acceptable.

## How Has This Been / Can This Be Tested?

Running Franka tutorial on my machine with viewer enabled and trying the save pictures and videos.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
