### PR TITLE
[BUG FIX] Fix fragile libompl dynamic library import logics.

### DIFF
--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -1,10 +1,12 @@
 # import taichi while suppressing its output
 import os
 import sys
+import site
 import ctypes
 import atexit
 import logging as _logging
 import traceback
+from platform import system
 from unittest.mock import patch
 
 _ti_outputs = []
@@ -31,6 +33,50 @@ _initialized = False
 backend = None
 exit_callbacks = []
 global_scene_list = set()
+
+
+############ fix python DLL search dir for OMPL ############
+try:
+    import ompl
+
+    _is_ompl_available = True
+except ImportError:
+    _is_ompl_available = False
+
+
+def dll_loader(lib, path):
+    # First, try the user-specified path
+    sys = system()
+    if sys == "Windows":
+        ext = ".dll"
+    elif sys == "Darwin":
+        ext = ".dylib"
+    else:  # Linux, other UNIX systems
+        ext = ".so"
+    fname = f"lib{lib}{ext}"
+    fpath = os.path.join(path, fname)
+
+    # Fallback to site-packages
+    if not os.path.isfile(fpath):
+        for sitepackagedir in site.getsitepackages():
+            for _fname in os.listdir(sitepackagedir):
+                _fpath = os.path.join(sitepackagedir, _fname)
+                if os.path.isfile(_fpath):
+                    if _fname.startswith(fname):
+                        fpath = _fpath
+                        break
+
+    # Fallback to system loading and pray
+    if not os.path.isfile(fpath):
+        fpath = find_library(lib)
+
+    cdll = ctypes.CDLL(fpath, ctypes.RTLD_GLOBAL)
+    if cdll is None:
+        gs.raise_exception(f"Failed to load dynamic library '{lib}' (search path '{path}').")
+
+
+if _is_ompl_available:
+    ompl.dll_loader = dll_loader
 
 
 ########################## init ##########################

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1403,7 +1403,7 @@ class RigidEntity(Entity):
             from ompl import util as ou
 
             ou.setLogLevel(ou.LOG_ERROR)
-        except Exception as e:
+        except ImportError as e:
             gs.raise_exception_from(
                 "Failed to import OMPL. Did you install? (For installation instructions, see "
                 "https://genesis-world.readthedocs.io/en/latest/user_guide/overview/installation.html#optional-motion-planning)",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description

This PR looks for the site packages directories first when failing to import OMPL dynamic libraries, and only fallbacks to system libraries if it does not works. Raises an exception if not found, which was not the case previously.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/366
Resolves Genesis-Embodied-AI/Genesis/issues/401
Resolves Genesis-Embodied-AI/Genesis/issues/318
Related to Genesis-Embodied-AI/Genesis/issues/505
Related to Genesis-Embodied-AI/Genesis/issues/749 

## Motivation and Context

Currently, the import logics of OMPL dynamics shared libraries is quite fragile and causes segfault if a different version is already installed on the system. Fixing this issue is important because it would be too difficult to debug for the average user. This bug has been reported [ompl repository](https://github.com/ompl/ompl/issues/1121).

## How Has This Been / Can This Be Tested?

Running the unit tests on a machine affected by this issue.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
