### PR TITLE
[MISC] Refactor rigid body data accessors.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1657,6 +1657,7 @@ class RigidEntity(Entity):
         vel : torch.Tensor, shape (3,) or (n_envs, 3)
             The linear velocity of the entity's base link.
         """
+        # TODO: This would require tensor allocation because the velocity is not pre-computed
         return self._solver.get_links_vel([self.base_link_idx], envs_idx).squeeze(-2)
 
     @gs.assert_built
@@ -1677,7 +1678,7 @@ class RigidEntity(Entity):
         return self._solver.get_links_ang([self.base_link_idx], envs_idx).squeeze(-2)
 
     @gs.assert_built
-    def get_links_pos(self, ls_idx_local=None, envs_idx=None):
+    def get_links_pos(self, ls_idx_local=None, envs_idx=None, *, unsafe=False):
         """
         Returns position of all the entity's links.
 
@@ -1694,10 +1695,10 @@ class RigidEntity(Entity):
             The position of all the entity's links.
         """
         links_idx = self._get_idx(ls_idx_local, self.n_links, self._link_start, unsafe=True)
-        return self._solver.get_links_pos(links_idx, envs_idx)
+        return self._solver.get_links_pos(links_idx, envs_idx, unsafe=unsafe)
 
     @gs.assert_built
-    def get_links_quat(self, ls_idx_local=None, envs_idx=None):
+    def get_links_quat(self, ls_idx_local=None, envs_idx=None, *, unsafe=False):
         """
         Returns quaternion of all the entity's links.
 
@@ -1714,10 +1715,10 @@ class RigidEntity(Entity):
             The quaternion of all the entity's links.
         """
         links_idx = self._get_idx(ls_idx_local, self.n_links, self._link_start, unsafe=True)
-        return self._solver.get_links_quat(links_idx, envs_idx)
+        return self._solver.get_links_quat(links_idx, envs_idx, unsafe=unsafe)
 
     @gs.assert_built
-    def get_links_vel(self, ls_idx_local=None, envs_idx=None):
+    def get_links_vel(self, ls_idx_local=None, envs_idx=None, *, unsafe=False):
         """
         Returns linear velocity of all the entity's links.
 
@@ -1734,10 +1735,10 @@ class RigidEntity(Entity):
             The linear velocity of all the entity's links.
         """
         links_idx = self._get_idx(ls_idx_local, self.n_links, self._link_start, unsafe=True)
-        return self._solver.get_links_vel(links_idx, envs_idx)
+        return self._solver.get_links_vel(links_idx, envs_idx, unsafe=unsafe)
 
     @gs.assert_built
-    def get_links_ang(self, ls_idx_local=None, envs_idx=None):
+    def get_links_ang(self, ls_idx_local=None, envs_idx=None, *, unsafe=False):
         """
         Returns angular velocity of all the entity's links.
 
@@ -1754,10 +1755,10 @@ class RigidEntity(Entity):
             The angular velocity of all the entity's links.
         """
         links_idx = self._get_idx(ls_idx_local, self.n_links, self._link_start, unsafe=True)
-        return self._solver.get_links_ang(links_idx, envs_idx)
+        return self._solver.get_links_ang(links_idx, envs_idx, unsafe=unsafe)
 
     @gs.assert_built
-    def get_links_acc(self, ls_idx_local=None, envs_idx=None):
+    def get_links_acc(self, ls_idx_local=None, envs_idx=None, *, unsafe=False):
         """
         Returns linear acceleration of the specified entity's links. (Mimicking accelerometer)
 
@@ -1774,17 +1775,17 @@ class RigidEntity(Entity):
             The linear acceleration of the specified entity's links.
         """
         links_idx = self._get_idx(ls_idx_local, self.n_links, self._link_start, unsafe=True)
-        return self._solver.get_links_acc(links_idx, envs_idx)
+        return self._solver.get_links_acc(links_idx, envs_idx, unsafe=unsafe)
 
     @gs.assert_built
-    def get_links_inertial_mass(self, ls_idx_local=None, envs_idx=None):
+    def get_links_inertial_mass(self, ls_idx_local=None, envs_idx=None, *, unsafe=False):
         links_idx = self._get_idx(ls_idx_local, self.n_links, self._link_start, unsafe=True)
-        return self._solver.get_links_inertial_mass(links_idx, envs_idx)
+        return self._solver.get_links_inertial_mass(links_idx, envs_idx, unsafe=unsafe)
 
     @gs.assert_built
-    def get_links_invweight(self, ls_idx_local=None, envs_idx=None):
+    def get_links_invweight(self, ls_idx_local=None, envs_idx=None, *, unsafe=False):
         links_idx = self._get_idx(ls_idx_local, self.n_links, self._link_start, unsafe=True)
-        return self._solver.get_links_invweight(links_idx, envs_idx)
+        return self._solver.get_links_invweight(links_idx, envs_idx, unsafe=unsafe)
 
     @gs.assert_built
     def set_pos(self, pos, zero_velocity=True, envs_idx=None):

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -786,7 +786,7 @@ class RigidEntity(Entity):
             Pose error for each target. The 6-vector is [err_pos_x, err_pos_y, err_pos_z, err_rot_x, err_rot_y, err_rot_z]. Only returned if `return_error` is True.
         """
         if self._solver.n_envs > 0:
-            envs_idx = self._solver._get_envs_idx(envs_idx)
+            envs_idx = self._solver._sanitize_envs_idx(envs_idx)
 
             if pos is not None:
                 if pos.shape[0] != len(envs_idx):
@@ -888,7 +888,7 @@ class RigidEntity(Entity):
             Pose error for each target. The 6-vector is [err_pos_x, err_pos_y, err_pos_z, err_rot_x, err_rot_y, err_rot_z]. Only returned if `return_error` is True.
         """
         if self._solver.n_envs > 0:
-            envs_idx = self._solver._get_envs_idx(envs_idx)
+            envs_idx = self._solver._sanitize_envs_idx(envs_idx)
 
         if not self._requires_jac_and_IK:
             gs.raise_exception(
@@ -1308,7 +1308,7 @@ class RigidEntity(Entity):
             qpos = qpos.unsqueeze(0)
             envs_idx = torch.zeros(1, dtype=gs.tc_int)
         else:
-            envs_idx = self._solver._get_envs_idx(envs_idx)
+            envs_idx = self._solver._sanitize_envs_idx(envs_idx)
 
         links_idx = self._get_ls_idx(ls_idx_local)
         links_pos = torch.empty((len(envs_idx), len(links_idx), 3), dtype=gs.tc_float, device=gs.device)
@@ -2323,7 +2323,7 @@ class RigidEntity(Entity):
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         """
 
-        envs_idx = self._solver._get_envs_idx(envs_idx)
+        envs_idx = self._solver._sanitize_envs_idx(envs_idx)
         if self._solver.n_envs == 0:
             qvel = torch.zeros(self.n_dofs, dtype=gs.tc_float, device=gs.device)
             self.set_dofs_velocity(qvel)

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1788,7 +1788,7 @@ class RigidEntity(Entity):
         return self._solver.get_links_invweight(links_idx, envs_idx, unsafe=unsafe)
 
     @gs.assert_built
-    def set_pos(self, pos, zero_velocity=True, envs_idx=None):
+    def set_pos(self, pos, envs_idx=None, *, zero_velocity=True):
         """
         Set position of the entity's base link.
 
@@ -1804,21 +1804,12 @@ class RigidEntity(Entity):
 
         if self.base_link.is_fixed:
             gs.logger.warning("Base link is fixed. Overriding base link pose.")
-
-        pos = torch.as_tensor(pos)
-        if self._solver.n_envs == 0:
-            if pos.ndim != 1:
-                gs.raise_exception("`pos` must be a 1D tensor for unparallelized scene.")
-        else:
-            if pos.ndim != 2:
-                gs.raise_exception("`pos` must be a 2D tensor for parallelized scene.")
-
-        self._solver.set_links_pos(pos.unsqueeze(-2), [self.base_link_idx], envs_idx, skip_forward=zero_velocity)
+        self._solver.set_base_links_pos(pos.unsqueeze(-2), [self.base_link_idx], envs_idx, skip_forward=zero_velocity)
         if zero_velocity:
             self.zero_all_dofs_velocity(envs_idx)
 
     @gs.assert_built
-    def set_quat(self, quat, zero_velocity=True, envs_idx=None):
+    def set_quat(self, quat, envs_idx=None, *, zero_velocity=True):
         """
         Set quaternion of the entity's base link.
 
@@ -1834,18 +1825,7 @@ class RigidEntity(Entity):
 
         if self.base_link.is_fixed:
             gs.logger.warning("Base link is fixed. Overriding base link pose.")
-
-        quat = torch.as_tensor(quat)
-        if self._solver.n_envs == 0:
-            if quat.ndim != 1:
-                gs.raise_exception("`quat` must be a 1D tensor for unparallelized scene.")
-        else:
-            if quat.ndim != 2:
-                gs.raise_exception("`quat` must be a 2D tensor for parallelized scene.")
-
-        self._solver.set_links_quat(
-            torch.as_tensor(quat).unsqueeze(-2), [self.base_link_idx], envs_idx, skip_forward=zero_velocity
-        )
+        self._solver.set_base_links_quat(quat.unsqueeze(-2), [self.base_link_idx], envs_idx, skip_forward=zero_velocity)
         if zero_velocity:
             self.zero_all_dofs_velocity(envs_idx)
 

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1915,7 +1915,10 @@ class RigidEntity(Entity):
     def _get_idx(self, idx_local, idx_local_max, idx_global_start=0, *, unsafe=False):
         # Handling default argument and special cases
         if idx_local is None:
-            idx_global = slice(idx_global_start, idx_local_max + idx_global_start)
+            if unsafe:
+                idx_global = slice(idx_global_start, idx_local_max + idx_global_start)
+            else:
+                idx_global = range(idx_global_start, idx_local_max + idx_global_start)
         elif isinstance(idx_local, (range, slice)):
             idx_global = range(
                 (idx_local.start or 0) + idx_global_start,
@@ -1942,7 +1945,7 @@ class RigidEntity(Entity):
 
         if idx_global.ndim != 1:
             gs.raise_exception("Expecting a 1D tensor for `idx_local`.")
-        if (idx_global < 0).any() or (idx_local >= idx_global_start + idx_local_max).any():
+        if (idx_global < 0).any() or (idx_global >= idx_global_start + idx_local_max).any():
             gs.raise_exception("`idx_local` exceeds valid range.")
 
         return idx_global

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1915,10 +1915,16 @@ class RigidEntity(Entity):
         # Handling default argument and special cases
         if idx_local is None:
             idx_global = slice(idx_global_start, idx_local_max + idx_global_start)
+        elif isinstance(idx_local, (range, slice)):
+            idx_global = range(
+                (idx_local.start or 0) + idx_global_start,
+                (idx_local.stop if idx_local.stop is not None else idx_local_max) + idx_global_start,
+                idx_local.step or 1,
+            )
         elif isinstance(idx_local, int):
             idx_global = idx_local + idx_global_start
         elif isinstance(idx_local, (list, tuple)):
-            idx_global = [i + idx_local for i in idx_local]
+            idx_global = [i + idx_global_start for i in idx_local]
         else:
             # Increment may be slow when dealing with heterogenuous data, so it must be avoided if possible
             if idx_global_start > 0:
@@ -1957,7 +1963,7 @@ class RigidEntity(Entity):
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         """
         qs_idx = self._get_idx(qs_idx_local, self.n_qs, self._q_start, unsafe=True)
-        self._solver.set_qpos(qpos, qs, envs_idx)
+        self._solver.set_qpos(qpos, qs_idx, envs_idx)
         if zero_velocity:
             self.zero_all_dofs_velocity(envs_idx)
 

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1034,7 +1034,7 @@ class RigidEntity(Entity):
             respect_joint_limit,
             envs_idx,
         )
-        qpos = self._IK_qpos_best.to_torch(gs.device).tranpose(1, 0)
+        qpos = self._IK_qpos_best.to_torch(gs.device).transpose(1, 0)
         if self._solver.n_envs > 0:
             qpos = qpos[envs_idx]
         else:
@@ -1929,6 +1929,7 @@ class RigidEntity(Entity):
         return self._get_dofs_idx_local(dofs_idx_local) + self._dof_start
 
     def _get_ls_idx_local(self, ls_idx_local=None):
+        # FIXME: Should avoid allocating memory systematically, and through warning if necessary
         if ls_idx_local is None:
             ls_idx_local = torch.arange(self.n_links, dtype=torch.int32, device=gs.device)
         else:

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -21,6 +21,11 @@ IMP_MIN = 0.0001
 # maximum constraint impedance
 IMP_MAX = 0.9999
 
+ALLOCATE_TENSOR_WARNING = (
+    "Tensor had to converted because dtype or device are incorrect or memory is not contiguous. This may dramatically "
+    "impede performance if it occurs in the critical path of your application."
+)
+
 
 def _sanitize_sol_params(sol_params, substep_dt, default_resolve_time=None):
     timeconst, dampratio, dmin, dmax, width, mid, power = sol_params.T
@@ -2617,9 +2622,10 @@ class RigidSolver(Solver):
                 n_awake_links = ti.atomic_add(self.n_awake_links[i_b], 1)
                 self.awake_links[n_awake_links, i_b] = i_l
 
-    def apply_links_external_force(self, force, links_idx, envs_idx=None):
-        force, links_idx, envs_idx = self._validate_2D_io_variables(force, links_idx, 3, envs_idx, idx_name="links_idx")
-
+    def apply_links_external_force(self, force, links_idx, envs_idx=None, *, unsafe=False):
+        force, links_idx, envs_idx = self._sanitize_2D_io_variables(
+            force, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
+        )
         self._kernel_apply_links_external_force(force, links_idx, envs_idx)
 
     @ti.kernel
@@ -2634,11 +2640,10 @@ class RigidSolver(Solver):
             for i in ti.static(range(3)):
                 self.links_state[links_idx[i_l_], envs_idx[i_b_]].cfrc_ext_vel[i] -= force[i_b_, i_l_, i]
 
-    def apply_links_external_torque(self, torque, links_idx, envs_idx=None):
-        torque, links_idx, envs_idx = self._validate_2D_io_variables(
-            torque, links_idx, 3, envs_idx, idx_name="links_idx"
+    def apply_links_external_torque(self, torque, links_idx, envs_idx=None, *, unsafe=False):
+        torque, links_idx, envs_idx = self._sanitize_2D_io_variables(
+            torque, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
         )
-
         self._kernel_apply_links_external_torque(torque, links_idx, envs_idx)
 
     @ti.kernel
@@ -3457,7 +3462,7 @@ class RigidSolver(Solver):
 
     def set_state(self, f, state, envs_idx=None):
         if self.is_active():
-            envs_idx = self._get_envs_idx(envs_idx)
+            envs_idx = self._sanitize_envs_idx(envs_idx)
             self._kernel_set_state(
                 state.qpos,
                 state.dofs_vel,
@@ -3528,143 +3533,167 @@ class RigidSolver(Solver):
     # ------------------------------------ control ---------------------------------------
     # ------------------------------------------------------------------------------------
 
-    def _get_envs_idx(self, envs_idx):
+    def _sanitize_envs_idx(self, envs_idx, *, unsafe=False):
+        # Handling default arguments
         if envs_idx is None:
-            envs_idx = self._scene._envs_idx
+            return self._scene._envs_idx
 
-        else:
-            if self.n_envs == 0:
-                gs.raise_exception("`envs_idx` is not supported for non-parallelized scene.")
+        # Early return if unsafe
+        if unsafe:
+            return envs_idx
 
-            envs_idx = torch.as_tensor(envs_idx, dtype=gs.tc_int, device=gs.device).contiguous()
+        # Perform a bunch of sanity checks
+        if self.n_envs == 0:
+            gs.raise_exception("`envs_idx` is not supported for non-parallelized scene.")
 
-            if envs_idx.ndim != 1:
-                gs.raise_exception("Expecting a 1D tensor for `envs_idx`.")
+        _envs_idx = torch.as_tensor(envs_idx, dtype=gs.tc_int, device=gs.device).contiguous()
+        if _envs_idx is not envs_idx:
+            gs.logger.debug(ALLOCATE_TENSOR_WARNING)
 
-            if (envs_idx < 0).any() or (envs_idx >= self.n_envs).any():
-                gs.raise_exception("`envs_idx` exceeds valid range.")
+        if _envs_idx.ndim != 1:
+            gs.raise_exception("Expecting a 1D tensor for `envs_idx`.")
 
-        return envs_idx
+        if (_envs_idx < 0).any() or (_envs_idx >= self.n_envs).any():
+            gs.raise_exception("`envs_idx` exceeds valid range.")
 
-    def _validate_1D_io_variables(self, tensor, inputs_idx, envs_idx=None, batched=True, idx_name="dofs_idx"):
-        inputs_idx = torch.as_tensor(inputs_idx, dtype=gs.tc_int, device=gs.device).contiguous()
-        if inputs_idx.ndim != 1:
-            gs.raise_exception(f"Expecting 1D tensor for `{idx_name}`.")
+        return _envs_idx
 
-        if tensor is not None:
-            tensor = torch.as_tensor(tensor, dtype=gs.tc_float, device=gs.device).contiguous()
-            if tensor.shape[-1] != len(inputs_idx):
-                gs.raise_exception(f"Last dimension of the input tensor does not match length of `{idx_name}`.")
-        else:
+    def _sanitize_1D_io_variables(
+        self, tensor, inputs_idx, envs_idx, batched=True, idx_name="dofs_idx", *, unsafe=False
+    ):
+        # Handling default arguments
+        if tensor is None:
             if batched and self.n_envs > 0:
                 if envs_idx is not None:
                     B = len(envs_idx)
                 else:
                     B = self.n_envs
-                tensor = torch.empty(self._batch_shape(len(inputs_idx), True, B=B), dtype=gs.tc_float, device=gs.device)
+                shape = tself._batch_shape(len(inputs_idx), True, B=B)
             else:
-                tensor = torch.empty(len(inputs_idx), dtype=gs.tc_float, device=gs.device)
+                shape = (len(inputs_idx),)
+            _tensor = torch.empty(shape, dtype=gs.tc_float, device=gs.device)
 
-        if batched:
-            envs_idx = self._get_envs_idx(envs_idx)
-
-            if self.n_envs == 0:
-                if tensor.ndim == 1:
-                    tensor = tensor[None, :]
-                else:
-                    gs.raise_exception(
-                        f"Invalid input shape: {tensor.shape}. Expecting a 1D tensor for non-parallelized scene."
-                    )
-
+        if envs_idx is None:
+            if batched:
+                envs_idx = self._sanitize_envs_idx(envs_idx, unsafe=unsafe)
             else:
-                if tensor.ndim == 2:
-                    if tensor.shape[0] != len(envs_idx):
-                        gs.raise_exception(
-                            f"Invalid input shape: {tensor.shape}. First dimension of the input tensor does not match length of `envs_idx` (or `scene.n_envs` if `envs_idx` is None)."
-                        )
-                else:
-                    tensor = tensor.repeat(len(envs_idx), 1)
-                    gs.logger.warning(f"Input tensor is converted to {tensor.shape} for an additional batch dimension")
+                envs_idx = torch.empty((), dtype=gs.tc_int, device=gs.device)
 
-            return tensor, inputs_idx, envs_idx
+        # Early return if unsafe
+        if unsafe:
+            return _tensor, inputs_idx, envs_idx
 
-        else:
-            if tensor.ndim != 1:
-                gs.raise_exception("Expecting 1D input tensor.")
-
-            return tensor, inputs_idx
-
-    def _validate_2D_io_variables(
-        self, tensor, inputs_idx, vec_size, envs_idx=None, batched=True, idx_name="links_idx"
-    ):
-        inputs_idx = torch.as_tensor(inputs_idx, dtype=gs.tc_int, device=gs.device).contiguous()
-        if inputs_idx.ndim != 1:
+        # Perform a bunch of sanity checks
+        _inputs_idx = torch.as_tensor(inputs_idx, dtype=gs.tc_int, device=gs.device).contiguous()
+        if _inputs_idx is not inputs_idx:
+            gs.logger.debug(ALLOCATE_TENSOR_WARNING)
+        if _inputs_idx.ndim != 1:
             gs.raise_exception(f"Expecting 1D tensor for `{idx_name}`.")
 
         if tensor is not None:
-            tensor = torch.as_tensor(tensor, dtype=gs.tc_float, device=gs.device).contiguous()
-            if tensor.shape[-2] != len(inputs_idx):
+            _tensor = torch.as_tensor(tensor, dtype=gs.tc_float, device=gs.device).contiguous()
+            if _tensor is not tensor:
+                gs.logger.debug(ALLOCATE_TENSOR_WARNING)
+            if _tensor.shape[-1] != len(_inputs_idx):
+                gs.raise_exception(f"Last dimension of the input tensor does not match length of `{idx_name}`.")
+
+        if batched:
+            if self.n_envs == 0:
+                if _tensor.ndim != 1:
+                    gs.raise_exception(
+                        f"Invalid input shape: {_tensor.shape}. Expecting a 1D tensor for non-parallelized scene."
+                    )
+            else:
+                if _tensor.ndim == 2:
+                    if _tensor.shape[0] != len(envs_idx):
+                        gs.raise_exception(
+                            f"Invalid input shape: {_tensor.shape}. First dimension of the input tensor does not match "
+                            "length of `envs_idx` (or `scene.n_envs` if `envs_idx` is None)."
+                        )
+                else:
+                    gs.raise_exception(
+                        f"Invalid input shape: {_tensor.shape}. Expecting a 2D tensor for scene with parallelized envs."
+                    )
+        else:
+            if _tensor.ndim != 1:
+                gs.raise_exception("Expecting 1D input tensor.")
+        return _tensor, _inputs_idx, envs_idx
+
+    def _sanitize_2D_io_variables(
+        self, tensor, inputs_idx, vec_size, envs_idx=None, batched=True, idx_name="links_idx", *, unsafe=False
+    ):
+        # Handling default arguments
+        if tensor is None:
+            if batched and self.n_envs > 0:
+                if envs_idx is not None:
+                    B = len(envs_idx)
+                else:
+                    B = self.n_envs
+                shape = self._batch_shape((len(inputs_idx), vec_size), True, B=B)
+            else:
+                shape = (len(inputs_idx), vec_size)
+            _tensor = torch.empty(shape, dtype=gs.tc_float, device=gs.device)
+
+        if envs_idx is None:
+            if batched:
+                envs_idx = self._sanitize_envs_idx(envs_idx, unsafe=unsafe)
+            else:
+                envs_idx = torch.empty((), dtype=gs.tc_int, device=gs.device)
+
+        # Early return if unsafe
+        if unsafe:
+            return _tensor, inputs_idx, envs_idx
+
+        # Perform a bunch of sanity checks
+        _inputs_idx = torch.as_tensor(inputs_idx, dtype=gs.tc_int, device=gs.device).contiguous()
+        if _inputs_idx is not inputs_idx:
+            gs.logger.debug(ALLOCATE_TENSOR_WARNING)
+        if _inputs_idx.ndim != 1:
+            gs.raise_exception(f"Expecting 1D tensor for `{idx_name}`.")
+
+        if tensor is not None:
+            _tensor = torch.as_tensor(tensor, dtype=gs.tc_float, device=gs.device).contiguous()
+            if _tensor.shape[-2] != len(_inputs_idx):
                 gs.raise_exception(f"Second last dimension of the input tensor does not match length of `{idx_name}`.")
-            if tensor.shape[-1] != vec_size:
+            if _tensor.shape[-1] != vec_size:
                 gs.raise_exception(f"Last dimension of the input tensor must be {vec_size}.")
 
-        else:
-            if batched and self.n_envs > 0:
-                if envs_idx is not None:
-                    B = len(envs_idx)
-                else:
-                    B = self.n_envs
-                tensor = torch.empty(
-                    self._batch_shape((len(inputs_idx), vec_size), True, B=B), dtype=gs.tc_float, device=gs.device
-                )
-            else:
-                tensor = torch.empty((len(inputs_idx), vec_size), dtype=gs.tc_float, device=gs.device)
-
         if batched:
-            envs_idx = self._get_envs_idx(envs_idx)
-
             if self.n_envs == 0:
-                if tensor.ndim == 2:
-                    tensor = tensor[None, :]
-                else:
+                if _tensor.ndim != 2:
                     gs.raise_exception(
-                        f"Invalid input shape: {tensor.shape}. Expecting a 2D tensor for non-parallelized scene."
+                        f"Invalid input shape: {_tensor.shape}. Expecting a 2D tensor for non-parallelized scene."
                     )
 
             else:
-                if tensor.ndim == 3:
-                    if tensor.shape[0] != len(envs_idx):
+                if _tensor.ndim == 3:
+                    if _tensor.shape[0] != len(envs_idx):
                         gs.raise_exception(
-                            f"Invalid input shape: {tensor.shape}. First dimension of the input tensor does not match length of `envs_idx` (or `scene.n_envs` if `envs_idx` is None)."
+                            f"Invalid input shape: {_tensor.shape}. First dimension of the input tensor does not match "
+                            "length of `envs_idx` (or `scene.n_envs` if `envs_idx` is None)."
                         )
                 else:
                     gs.raise_exception(
-                        f"Invalid input shape: {tensor.shape}. Expecting a 3D tensor for scene with parallelized envs."
+                        f"Invalid input shape: {_tensor.shape}. Expecting a 3D tensor for scene with parallelized envs."
                     )
-
-            return tensor, inputs_idx, envs_idx
-
         else:
-            if tensor.ndim != 2:
+            if _tensor.ndim != 2:
                 gs.raise_exception("Expecting 2D input tensor.")
-
-            return tensor, inputs_idx
+        return _tensor, _inputs_idx, envs_idx
 
     def _get_qs_idx(self, qs_idx_local=None):
         return self._get_qs_idx_local(qs_idx_local) + self._q_start
 
-    def set_links_pos(self, pos, links_idx, envs_idx=None):
+    def set_links_pos(self, pos, links_idx, envs_idx=None, *, unsafe=False, skip_forward=False):
         """
         Only effetive for base links.
         """
-        pos, links_idx, envs_idx = self._validate_2D_io_variables(pos, links_idx, 3, envs_idx, idx_name="links_idx")
-
-        self._kernel_set_links_pos(
-            pos,
-            links_idx,
-            envs_idx,
+        pos, links_idx, envs_idx = self._sanitize_2D_io_variables(
+            pos, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
         )
-        self._kernel_forward_kinematics_links_geoms(envs_idx)
+        self._kernel_set_links_pos(pos, links_idx, envs_idx)
+        if not skip_forward:
+            self._kernel_forward_kinematics_links_geoms(envs_idx)
 
     @ti.kernel
     def _kernel_set_links_pos(
@@ -3686,18 +3715,16 @@ class RigidSolver(Solver):
                 for i in ti.static(range(3)):
                     self.qpos[q_start + i, envs_idx[i_b_]] = pos[i_b_, i_l_, i]
 
-    def set_links_quat(self, quat, links_idx, envs_idx=None):
+    def set_links_quat(self, quat, links_idx, envs_idx=None, *, unsafe=False, skip_forward=False):
         """
         Only effetive for base links.
         """
-        quat, links_idx, envs_idx = self._validate_2D_io_variables(quat, links_idx, 4, envs_idx, idx_name="links_idx")
-
-        self._kernel_set_links_quat(
-            quat,
-            links_idx,
-            envs_idx,
+        quat, links_idx, envs_idx = self._sanitize_2D_io_variables(
+            quat, links_idx, 4, envs_idx, idx_name="links_idx", unsafe=unsafe
         )
-        self._kernel_forward_kinematics_links_geoms(envs_idx)
+        self._kernel_set_links_quat(quat, links_idx, envs_idx)
+        if skip_forward:
+            self._kernel_forward_kinematics_links_geoms(envs_idx)
 
     @ti.kernel
     def _kernel_set_links_quat(
@@ -3719,8 +3746,10 @@ class RigidSolver(Solver):
                 for i in ti.static(range(4)):
                     self.qpos[q_start + i + 3, envs_idx[i_b_]] = quat[i_b_, i_l_, i]
 
-    def set_links_mass_shift(self, mass, links_idx, envs_idx=None):
-        mass, links_idx, envs_idx = self._validate_1D_io_variables(mass, links_idx, envs_idx, idx_name="links_idx")
+    def set_links_mass_shift(self, mass, links_idx, envs_idx=None, *, unsafe=False):
+        mass, links_idx, envs_idx = self._sanitize_1D_io_variables(
+            mass, links_idx, envs_idx, idx_name="links_idx", unsafe=unsafe
+        )
 
         self._kernel_set_links_mass_shift(mass, links_idx, envs_idx)
 
@@ -3735,9 +3764,10 @@ class RigidSolver(Solver):
         for i_l_, i_b_ in ti.ndrange(links_idx.shape[0], envs_idx.shape[0]):
             self.links_state[links_idx[i_l_], envs_idx[i_b_]].mass_shift = mass[i_b_, i_l_]
 
-    def set_links_COM_shift(self, com, links_idx, envs_idx=None):
-        com, links_idx, envs_idx = self._validate_2D_io_variables(com, links_idx, 3, envs_idx, idx_name="links_idx")
-
+    def set_links_COM_shift(self, com, links_idx, envs_idx=None, *, unsafe=False):
+        com, links_idx, envs_idx = self._sanitize_2D_io_variables(
+            com, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
+        )
         self._kernel_set_links_COM_shift(com, links_idx, envs_idx)
 
     @ti.kernel
@@ -3752,15 +3782,10 @@ class RigidSolver(Solver):
             for i in ti.static(range(3)):
                 self.links_state[links_idx[i_l_], envs_idx[i_b_]].i_pos_shift[i] = com[i_b_, i_l_, i]
 
-    def _set_links_info(self, tensor, links_idx, name, envs_idx=None):
-        if self._options.batch_links_info:
-            tensor, links_idx, envs_idx = self._validate_1D_io_variables(
-                tensor, links_idx, envs_idx, idx_name="links_idx"
-            )
-        else:
-            tensor, links_idx = self._validate_1D_io_variables(tensor, links_idx, idx_name="links_idx", batched=False)
-            envs_idx = torch.empty(())
-
+    def _set_links_info(self, tensor, links_idx, name, envs_idx=None, *, unsafe=False):
+        tensor, links_idx, envs_idx = self._sanitize_1D_io_variables(
+            tensor, links_idx, batched=self._options.batch_links_info, idx_name="links_idx", unsafe=unsafe
+        )
         if name == "invweight":
             self._kernel_set_links_invweight(tensor, links_idx, envs_idx)
         elif name == "inertial_mass":
@@ -3804,11 +3829,10 @@ class RigidSolver(Solver):
             for i_l_ in range(links_idx.shape[0]):
                 self.links_info[links_idx[i_l_]].invweight = invweight[i_l_]
 
-    def set_geoms_friction_ratio(self, friction_ratio, geoms_idx, envs_idx=None):
-        friction_ratio, geoms_idx, envs_idx = self._validate_1D_io_variables(
-            friction_ratio, geoms_idx, envs_idx, idx_name="geoms_idx"
+    def set_geoms_friction_ratio(self, friction_ratio, geoms_idx, envs_idx=None, *, unsafe=False):
+        friction_ratio, geoms_idx, envs_idx = self._sanitize_1D_io_variables(
+            friction_ratio, geoms_idx, envs_idx, idx_name="geoms_idx", unsafe=unsafe
         )
-
         self._kernel_set_geoms_friction_ratio(friction_ratio, geoms_idx, envs_idx)
 
     @ti.kernel
@@ -3822,20 +3846,18 @@ class RigidSolver(Solver):
         for i_g_, i_b_ in ti.ndrange(geoms_idx.shape[0], envs_idx.shape[0]):
             self.geoms_state[geoms_idx[i_g_], envs_idx[i_b_]].friction_ratio = friction_ratio[i_b_, i_g_]
 
-    def set_qpos(self, qpos, qs_idx, envs_idx=None):
-        qpos, qs_idx, envs_idx = self._validate_1D_io_variables(qpos, qs_idx, envs_idx, idx_name="qs_idx")
-
-        self._kernel_set_qpos(
-            qpos,
-            qs_idx,
-            envs_idx,
+    def set_qpos(self, qpos, qs_idx, envs_idx=None, *, unsafe=False, skip_forward=False):
+        qpos, qs_idx, envs_idx = self._sanitize_1D_io_variables(
+            qpos, qs_idx, envs_idx, idx_name="qs_idx", unsafe=unsafe
         )
+        self._kernel_set_qpos(qpos, qs_idx, envs_idx)
         self.collider.reset(envs_idx)
         self.collider.clear(envs_idx)
         if self.constraint_solver is not None:
             self.constraint_solver.reset(envs_idx)
             self.constraint_solver.clear(envs_idx)
-        self._kernel_forward_kinematics_links_geoms(envs_idx)
+        if skip_forward:
+            self._kernel_forward_kinematics_links_geoms(envs_idx)
 
     @ti.kernel
     def _kernel_set_qpos(
@@ -3879,21 +3901,11 @@ class RigidSolver(Solver):
             for j in ti.static(range(7)):
                 self.dofs_info[I].sol_params[j] = sol_params[j]
 
-    def _set_dofs_info(self, tensor_list, dofs_idx, name, envs_idx=None):
-        if self._options.batch_dofs_info:
-            for i, tensor in enumerate(tensor_list):
-                if i == (len(tensor_list) - 1):
-                    tensor_list[i], dofs_idx, envs_idx = self._validate_1D_io_variables(tensor, dofs_idx, envs_idx)
-                else:
-                    tensor_list[i], _, _ = self._validate_1D_io_variables(tensor, dofs_idx, envs_idx)
-        else:
-            for i, tensor in enumerate(tensor_list):
-                if i == (len(tensor_list) - 1):
-                    tensor_list[i], _ = self._validate_1D_io_variables(tensor, dofs_idx, batched=False)
-                else:
-                    tensor_list[i], dofs_idx = self._validate_1D_io_variables(tensor, dofs_idx, batched=False)
-            envs_idx = torch.empty(())
-
+    def _set_dofs_info(self, tensor_list, dofs_idx, name, envs_idx=None, *, unsafe=False):
+        for i, tensor in enumerate(tensor_list):
+            tensor_list[i], dofs_idx, envs_idx = self._sanitize_1D_io_variables(
+                tensor, dofs_idx, envs_idx, batched=self._options.batch_dofs_info, unsafe=unsafe
+            )
         if name == "kp":
             self._kernel_set_dofs_kp(tensor_list[0], dofs_idx, envs_idx)
         elif name == "kv":
@@ -4063,13 +4075,9 @@ class RigidSolver(Solver):
                 self.dofs_info[dofs_idx[i_d_]].limit[0] = lower[i_d_]
                 self.dofs_info[dofs_idx[i_d_]].limit[1] = upper[i_d_]
 
-    def set_dofs_velocity(self, velocity, dofs_idx, envs_idx=None):
-        velocity, dofs_idx, envs_idx = self._validate_1D_io_variables(velocity, dofs_idx, envs_idx)
-        self._kernel_set_dofs_velocity(
-            velocity,
-            dofs_idx,
-            envs_idx,
-        )
+    def set_dofs_velocity(self, velocity, dofs_idx, envs_idx=None, *, unsafe=False):
+        velocity, dofs_idx, envs_idx = self._sanitize_1D_io_variables(velocity, dofs_idx, envs_idx, unsafe=unsafe)
+        self._kernel_set_dofs_velocity(velocity, dofs_idx, envs_idx)
         self._kernel_forward_kinematics_links_geoms(envs_idx)
 
     @ti.kernel
@@ -4083,19 +4091,16 @@ class RigidSolver(Solver):
         for i_d_, i_b_ in ti.ndrange(dofs_idx.shape[0], envs_idx.shape[0]):
             self.dofs_state[dofs_idx[i_d_], envs_idx[i_b_]].vel = velocity[i_b_, i_d_]
 
-    def set_dofs_position(self, position, dofs_idx, envs_idx=None):
-        position, dofs_idx, envs_idx = self._validate_1D_io_variables(position, dofs_idx, envs_idx)
-        self._kernel_set_dofs_position(
-            position,
-            dofs_idx,
-            envs_idx,
-        )
+    def set_dofs_position(self, position, dofs_idx, envs_idx=None, *, unsafe=False, skip_forward=False):
+        position, dofs_idx, envs_idx = self._sanitize_1D_io_variables(position, dofs_idx, envs_idx, unsafe=unsafe)
+        self._kernel_set_dofs_position(position, dofs_idx, envs_idx)
         self.collider.reset(envs_idx)
         self.collider.clear(envs_idx)
         if self.constraint_solver is not None:
             self.constraint_solver.reset(envs_idx)
             self.constraint_solver.clear(envs_idx)
-        self._kernel_forward_kinematics_links_geoms(envs_idx)
+        if skip_forward:
+            self._kernel_forward_kinematics_links_geoms(envs_idx)
 
     @ti.kernel
     def _kernel_set_dofs_position(
@@ -4143,13 +4148,9 @@ class RigidSolver(Solver):
                     for i_q in range(q_start, l_info.q_end):
                         self.qpos[i_q, i_b] = self.dofs_state[dof_start + i_q - q_start, i_b].pos
 
-    def control_dofs_force(self, force, dofs_idx, envs_idx=None):
-        force, dofs_idx, envs_idx = self._validate_1D_io_variables(force, dofs_idx, envs_idx)
-        self._kernel_control_dofs_force(
-            force,
-            dofs_idx,
-            envs_idx,
-        )
+    def control_dofs_force(self, force, dofs_idx, envs_idx=None, *, unsafe=False):
+        force, dofs_idx, envs_idx = self._sanitize_1D_io_variables(force, dofs_idx, envs_idx, unsafe=unsafe)
+        self._kernel_control_dofs_force(force, dofs_idx, envs_idx)
 
     @ti.kernel
     def _kernel_control_dofs_force(
@@ -4163,13 +4164,9 @@ class RigidSolver(Solver):
             self.dofs_state[dofs_idx[i_d_], envs_idx[i_b_]].ctrl_mode = gs.CTRL_MODE.FORCE
             self.dofs_state[dofs_idx[i_d_], envs_idx[i_b_]].ctrl_force = force[i_b_, i_d_]
 
-    def control_dofs_velocity(self, velocity, dofs_idx, envs_idx=None):
-        velocity, dofs_idx, envs_idx = self._validate_1D_io_variables(velocity, dofs_idx, envs_idx)
-        self._kernel_control_dofs_velocity(
-            velocity,
-            dofs_idx,
-            envs_idx,
-        )
+    def control_dofs_velocity(self, velocity, dofs_idx, envs_idx=None, *, unsafe=False):
+        velocity, dofs_idx, envs_idx = self._sanitize_1D_io_variables(velocity, dofs_idx, envs_idx, unsafe=unsafe)
+        self._kernel_control_dofs_velocity(velocity, dofs_idx, envs_idx)
 
     @ti.kernel
     def _kernel_control_dofs_velocity(
@@ -4183,13 +4180,9 @@ class RigidSolver(Solver):
             self.dofs_state[dofs_idx[i_d_], envs_idx[i_b_]].ctrl_mode = gs.CTRL_MODE.VELOCITY
             self.dofs_state[dofs_idx[i_d_], envs_idx[i_b_]].ctrl_vel = velocity[i_b_, i_d_]
 
-    def control_dofs_position(self, position, dofs_idx, envs_idx=None):
-        position, dofs_idx, envs_idx = self._validate_1D_io_variables(position, dofs_idx, envs_idx)
-        self._kernel_control_dofs_position(
-            position,
-            dofs_idx,
-            envs_idx,
-        )
+    def control_dofs_position(self, position, dofs_idx, envs_idx=None, *, unsafe=False):
+        position, dofs_idx, envs_idx = self._sanitize_1D_io_variables(position, dofs_idx, envs_idx, unsafe=unsafe)
+        self._kernel_control_dofs_position(position, dofs_idx, envs_idx)
 
     @ti.kernel
     def _kernel_control_dofs_position(
@@ -4203,14 +4196,13 @@ class RigidSolver(Solver):
             self.dofs_state[dofs_idx[i_d_], envs_idx[i_b_]].ctrl_mode = gs.CTRL_MODE.POSITION
             self.dofs_state[dofs_idx[i_d_], envs_idx[i_b_]].ctrl_pos = position[i_b_, i_d_]
 
-    def get_links_pos(self, links_idx, envs_idx=None):
-        tensor, links_idx, envs_idx = self._validate_2D_io_variables(None, links_idx, 3, envs_idx, idx_name="links_idx")
-
+    def get_links_pos(self, links_idx, envs_idx=None, *, unsafe=False):
+        _tensor, links_idx, envs_idx = self._sanitize_2D_io_variables(
+            None, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
+        )
+        tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
         self._kernel_get_links_pos(tensor, links_idx, envs_idx)
-
-        if self.n_envs == 0:
-            tensor = tensor.squeeze(0)
-        return tensor
+        return _tensor
 
     @ti.kernel
     def _kernel_get_links_pos(
@@ -4224,14 +4216,13 @@ class RigidSolver(Solver):
             for i in ti.static(range(3)):
                 tensor[i_b_, i_l_, i] = self.links_state[links_idx[i_l_], envs_idx[i_b_]].pos[i]
 
-    def get_links_quat(self, links_idx, envs_idx=None):
-        tensor, links_idx, envs_idx = self._validate_2D_io_variables(None, links_idx, 4, envs_idx, idx_name="links_idx")
-
+    def get_links_quat(self, links_idx, envs_idx=None, *, unsafe=False):
+        _tensor, links_idx, envs_idx = self._sanitize_2D_io_variables(
+            None, links_idx, 4, envs_idx, idx_name="links_idx", unsafe=unsafe
+        )
+        tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
         self._kernel_get_links_quat(tensor, links_idx, envs_idx)
-
-        if self.n_envs == 0:
-            tensor = tensor.squeeze(0)
-        return tensor
+        return _tensor
 
     @ti.kernel
     def _kernel_get_links_quat(
@@ -4245,14 +4236,13 @@ class RigidSolver(Solver):
             for i in ti.static(range(4)):
                 tensor[i_b_, i_l_, i] = self.links_state[links_idx[i_l_], envs_idx[i_b_]].quat[i]
 
-    def get_links_vel(self, links_idx, envs_idx=None):
-        tensor, links_idx, envs_idx = self._validate_2D_io_variables(None, links_idx, 3, envs_idx, idx_name="links_idx")
-
+    def get_links_vel(self, links_idx, envs_idx=None, *, unsafe=False):
+        _tensor, links_idx, envs_idx = self._sanitize_2D_io_variables(
+            None, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
+        )
+        tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
         self._kernel_get_links_vel(tensor, links_idx, envs_idx)
-
-        if self.n_envs == 0:
-            tensor = tensor.squeeze(0)
-        return tensor
+        return _tensor
 
     @ti.kernel
     def _kernel_get_links_vel(
@@ -4266,14 +4256,13 @@ class RigidSolver(Solver):
             for i in ti.static(range(3)):
                 tensor[i_b_, i_l_, i] = self.links_state[links_idx[i_l_], envs_idx[i_b_]].vel[i]
 
-    def get_links_ang(self, links_idx, envs_idx=None):
-        tensor, links_idx, envs_idx = self._validate_2D_io_variables(None, links_idx, 3, envs_idx, idx_name="links_idx")
-
+    def get_links_ang(self, links_idx, envs_idx=None, *, unsafe=False):
+        _tensor, links_idx, envs_idx = self._sanitize_2D_io_variables(
+            None, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
+        )
+        tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
         self._kernel_get_links_ang(tensor, links_idx, envs_idx)
-
-        if self.n_envs == 0:
-            tensor = tensor.squeeze(0)
-        return tensor
+        return _tensor
 
     @ti.kernel
     def _kernel_get_links_ang(
@@ -4293,14 +4282,14 @@ class RigidSolver(Solver):
         self._func_system_update_force()
         self._func_inverse_link_force()
 
-    def get_links_acc(self, links_idx, envs_idx=None):
-        tensor, links_idx, envs_idx = self._validate_2D_io_variables(None, links_idx, 3, envs_idx, idx_name="links_idx")
+    def get_links_acc(self, links_idx, envs_idx=None, *, unsafe=False):
+        _tensor, links_idx, envs_idx = self._sanitize_2D_io_variables(
+            None, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
+        )
         self._kernel_inverse_dynamics_for_sensors()
+        tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
         self._kernel_get_links_acc(tensor, links_idx, envs_idx)
-
-        if self.n_envs == 0:
-            tensor = tensor.squeeze(0)
-        return tensor
+        return _tensor
 
     @ti.kernel
     def _kernel_get_links_acc(
@@ -4332,14 +4321,13 @@ class RigidSolver(Solver):
             for i in range(3):
                 tensor[i_b_, i_l_, i] = final_acc[i]
 
-    def get_links_COM(self, links_idx, envs_idx=None):
-        tensor, links_idx, envs_idx = self._validate_2D_io_variables(None, links_idx, 3, envs_idx, idx_name="links_idx")
-
+    def get_links_COM(self, links_idx, envs_idx=None, *, unsafe=False):
+        _tensor, links_idx, envs_idx = self._sanitize_2D_io_variables(
+            None, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
+        )
+        tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
         self._kernel_get_links_COM(tensor, links_idx, envs_idx)
-
-        if self.n_envs == 0:
-            tensor = tensor.squeeze(0)
-        return tensor
+        return _tensor
 
     @ti.kernel
     def _kernel_get_links_COM(
@@ -4353,14 +4341,13 @@ class RigidSolver(Solver):
             for i in ti.static(range(3)):
                 tensor[i_b_, i_l_, i] = self.links_state[links_idx[i_l_], envs_idx[i_b_]].COM[i]
 
-    def get_links_mass_shift(self, links_idx, envs_idx=None):
-        tensor, links_idx, envs_idx = self._validate_1D_io_variables(None, links_idx, envs_idx, idx_name="links_idx")
-
+    def get_links_mass_shift(self, links_idx, envs_idx=None, *, unsafe=False):
+        _tensor, links_idx, envs_idx = self._sanitize_1D_io_variables(
+            None, links_idx, envs_idx, idx_name="links_idx", unsafe=unsafe
+        )
+        tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
         self._kernel_get_links_mass_shift(tensor, links_idx, envs_idx)
-
-        if self.n_envs == 0:
-            tensor = tensor.squeeze(0)
-        return tensor
+        return _tensor
 
     @ti.kernel
     def _kernel_get_links_mass_shift(
@@ -4373,13 +4360,13 @@ class RigidSolver(Solver):
         for i_l_, i_b_ in ti.ndrange(links_idx.shape[0], envs_idx.shape[0]):
             tensor[i_b_, i_l_] = self.links_state[links_idx[i_l_], envs_idx[i_b_]].mass_shift
 
-    def get_links_COM_shift(self, links_idx, envs_idx=None):
-        tensor, links_idx, envs_idx = self._validate_2D_io_variables(None, links_idx, 3, envs_idx, idx_name="links_idx")
+    def get_links_COM_shift(self, links_idx, envs_idx=None, *, unsafe=False):
+        _tensor, links_idx, envs_idx = self._sanitize_2D_io_variables(
+            None, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
+        )
+        tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
         self._kernel_get_links_COM_shift(tensor, links_idx, envs_idx)
-
-        if self.n_envs == 0:
-            tensor = tensor.squeeze(0)
-        return tensor
+        return _tensor
 
     @ti.kernel
     def _kernel_get_links_COM_shift(
@@ -4393,15 +4380,10 @@ class RigidSolver(Solver):
             for i in ti.static(range(3)):
                 tensor[i_b_, i_l_, i] = self.links_state[links_idx[i_l_], envs_idx[i_b_]].i_pos_shift[i]
 
-    def _get_links_info(self, links_idx, name, envs_idx=None):
-        if self._options.batch_links_info:
-            tensor, links_idx, envs_idx = self._validate_1D_io_variables(
-                None, links_idx, envs_idx, idx_name="links_idx"
-            )
-        else:
-            tensor, links_idx = self._validate_1D_io_variables(None, links_idx, idx_name="links_idx", batched=False)
-            envs_idx = torch.empty(())
-
+    def _get_links_info(self, links_idx, name, envs_idx=None, *, unsafe=False):
+        tensor, links_idx, envs_idx = self._sanitize_1D_io_variables(
+            None, links_idx, batched=self._options.batch_links_info, idx_name="links_idx", unsafe=unsafe
+        )
         if name == "invweight":
             self._kernel_get_links_invweight(tensor, links_idx, envs_idx)
             return tensor
@@ -4447,14 +4429,13 @@ class RigidSolver(Solver):
             for i_l_ in range(links_idx.shape[0]):
                 tensor[i_l_] = self.links_info[links_idx[i_l_]].invweight
 
-    def get_geoms_friction_ratio(self, geoms_idx, envs_idx=None):
-        tensor, geoms_idx, envs_idx = self._validate_1D_io_variables(None, geoms_idx, envs_idx, idx_name="geoms_idx")
-
+    def get_geoms_friction_ratio(self, geoms_idx, envs_idx=None, *, unsafe=False):
+        _tensor, geoms_idx, envs_idx = self._sanitize_1D_io_variables(
+            None, geoms_idx, envs_idx, idx_name="geoms_idx", unsafe=unsafe
+        )
+        tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
         self._kernel_get_geoms_friction_ratio(tensor, geoms_idx, envs_idx)
-
-        if self.n_envs == 0:
-            tensor = tensor.squeeze(0)
-        return tensor
+        return _tensor
 
     @ti.kernel
     def _kernel_get_geoms_friction_ratio(
@@ -4467,14 +4448,13 @@ class RigidSolver(Solver):
         for i_g_, i_b_ in ti.ndrange(geoms_idx.shape[0], envs_idx.shape[0]):
             tensor[i_b_, i_g_] = self.geoms_state[geoms_idx[i_g_], envs_idx[i_b_]].friction_ratio
 
-    def get_geoms_pos(self, geoms_idx, envs_idx=None):
-        tensor, geoms_idx, envs_idx = self._validate_2D_io_variables(None, geoms_idx, 3, envs_idx, idx_name="geoms_idx")
-
+    def get_geoms_pos(self, geoms_idx, envs_idx=None, *, unsafe=False):
+        _tensor, geoms_idx, envs_idx = self._sanitize_2D_io_variables(
+            None, geoms_idx, 3, envs_idx, idx_name="geoms_idx", unsafe=unsafe
+        )
+        tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
         self._kernel_get_geoms_pos(tensor, geoms_idx, envs_idx)
-
-        if self.n_envs == 0:
-            tensor = tensor.squeeze(0)
-        return tensor
+        return _tensor
 
     @ti.kernel
     def _kernel_get_geoms_pos(
@@ -4488,14 +4468,13 @@ class RigidSolver(Solver):
             for i in ti.static(range(3)):
                 tensor[i_b_, i_g_, i] = self.geoms_state[geoms_idx[i_g_], envs_idx[i_b_]].pos[i]
 
-    def get_qpos(self, qs_idx, envs_idx=None):
-        tensor, qs_idx, envs_idx = self._validate_1D_io_variables(None, qs_idx, envs_idx, idx_name="qs_idx")
-
+    def get_qpos(self, qs_idx, envs_idx=None, *, unsafe=False):
+        _tensor, qs_idx, envs_idx = self._sanitize_1D_io_variables(
+            None, qs_idx, envs_idx, idx_name="qs_idx", unsafe=unsafe
+        )
+        tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
         self._kernel_get_qpos(tensor, qs_idx, envs_idx)
-
-        if self.n_envs == 0:
-            tensor = tensor.squeeze(0)
-        return tensor
+        return _tensor
 
     @ti.kernel
     def _kernel_get_qpos(
@@ -4520,9 +4499,9 @@ class RigidSolver(Solver):
     def get_dofs_position(self, dofs_idx, envs_idx=None):
         return self._get_dofs_state(dofs_idx, "position", envs_idx)
 
-    def _get_dofs_state(self, dofs_idx, name, envs_idx=None):
-        tensor, dofs_idx, envs_idx = self._validate_1D_io_variables(None, dofs_idx, envs_idx)
-
+    def _get_dofs_state(self, dofs_idx, name, envs_idx=None, *, unsafe=False):
+        _tensor, dofs_idx, envs_idx = self._sanitize_1D_io_variables(None, dofs_idx, envs_idx, unsafe=unsafe)
+        tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
         if name == "control_force":
             self._kernel_get_dofs_control_force(tensor, dofs_idx, envs_idx)
         elif name == "force":
@@ -4533,10 +4512,7 @@ class RigidSolver(Solver):
             self._kernel_get_dofs_position(tensor, dofs_idx, envs_idx)
         else:
             gs.raise_exception("Invalid `name`.")
-
-        if self.n_envs == 0:
-            tensor = tensor.squeeze(0)
-        return tensor
+        return _tensor
 
     @ti.kernel
     def _kernel_get_dofs_control_force(
@@ -4624,49 +4600,38 @@ class RigidSolver(Solver):
     def get_dofs_damping(self, dofs_idx, envs_idx=None):
         return self._get_dofs_info(dofs_idx, "damping", envs_idx)
 
-    def _get_dofs_info(self, dofs_idx, name, envs_idx=None):
-        if self._options.batch_dofs_info:
-            tensor, dofs_idx, envs_idx = self._validate_1D_io_variables(None, dofs_idx, envs_idx)
-        else:
-            tensor, dofs_idx = self._validate_1D_io_variables(None, dofs_idx, batched=False)
-            envs_idx = torch.empty(())
-
+    def _get_dofs_info(self, dofs_idx, name, envs_idx=None, *, unsafe=False):
+        tensor, dofs_idx, envs_idx = self._sanitize_1D_io_variables(
+            None, dofs_idx, batched=self._options.batch_dofs_info, unsafe=unsafe
+        )
         if name == "kp":
             self._kernel_get_dofs_kp(tensor, dofs_idx, envs_idx)
             return tensor
-
         elif name == "kv":
             self._kernel_get_dofs_kv(tensor, dofs_idx, envs_idx)
             return tensor
-
         elif name == "force_range":
             lower = torch.empty_like(tensor)
             upper = torch.empty_like(tensor)
             self._kernel_get_dofs_force_range(lower, upper, dofs_idx, envs_idx)
             return lower, upper
-
         elif name == "limit":
             lower = torch.empty_like(tensor)
             upper = torch.empty_like(tensor)
             self._kernel_get_dofs_limit(lower, upper, dofs_idx, envs_idx)
             return lower, upper
-
         elif name == "stiffness":
             self._kernel_get_dofs_stiffness(tensor, dofs_idx, envs_idx)
             return tensor
-
         elif name == "invweight":
             self._kernel_get_dofs_invweight(tensor, dofs_idx, envs_idx)
             return tensor
-
         elif name == "armature":
             self._kernel_get_dofs_armature(tensor, dofs_idx, envs_idx)
             return tensor
-
         elif name == "damping":
             self._kernel_get_dofs_damping(tensor, dofs_idx, envs_idx)
             return tensor
-
         else:
             gs.raise_exception()
 
@@ -4844,14 +4809,13 @@ class RigidSolver(Solver):
                 self.vgeoms_state[propellers_vgeom_idxs[i], b].quat,
             )
 
-    def get_geoms_friction(self, geoms_idx):
-        tensor, geoms_idx = self._validate_1D_io_variables(None, geoms_idx, batched=False, idx_name="geoms_idx")
-
+    def get_geoms_friction(self, geoms_idx, *, unsafe=False):
+        _tensor, geoms_idx = self._sanitize_1D_io_variables(
+            None, geoms_idx, batched=False, idx_name="geoms_idx", unsafe=unsafe
+        )
+        tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
         self._kernel_get_geoms_friction(tensor, geoms_idx)
-
-        if self.n_envs == 0:
-            tensor = tensor.squeeze(0)
-        return tensor
+        return _tensor
 
     @ti.kernel
     def _kernel_get_geoms_friction(
@@ -4870,9 +4834,10 @@ class RigidSolver(Solver):
     def _kernel_set_geom_friction(self, geoms_idx: ti.i32, friction: ti.f32):
         self.geoms_info[geoms_idx].friction = friction
 
-    def set_geoms_friction(self, friction, geoms_idx):
-        friction, geoms_idx = self._validate_1D_io_variables(friction, geoms_idx, batched=False, idx_name="geoms_idx")
-
+    def set_geoms_friction(self, friction, geoms_idx, *, unsafe=False):
+        friction, geoms_idx = self._sanitize_1D_io_variables(
+            friction, geoms_idx, batched=False, idx_name="geoms_idx", unsafe=unsafe
+        )
         self._kernel_set_geoms_friction(friction, geoms_idx)
 
     @ti.kernel

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -3571,7 +3571,11 @@ class RigidSolver(Solver):
         if inputs_idx is None:
             inputs_idx = range(0, input_max)
         elif isinstance(inputs_idx, slice):
-            inputs_idx = range(inputs_idx.start or 0, inputs_idx.stop or input_max, inputs_idx.step or 1)
+            inputs_idx = range(
+                inputs_idx.start or 0,
+                inputs_idx.stop if inputs_idx.stop is not None else input_max,
+                inputs_idx.step or 1,
+            )
         elif isinstance(envs_idx, int):
             inputs_idx = [inputs_idx]
 
@@ -3646,7 +3650,11 @@ class RigidSolver(Solver):
         if inputs_idx is None:
             inputs_idx = range(0, input_max)
         elif isinstance(inputs_idx, slice):
-            inputs_idx = range(inputs_idx.start or 0, inputs_idx.stop or input_max, inputs_idx.step or 1)
+            inputs_idx = range(
+                inputs_idx.start or 0,
+                inputs_idx.stop if inputs_idx.stop is not None else input_max,
+                inputs_idx.step or 1,
+            )
         elif isinstance(envs_idx, int):
             inputs_idx = [inputs_idx]
 

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -3797,7 +3797,8 @@ class RigidSolver(Solver):
         mass, links_idx, envs_idx = self._sanitize_1D_io_variables(
             mass, links_idx, self.n_links, envs_idx, idx_name="links_idx", unsafe=unsafe
         )
-
+        if self.n_envs == 0:
+            mass = mass.unsqueeze(0)
         self._kernel_set_links_mass_shift(mass, links_idx, envs_idx)
 
     @ti.kernel
@@ -3815,6 +3816,8 @@ class RigidSolver(Solver):
         com, links_idx, envs_idx = self._sanitize_2D_io_variables(
             com, links_idx, self.n_links, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
         )
+        if self.n_envs == 0:
+            com = com.unsqueeze(0)
         self._kernel_set_links_COM_shift(com, links_idx, envs_idx)
 
     @ti.kernel

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -3540,8 +3540,6 @@ class RigidSolver(Solver):
         if isinstance(envs_idx, slice):
             return self._scene._envs_idx[envs_idx]
         if isinstance(envs_idx, int):
-            if not 0 <= envs_idx < self._scene.n_envs:
-                gs.raise_exception("`envs_idx` exceeds valid range.")
             return self._scene._envs_idx[[envs_idx]]
 
         # Early return if unsafe

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -6,7 +6,7 @@ import taichi as ti
 
 import genesis as gs
 import genesis.utils.geom as gu
-from genesis.utils.misc import ti_mat_field_to_torch
+from genesis.utils.misc import ti_mat_field_to_torch, ALLOCATE_TENSOR_WARNING
 from genesis.engine.entities import AvatarEntity, DroneEntity, RigidEntity
 from genesis.engine.states.solvers import RigidSolverState
 
@@ -21,11 +21,6 @@ from .sdf_decomp import SDF
 IMP_MIN = 0.0001
 # maximum constraint impedance
 IMP_MAX = 0.9999
-
-ALLOCATE_TENSOR_WARNING = (
-    "Tensor had to converted because dtype or device are incorrect or memory is not contiguous. This may dramatically "
-    "impede performance if it occurs in the critical path of your application."
-)
 
 
 def _sanitize_sol_params(sol_params, substep_dt, default_resolve_time=None):
@@ -2623,9 +2618,9 @@ class RigidSolver(Solver):
                 n_awake_links = ti.atomic_add(self.n_awake_links[i_b], 1)
                 self.awake_links[n_awake_links, i_b] = i_l
 
-    def apply_links_external_force(self, force, links_idx, envs_idx=None, *, unsafe=False):
+    def apply_links_external_force(self, force, links_idx=None, envs_idx=None, *, unsafe=False):
         force, links_idx, envs_idx = self._sanitize_2D_io_variables(
-            force, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
+            force, links_idx, self.n_links, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
         )
         self._kernel_apply_links_external_force(force, links_idx, envs_idx)
 
@@ -2641,9 +2636,9 @@ class RigidSolver(Solver):
             for i in ti.static(range(3)):
                 self.links_state[links_idx[i_l_], envs_idx[i_b_]].cfrc_ext_vel[i] -= force[i_b_, i_l_, i]
 
-    def apply_links_external_torque(self, torque, links_idx, envs_idx=None, *, unsafe=False):
+    def apply_links_external_torque(self, torque, links_idx=None, envs_idx=None, *, unsafe=False):
         torque, links_idx, envs_idx = self._sanitize_2D_io_variables(
-            torque, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
+            torque, links_idx, self.n_links, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
         )
         self._kernel_apply_links_external_torque(torque, links_idx, envs_idx)
 
@@ -3535,18 +3530,25 @@ class RigidSolver(Solver):
     # ------------------------------------------------------------------------------------
 
     def _sanitize_envs_idx(self, envs_idx, *, unsafe=False):
-        # Handling default arguments
+        # Handling default argument and special cases
         if envs_idx is None:
             return self._scene._envs_idx
+
+        if self.n_envs == 0:
+            gs.raise_exception("`envs_idx` is not supported for non-parallelized scene.")
+
+        if isinstance(envs_idx, slice):
+            return self._scene._envs_idx[envs_idx]
+        if isinstance(envs_idx, int):
+            if not 0 <= envs_idx < self._scene.n_envs:
+                gs.raise_exception("`envs_idx` exceeds valid range.")
+            return self._scene._envs_idx[[envs_idx]]
 
         # Early return if unsafe
         if unsafe:
             return envs_idx
 
         # Perform a bunch of sanity checks
-        if self.n_envs == 0:
-            gs.raise_exception("`envs_idx` is not supported for non-parallelized scene.")
-
         _envs_idx = torch.as_tensor(envs_idx, dtype=gs.tc_int, device=gs.device).contiguous()
         if _envs_idx is not envs_idx:
             gs.logger.debug(ALLOCATE_TENSOR_WARNING)
@@ -3560,25 +3562,27 @@ class RigidSolver(Solver):
         return _envs_idx
 
     def _sanitize_1D_io_variables(
-        self, tensor, inputs_idx, envs_idx, batched=True, idx_name="dofs_idx", *, unsafe=False
+        self, tensor, inputs_idx, input_max, envs_idx, batched=True, idx_name="dofs_idx", *, unsafe=False
     ):
         # Handling default arguments
+        if batched:
+            envs_idx = self._sanitize_envs_idx(envs_idx, unsafe=unsafe)
+        else:
+            envs_idx = torch.empty((), dtype=gs.tc_int, device=gs.device)
+
+        if inputs_idx is None:
+            inputs_idx = range(0, input_max)
+        elif isinstance(inputs_idx, slice):
+            inputs_idx = range(inputs_idx.start or 0, inputs_idx.stop or input_max, inputs_idx.step or 1)
+        elif isinstance(envs_idx, int):
+            inputs_idx = [inputs_idx]
+
         if tensor is None:
             if batched and self.n_envs > 0:
-                if envs_idx is not None:
-                    B = len(envs_idx)
-                else:
-                    B = self.n_envs
-                shape = tself._batch_shape(len(inputs_idx), True, B=B)
+                shape = self._batch_shape(len(inputs_idx), True, B=len(envs_idx))
             else:
                 shape = (len(inputs_idx),)
             _tensor = torch.empty(shape, dtype=gs.tc_float, device=gs.device)
-
-        if envs_idx is None:
-            if batched:
-                envs_idx = self._sanitize_envs_idx(envs_idx, unsafe=unsafe)
-            else:
-                envs_idx = torch.empty((), dtype=gs.tc_int, device=gs.device)
 
         # Early return if unsafe
         if unsafe:
@@ -3590,6 +3594,9 @@ class RigidSolver(Solver):
             gs.logger.debug(ALLOCATE_TENSOR_WARNING)
         if _inputs_idx.ndim != 1:
             gs.raise_exception(f"Expecting 1D tensor for `{idx_name}`.")
+        inputs_start, inputs_end = inputs_idx[0], inputs_idx[-1]
+        if not (0 <= inputs_start <= inputs_end < input_max):
+            gs.raise_exception("`{idx_name}` is out-of-range.")
 
         if tensor is not None:
             _tensor = torch.as_tensor(tensor, dtype=gs.tc_float, device=gs.device).contiguous()
@@ -3617,29 +3624,40 @@ class RigidSolver(Solver):
                     )
         else:
             if _tensor.ndim != 1:
-                gs.raise_exception("Expecting 1D input tensor.")
+                gs.raise_exception("Expecting 1D output tensor.")
         return _tensor, _inputs_idx, envs_idx
 
     def _sanitize_2D_io_variables(
-        self, tensor, inputs_idx, vec_size, envs_idx=None, batched=True, idx_name="links_idx", *, unsafe=False
+        self,
+        tensor,
+        inputs_idx,
+        input_max,
+        vec_size,
+        envs_idx=None,
+        batched=True,
+        idx_name="links_idx",
+        *,
+        unsafe=False,
     ):
         # Handling default arguments
+        if batched:
+            envs_idx = self._sanitize_envs_idx(envs_idx, unsafe=unsafe)
+        else:
+            envs_idx = torch.empty((), dtype=gs.tc_int, device=gs.device)
+
+        if inputs_idx is None:
+            inputs_idx = range(0, input_max)
+        elif isinstance(inputs_idx, slice):
+            inputs_idx = range(inputs_idx.start or 0, inputs_idx.stop or input_max, inputs_idx.step or 1)
+        elif isinstance(envs_idx, int):
+            inputs_idx = [inputs_idx]
+
         if tensor is None:
             if batched and self.n_envs > 0:
-                if envs_idx is not None:
-                    B = len(envs_idx)
-                else:
-                    B = self.n_envs
-                shape = self._batch_shape((len(inputs_idx), vec_size), True, B=B)
+                shape = self._batch_shape((len(inputs_idx), vec_size), True, B=len(envs_idx))
             else:
                 shape = (len(inputs_idx), vec_size)
             _tensor = torch.empty(shape, dtype=gs.tc_float, device=gs.device)
-
-        if envs_idx is None:
-            if batched:
-                envs_idx = self._sanitize_envs_idx(envs_idx, unsafe=unsafe)
-            else:
-                envs_idx = torch.empty((), dtype=gs.tc_int, device=gs.device)
 
         # Early return if unsafe
         if unsafe:
@@ -3651,6 +3669,9 @@ class RigidSolver(Solver):
             gs.logger.debug(ALLOCATE_TENSOR_WARNING)
         if _inputs_idx.ndim != 1:
             gs.raise_exception(f"Expecting 1D tensor for `{idx_name}`.")
+        inputs_start, inputs_end = inputs_idx[0], inputs_idx[-1]
+        if not (0 <= inputs_start <= inputs_end < input_max):
+            gs.raise_exception("`{idx_name}` is out-of-range.")
 
         if tensor is not None:
             _tensor = torch.as_tensor(tensor, dtype=gs.tc_float, device=gs.device).contiguous()
@@ -3685,12 +3706,12 @@ class RigidSolver(Solver):
     def _get_qs_idx(self, qs_idx_local=None):
         return self._get_qs_idx_local(qs_idx_local) + self._q_start
 
-    def set_links_pos(self, pos, links_idx, envs_idx=None, *, unsafe=False, skip_forward=False):
+    def set_links_pos(self, pos, links_idx=None, envs_idx=None, *, unsafe=False, skip_forward=False):
         """
         Only effetive for base links.
         """
         pos, links_idx, envs_idx = self._sanitize_2D_io_variables(
-            pos, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
+            pos, links_idx, self.n_links, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
         )
         self._kernel_set_links_pos(pos, links_idx, envs_idx)
         if not skip_forward:
@@ -3716,12 +3737,12 @@ class RigidSolver(Solver):
                 for i in ti.static(range(3)):
                     self.qpos[q_start + i, envs_idx[i_b_]] = pos[i_b_, i_l_, i]
 
-    def set_links_quat(self, quat, links_idx, envs_idx=None, *, unsafe=False, skip_forward=False):
+    def set_links_quat(self, quat, links_idx=None, envs_idx=None, *, unsafe=False, skip_forward=False):
         """
         Only effetive for base links.
         """
         quat, links_idx, envs_idx = self._sanitize_2D_io_variables(
-            quat, links_idx, 4, envs_idx, idx_name="links_idx", unsafe=unsafe
+            quat, links_idx, self.n_links, 4, envs_idx, idx_name="links_idx", unsafe=unsafe
         )
         self._kernel_set_links_quat(quat, links_idx, envs_idx)
         if skip_forward:
@@ -3747,9 +3768,9 @@ class RigidSolver(Solver):
                 for i in ti.static(range(4)):
                     self.qpos[q_start + i + 3, envs_idx[i_b_]] = quat[i_b_, i_l_, i]
 
-    def set_links_mass_shift(self, mass, links_idx, envs_idx=None, *, unsafe=False):
+    def set_links_mass_shift(self, mass, links_idx=None, envs_idx=None, *, unsafe=False):
         mass, links_idx, envs_idx = self._sanitize_1D_io_variables(
-            mass, links_idx, envs_idx, idx_name="links_idx", unsafe=unsafe
+            mass, links_idx, self.n_links, envs_idx, idx_name="links_idx", unsafe=unsafe
         )
 
         self._kernel_set_links_mass_shift(mass, links_idx, envs_idx)
@@ -3765,9 +3786,9 @@ class RigidSolver(Solver):
         for i_l_, i_b_ in ti.ndrange(links_idx.shape[0], envs_idx.shape[0]):
             self.links_state[links_idx[i_l_], envs_idx[i_b_]].mass_shift = mass[i_b_, i_l_]
 
-    def set_links_COM_shift(self, com, links_idx, envs_idx=None, *, unsafe=False):
+    def set_links_COM_shift(self, com, links_idx=None, envs_idx=None, *, unsafe=False):
         com, links_idx, envs_idx = self._sanitize_2D_io_variables(
-            com, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
+            com, links_idx, self.n_links, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
         )
         self._kernel_set_links_COM_shift(com, links_idx, envs_idx)
 
@@ -3785,7 +3806,12 @@ class RigidSolver(Solver):
 
     def _set_links_info(self, tensor, links_idx, name, envs_idx=None, *, unsafe=False):
         tensor, links_idx, envs_idx = self._sanitize_1D_io_variables(
-            tensor, links_idx, batched=self._options.batch_links_info, idx_name="links_idx", unsafe=unsafe
+            tensor,
+            links_idx,
+            self.n_links,
+            batched=self._options.batch_links_info,
+            idx_name="links_idx",
+            unsafe=unsafe,
         )
         if name == "invweight":
             self._kernel_set_links_invweight(tensor, links_idx, envs_idx)
@@ -3830,9 +3856,9 @@ class RigidSolver(Solver):
             for i_l_ in range(links_idx.shape[0]):
                 self.links_info[links_idx[i_l_]].invweight = invweight[i_l_]
 
-    def set_geoms_friction_ratio(self, friction_ratio, geoms_idx, envs_idx=None, *, unsafe=False):
+    def set_geoms_friction_ratio(self, friction_ratio, geoms_idx=None, envs_idx=None, *, unsafe=False):
         friction_ratio, geoms_idx, envs_idx = self._sanitize_1D_io_variables(
-            friction_ratio, geoms_idx, envs_idx, idx_name="geoms_idx", unsafe=unsafe
+            friction_ratio, geoms_idx, self.n_geoms, envs_idx, idx_name="geoms_idx", unsafe=unsafe
         )
         self._kernel_set_geoms_friction_ratio(friction_ratio, geoms_idx, envs_idx)
 
@@ -3847,10 +3873,12 @@ class RigidSolver(Solver):
         for i_g_, i_b_ in ti.ndrange(geoms_idx.shape[0], envs_idx.shape[0]):
             self.geoms_state[geoms_idx[i_g_], envs_idx[i_b_]].friction_ratio = friction_ratio[i_b_, i_g_]
 
-    def set_qpos(self, qpos, qs_idx, envs_idx=None, *, unsafe=False, skip_forward=False):
+    def set_qpos(self, qpos, qs_idx=None, envs_idx=None, *, unsafe=False, skip_forward=False):
         qpos, qs_idx, envs_idx = self._sanitize_1D_io_variables(
-            qpos, qs_idx, envs_idx, idx_name="qs_idx", unsafe=unsafe
+            qpos, qs_idx, self.n_qs, envs_idx, idx_name="qs_idx", unsafe=unsafe
         )
+        if self.n_envs == 0:
+            qpos = qpos.unsqueeze(0)
         self._kernel_set_qpos(qpos, qs_idx, envs_idx)
         self.collider.reset(envs_idx)
         self.collider.clear(envs_idx)
@@ -3905,7 +3933,7 @@ class RigidSolver(Solver):
     def _set_dofs_info(self, tensor_list, dofs_idx, name, envs_idx=None, *, unsafe=False):
         for i, tensor in enumerate(tensor_list):
             tensor_list[i], dofs_idx, envs_idx = self._sanitize_1D_io_variables(
-                tensor, dofs_idx, envs_idx, batched=self._options.batch_dofs_info, unsafe=unsafe
+                tensor, dofs_idx, self.n_dofs, envs_idx, batched=self._options.batch_dofs_info, unsafe=unsafe
             )
         if name == "kp":
             self._kernel_set_dofs_kp(tensor_list[0], dofs_idx, envs_idx)
@@ -4076,8 +4104,12 @@ class RigidSolver(Solver):
                 self.dofs_info[dofs_idx[i_d_]].limit[0] = lower[i_d_]
                 self.dofs_info[dofs_idx[i_d_]].limit[1] = upper[i_d_]
 
-    def set_dofs_velocity(self, velocity, dofs_idx, envs_idx=None, *, unsafe=False):
-        velocity, dofs_idx, envs_idx = self._sanitize_1D_io_variables(velocity, dofs_idx, envs_idx, unsafe=unsafe)
+    def set_dofs_velocity(self, velocity, dofs_idx=None, envs_idx=None, *, unsafe=False):
+        velocity, dofs_idx, envs_idx = self._sanitize_1D_io_variables(
+            velocity, dofs_idx, self.n_dofs, envs_idx, unsafe=unsafe
+        )
+        if self.n_envs == 0:
+            velocity = velocity.unsqueeze(0)
         self._kernel_set_dofs_velocity(velocity, dofs_idx, envs_idx)
         self._kernel_forward_kinematics_links_geoms(envs_idx)
 
@@ -4092,8 +4124,12 @@ class RigidSolver(Solver):
         for i_d_, i_b_ in ti.ndrange(dofs_idx.shape[0], envs_idx.shape[0]):
             self.dofs_state[dofs_idx[i_d_], envs_idx[i_b_]].vel = velocity[i_b_, i_d_]
 
-    def set_dofs_position(self, position, dofs_idx, envs_idx=None, *, unsafe=False, skip_forward=False):
-        position, dofs_idx, envs_idx = self._sanitize_1D_io_variables(position, dofs_idx, envs_idx, unsafe=unsafe)
+    def set_dofs_position(self, position, dofs_idx=None, envs_idx=None, *, unsafe=False, skip_forward=False):
+        position, dofs_idx, envs_idx = self._sanitize_1D_io_variables(
+            position, dofs_idx, self.n_dofs, envs_idx, unsafe=unsafe
+        )
+        if self.n_envs == 0:
+            position = position.unsqueeze(0)
         self._kernel_set_dofs_position(position, dofs_idx, envs_idx)
         self.collider.reset(envs_idx)
         self.collider.clear(envs_idx)
@@ -4149,8 +4185,12 @@ class RigidSolver(Solver):
                     for i_q in range(q_start, l_info.q_end):
                         self.qpos[i_q, i_b] = self.dofs_state[dof_start + i_q - q_start, i_b].pos
 
-    def control_dofs_force(self, force, dofs_idx, envs_idx=None, *, unsafe=False):
-        force, dofs_idx, envs_idx = self._sanitize_1D_io_variables(force, dofs_idx, envs_idx, unsafe=unsafe)
+    def control_dofs_force(self, force, dofs_idx=None, envs_idx=None, *, unsafe=False):
+        force, dofs_idx, envs_idx = self._sanitize_1D_io_variables(
+            force, dofs_idx, self.n_dofs, envs_idx, unsafe=unsafe
+        )
+        if self.n_envs == 0:
+            force = force.unsqueeze(0)
         self._kernel_control_dofs_force(force, dofs_idx, envs_idx)
 
     @ti.kernel
@@ -4165,8 +4205,12 @@ class RigidSolver(Solver):
             self.dofs_state[dofs_idx[i_d_], envs_idx[i_b_]].ctrl_mode = gs.CTRL_MODE.FORCE
             self.dofs_state[dofs_idx[i_d_], envs_idx[i_b_]].ctrl_force = force[i_b_, i_d_]
 
-    def control_dofs_velocity(self, velocity, dofs_idx, envs_idx=None, *, unsafe=False):
-        velocity, dofs_idx, envs_idx = self._sanitize_1D_io_variables(velocity, dofs_idx, envs_idx, unsafe=unsafe)
+    def control_dofs_velocity(self, velocity, dofs_idx=None, envs_idx=None, *, unsafe=False):
+        velocity, dofs_idx, envs_idx = self._sanitize_1D_io_variables(
+            velocity, dofs_idx, self.n_dofs, envs_idx, unsafe=unsafe
+        )
+        if self.n_envs == 0:
+            velocity = velocity.unsqueeze(0)
         self._kernel_control_dofs_velocity(velocity, dofs_idx, envs_idx)
 
     @ti.kernel
@@ -4181,8 +4225,12 @@ class RigidSolver(Solver):
             self.dofs_state[dofs_idx[i_d_], envs_idx[i_b_]].ctrl_mode = gs.CTRL_MODE.VELOCITY
             self.dofs_state[dofs_idx[i_d_], envs_idx[i_b_]].ctrl_vel = velocity[i_b_, i_d_]
 
-    def control_dofs_position(self, position, dofs_idx, envs_idx=None, *, unsafe=False):
-        position, dofs_idx, envs_idx = self._sanitize_1D_io_variables(position, dofs_idx, envs_idx, unsafe=unsafe)
+    def control_dofs_position(self, position, dofs_idx=None, envs_idx=None, *, unsafe=False):
+        position, dofs_idx, envs_idx = self._sanitize_1D_io_variables(
+            position, dofs_idx, self.n_dofs, envs_idx, unsafe=unsafe
+        )
+        if self.n_envs == 0:
+            position = position.unsqueeze(0)
         self._kernel_control_dofs_position(position, dofs_idx, envs_idx)
 
     @ti.kernel
@@ -4205,11 +4253,11 @@ class RigidSolver(Solver):
         tensor = ti_mat_field_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, unsafe=unsafe)
         return tensor.squeeze(0) if self.n_envs == 0 else tensor
 
-    def get_links_vel(self, links_idx, envs_idx=None, *, unsafe=False):
+    def get_links_vel(self, links_idx=None, envs_idx=None, *, unsafe=False):
         # FIXME: This function should be updated to compute the link velocity
         # expressed at link position in world coordinates.
         _tensor, links_idx, envs_idx = self._sanitize_2D_io_variables(
-            None, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
+            None, links_idx, self.n_links, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
         )
         tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
         self._kernel_get_links_vel(tensor, links_idx, envs_idx)
@@ -4237,9 +4285,9 @@ class RigidSolver(Solver):
         self._func_system_update_force()
         self._func_inverse_link_force()
 
-    def get_links_acc(self, links_idx, envs_idx=None, *, unsafe=False):
+    def get_links_acc(self, links_idx=None, envs_idx=None, *, unsafe=False):
         _tensor, links_idx, envs_idx = self._sanitize_2D_io_variables(
-            None, links_idx, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
+            None, links_idx, self.n_links, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
         )
         self._kernel_inverse_dynamics_for_sensors()
         tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
@@ -4290,7 +4338,7 @@ class RigidSolver(Solver):
 
     def _get_links_info(self, links_idx, name, envs_idx=None):
         tensor, links_idx, envs_idx = self._sanitize_1D_io_variables(
-            None, links_idx, batched=self._options.batch_links_info, idx_name="links_idx"
+            None, links_idx, self.n_links, envs_idx, batched=self._options.batch_links_info, idx_name="links_idx"
         )
         if name == "invweight":
             self._kernel_get_links_invweight(tensor, links_idx, envs_idx)
@@ -4351,33 +4399,35 @@ class RigidSolver(Solver):
         tensor = ti_mat_field_to_torch(self.qpos, envs_idx, qs_idx, transpose=True, unsafe=unsafe)
         return tensor.squeeze(0) if self.n_envs == 0 else tensor
 
-    def get_dofs_control_force(self, dofs_idx, envs_idx=None):
-        return self._get_dofs_state(dofs_idx, "control_force", envs_idx)
+    def get_dofs_control_force(self, dofs_idx=None, envs_idx=None, *, unsafe=False):
+        return self._get_dofs_state(dofs_idx, "control_force", envs_idx, unsafe=unsafe)
 
-    def get_dofs_force(self, dofs_idx, envs_idx=None):
-        return self._get_dofs_state(dofs_idx, "force", envs_idx)
+    def get_dofs_force(self, dofs_idx=None, envs_idx=None, *, unsafe=False):
+        return self._get_dofs_state(dofs_idx, "force", envs_idx, unsafe=unsafe)
 
-    def get_dofs_velocity(self, dofs_idx, envs_idx=None):
-        return self._get_dofs_state(dofs_idx, "velocity", envs_idx)
+    def get_dofs_velocity(self, dofs_idx=None, envs_idx=None, *, unsafe=False):
+        return self._get_dofs_state(dofs_idx, "velocity", envs_idx, unsafe=unsafe)
 
-    def get_dofs_position(self, dofs_idx, envs_idx=None):
-        return self._get_dofs_state(dofs_idx, "position", envs_idx)
+    def get_dofs_position(self, dofs_idx=None, envs_idx=None, *, unsafe=False):
+        return self._get_dofs_state(dofs_idx, "position", envs_idx, unsafe=unsafe)
 
-    def _get_dofs_state(self, dofs_idx, name, envs_idx=None, *, unsafe=False):
-        if name == "control_force":
-            _tensor, dofs_idx, envs_idx = self._sanitize_1D_io_variables(None, dofs_idx, envs_idx, unsafe=unsafe)
+    def _get_dofs_state(self, dofs_idx, type, envs_idx=None, *, unsafe=False):
+        if type == "control_force":
+            _tensor, dofs_idx, envs_idx = self._sanitize_1D_io_variables(
+                None, dofs_idx, self.n_dofs, envs_idx, unsafe=unsafe
+            )
             tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
             self._kernel_get_dofs_control_force(tensor, dofs_idx, envs_idx)
         else:
-            if name == "force":
+            if type == "force":
                 field = self.dofs_state.force
-            elif name == "velocity":
+            elif type == "velocity":
                 field = self.dofs_state.vel
-            elif name == "position":
+            elif type == "position":
                 field = self.dofs_state.pos
             else:
-                gs.raise_exception("Invalid `name`.")
-            _tensor = ti_mat_field_to_torch(self.qpos, envs_idx, dofs_idx, transpose=True, unsafe=unsafe)
+                gs.raise_exception()
+            _tensor = ti_mat_field_to_torch(field, envs_idx, dofs_idx, transpose=True, unsafe=unsafe)
             if self.n_envs == 0:
                 _tensor = _tensor.squeeze(0)
         return _tensor
@@ -4437,7 +4487,7 @@ class RigidSolver(Solver):
 
     def _get_dofs_info(self, dofs_idx, name, envs_idx=None, *, unsafe=False):
         tensor, dofs_idx, envs_idx = self._sanitize_1D_io_variables(
-            None, dofs_idx, batched=self._options.batch_dofs_info, unsafe=unsafe
+            None, dofs_idx, self.n_dofs, batched=self._options.batch_dofs_info, unsafe=unsafe
         )
         if name == "kp":
             self._kernel_get_dofs_kp(tensor, dofs_idx, envs_idx)
@@ -4644,13 +4694,12 @@ class RigidSolver(Solver):
                 self.vgeoms_state[propellers_vgeom_idxs[i], b].quat,
             )
 
-    def get_geoms_friction(self, geoms_idx, *, unsafe=False):
-        _tensor, geoms_idx = self._sanitize_1D_io_variables(
-            None, geoms_idx, batched=False, idx_name="geoms_idx", unsafe=unsafe
+    def get_geoms_friction(self, geoms_idx=None, *, unsafe=False):
+        tensor, geoms_idx, _ = self._sanitize_1D_io_variables(
+            None, geoms_idx, self.n_geoms, None, batched=False, idx_name="geoms_idx", unsafe=unsafe
         )
-        tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
         self._kernel_get_geoms_friction(tensor, geoms_idx)
-        return _tensor
+        return tensor
 
     @ti.kernel
     def _kernel_get_geoms_friction(
@@ -4669,9 +4718,9 @@ class RigidSolver(Solver):
     def _kernel_set_geom_friction(self, geoms_idx: ti.i32, friction: ti.f32):
         self.geoms_info[geoms_idx].friction = friction
 
-    def set_geoms_friction(self, friction, geoms_idx, *, unsafe=False):
-        friction, geoms_idx = self._sanitize_1D_io_variables(
-            friction, geoms_idx, batched=False, idx_name="geoms_idx", unsafe=unsafe
+    def set_geoms_friction(self, friction, geoms_idx=None, *, unsafe=False):
+        friction, geoms_idx, _ = self._sanitize_1D_io_variables(
+            friction, geoms_idx, self.n_geoms, None, batched=False, idx_name="geoms_idx", unsafe=unsafe
         )
         self._kernel_set_geoms_friction(friction, geoms_idx)
 

--- a/genesis/utils/misc.py
+++ b/genesis/utils/misc.py
@@ -119,8 +119,9 @@ def get_device(backend: gs_backend):
         if not torch.cuda.is_available():
             gs.raise_exception("cuda device not available")
 
-        device = torch.device("cuda")
-        device_property = torch.cuda.get_device_properties(0)
+        device_idx = torch.cuda.current_device()
+        device = torch.device(f"cuda:{device_idx}")
+        device_property = torch.cuda.get_device_properties(device_idx)
         device_name = device_property.name
         total_mem = device_property.total_memory / 1024**3
 
@@ -130,12 +131,13 @@ def get_device(backend: gs_backend):
 
         # on mac, cpu and gpu are in the same device
         _, device_name, total_mem, _ = get_device(gs_backend.cpu)
-        device = torch.device("mps")
+        device = torch.device("mps:0")
 
     elif backend == gs_backend.vulkan:
         if torch.xpu.is_available():  # pytorch 2.5+ Intel XPU device
-            device = torch.device("xpu")
-            device_property = torch.xpu.get_device_properties(0)
+            device_idx = torch.xpu.current_device()
+            device = torch.device("xpu:{device_idx}")
+            device_property = torch.xpu.get_device_properties(device_idx)
             device_name = device_property.name
             total_mem = device_property.total_memory / 1024**3
         else:  # pytorch tensors on cpu

--- a/genesis/utils/misc.py
+++ b/genesis/utils/misc.py
@@ -136,7 +136,7 @@ def get_device(backend: gs_backend):
     elif backend == gs_backend.vulkan:
         if torch.xpu.is_available():  # pytorch 2.5+ Intel XPU device
             device_idx = torch.xpu.current_device()
-            device = torch.device("xpu:{device_idx}")
+            device = torch.device(f"xpu:{device_idx}")
             device_property = torch.xpu.get_device_properties(device_idx)
             device_name = device_property.name
             total_mem = device_property.total_memory / 1024**3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ addopts = [
     "--dist=loadgroup",
     "-m not benchmarks",
 ]
+filterwarnings = [
+    "ignore:.*PytestUnknownMarkWarning",
+    "ignore::DeprecationWarning",
+]
 markers = [
     "benchmarks: marks benchmarks (executed independently and sequentially).",
 ]

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -543,32 +543,32 @@ def test_data_accessor(n_envs):
     # Check attribute getters
     gs_solver = gs_sim.rigid_solver
     for arg1_max, arg2_max, getter, setter in (
-        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_pos, None),
-        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_quat, None),
-        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_vel, None),
-        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_ang, None),
-        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_acc, None),
-        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_COM, None),
-        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_mass_shift, gs_solver.set_links_mass_shift),
-        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_COM_shift, gs_solver.set_links_COM_shift),
-        (gs_solver.n_dofs, scene.n_envs, gs_solver.get_dofs_control_force, gs_solver.control_dofs_force),
-        (gs_solver.n_dofs, scene.n_envs, gs_solver.get_dofs_force, None),
-        (gs_solver.n_dofs, scene.n_envs, gs_solver.get_dofs_velocity, gs_solver.set_dofs_velocity),
-        (gs_solver.n_dofs, scene.n_envs, gs_solver.get_dofs_position, gs_solver.set_dofs_position),
-        (gs_solver.n_geoms, scene.n_envs, gs_solver.get_geoms_pos, None),
-        (gs_solver.n_qs, scene.n_envs, gs_solver.get_qpos, gs_solver.set_qpos),
+        (gs_solver.n_links, n_envs, gs_solver.get_links_pos, None),
+        (gs_solver.n_links, n_envs, gs_solver.get_links_quat, None),
+        (gs_solver.n_links, n_envs, gs_solver.get_links_vel, None),
+        (gs_solver.n_links, n_envs, gs_solver.get_links_ang, None),
+        (gs_solver.n_links, n_envs, gs_solver.get_links_acc, None),
+        (gs_solver.n_links, n_envs, gs_solver.get_links_COM, None),
+        (gs_solver.n_links, n_envs, gs_solver.get_links_mass_shift, gs_solver.set_links_mass_shift),
+        (gs_solver.n_links, n_envs, gs_solver.get_links_COM_shift, gs_solver.set_links_COM_shift),
+        (gs_solver.n_dofs, n_envs, gs_solver.get_dofs_control_force, gs_solver.control_dofs_force),
+        (gs_solver.n_dofs, n_envs, gs_solver.get_dofs_force, None),
+        (gs_solver.n_dofs, n_envs, gs_solver.get_dofs_velocity, gs_solver.set_dofs_velocity),
+        (gs_solver.n_dofs, n_envs, gs_solver.get_dofs_position, gs_solver.set_dofs_position),
+        (gs_solver.n_geoms, n_envs, gs_solver.get_geoms_pos, None),
+        (gs_solver.n_qs, n_envs, gs_solver.get_qpos, gs_solver.set_qpos),
         (gs_solver.n_geoms, -1, gs_solver.get_geoms_friction, gs_solver.set_geoms_friction),
-        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_pos, None),
-        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_quat, None),
-        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_vel, None),
-        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_ang, None),
-        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_acc, None),
-        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_control_force, None),
-        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_force, None),
-        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_velocity, gs_robot.set_dofs_velocity),
-        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_position, gs_robot.set_dofs_position),
-        (gs_robot.n_qs, scene.n_envs, gs_robot.get_qpos, gs_robot.set_qpos),
-        (-1, scene.n_envs, gs_robot.get_links_net_contact_force, None),
+        (gs_robot.n_links, n_envs, gs_robot.get_links_pos, None),
+        (gs_robot.n_links, n_envs, gs_robot.get_links_quat, None),
+        (gs_robot.n_links, n_envs, gs_robot.get_links_vel, None),
+        (gs_robot.n_links, n_envs, gs_robot.get_links_ang, None),
+        (gs_robot.n_links, n_envs, gs_robot.get_links_acc, None),
+        (gs_robot.n_dofs, n_envs, gs_robot.get_dofs_control_force, None),
+        (gs_robot.n_dofs, n_envs, gs_robot.get_dofs_force, None),
+        (gs_robot.n_dofs, n_envs, gs_robot.get_dofs_velocity, gs_robot.set_dofs_velocity),
+        (gs_robot.n_dofs, n_envs, gs_robot.get_dofs_position, gs_robot.set_dofs_position),
+        (gs_robot.n_qs, n_envs, gs_robot.get_qpos, gs_robot.set_qpos),
+        (-1, n_envs, gs_robot.get_links_net_contact_force, None),
     ):
         datas = getter().cpu()
         if setter is not None:
@@ -590,7 +590,7 @@ def test_data_accessor(n_envs):
                             data = getter(arg2).cpu()
                             if setter is not None:
                                 setter(data, arg2)
-                            data_ = datas[[j]]
+                            data_ = datas[[j]] if n_envs else datas
                         elif arg2 is None:
                             data = getter(arg1).cpu()
                             if setter is not None:

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -557,6 +557,8 @@ def test_data_accessor(n_envs):
         (gs_solver.n_dofs, n_envs, gs_solver.get_dofs_position, gs_solver.set_dofs_position),
         (gs_solver.n_geoms, n_envs, gs_solver.get_geoms_pos, None),
         (gs_solver.n_qs, n_envs, gs_solver.get_qpos, gs_solver.set_qpos),
+        (gs_solver.n_links, -1, gs_solver.get_links_inertial_mass, None),
+        (gs_solver.n_links, -1, gs_solver.get_links_invweight, None),
         (gs_solver.n_geoms, -1, gs_solver.get_geoms_friction, gs_solver.set_geoms_friction),
         (gs_robot.n_links, n_envs, gs_robot.get_links_pos, None),
         (gs_robot.n_links, n_envs, gs_robot.get_links_quat, None),
@@ -568,6 +570,8 @@ def test_data_accessor(n_envs):
         (gs_robot.n_dofs, n_envs, gs_robot.get_dofs_velocity, gs_robot.set_dofs_velocity),
         (gs_robot.n_dofs, n_envs, gs_robot.get_dofs_position, gs_robot.set_dofs_position),
         (gs_robot.n_qs, n_envs, gs_robot.get_qpos, gs_robot.set_qpos),
+        (gs_robot.n_links, -1, gs_robot.get_links_inertial_mass, None),
+        (gs_robot.n_links, -1, gs_robot.get_links_invweight, None),
         (-1, n_envs, gs_robot.get_links_net_contact_force, None),
     ):
         datas = getter().cpu()

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -531,6 +531,8 @@ def test_data_accessor(n_envs):
             break
     else:
         assert False
+    gs_sim.rigid_solver._kernel_forward_dynamics()
+    gs_sim.rigid_solver._func_constraint_force()
 
     # Make sure that all the robots ends up in the different state
     qposs = gs_robot.get_qpos().cpu()
@@ -538,38 +540,41 @@ def test_data_accessor(n_envs):
         with np.testing.assert_raises(AssertionError):
             np.testing.assert_allclose(qposs[i], qposs[i + 1], atol=1e-9)
 
-    # Check attributes getters
-    for arg1_max, arg2_max, accessor in (
-        (gs_sim.rigid_solver.n_links, n_envs, gs_sim.rigid_solver.get_links_pos),
-        (gs_sim.rigid_solver.n_links, n_envs, gs_sim.rigid_solver.get_links_quat),
-        (gs_sim.rigid_solver.n_links, n_envs, gs_sim.rigid_solver.get_links_vel),
-        (gs_sim.rigid_solver.n_links, n_envs, gs_sim.rigid_solver.get_links_ang),
-        (gs_sim.rigid_solver.n_links, n_envs, gs_sim.rigid_solver.get_links_acc),
-        (gs_sim.rigid_solver.n_links, n_envs, gs_sim.rigid_solver.get_links_COM),
-        (gs_sim.rigid_solver.n_links, n_envs, gs_sim.rigid_solver.get_links_mass_shift),
-        (gs_sim.rigid_solver.n_links, n_envs, gs_sim.rigid_solver.get_links_COM_shift),
-        (gs_sim.rigid_solver.n_dofs, n_envs, gs_sim.rigid_solver.get_dofs_control_force),
-        (gs_sim.rigid_solver.n_dofs, n_envs, gs_sim.rigid_solver.get_dofs_force),
-        (gs_sim.rigid_solver.n_dofs, n_envs, gs_sim.rigid_solver.get_dofs_velocity),
-        (gs_sim.rigid_solver.n_dofs, n_envs, gs_sim.rigid_solver.get_dofs_position),
-        (gs_sim.rigid_solver.n_geoms, n_envs, gs_sim.rigid_solver.get_geoms_pos),
-        (gs_sim.rigid_solver.n_qs, n_envs, gs_sim.rigid_solver.get_qpos),
-        (gs_sim.rigid_solver.n_geoms, -1, gs_sim.rigid_solver.get_geoms_friction),
-        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_pos),
-        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_quat),
-        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_vel),
-        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_ang),
-        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_acc),
-        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_control_force),
-        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_force),
-        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_velocity),
-        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_position),
-        (gs_robot.n_qs, scene.n_envs, gs_robot.get_qpos),
-        (-1, scene.n_envs, gs_robot.get_links_net_contact_force),
+    # Check attribute getters
+    gs_solver = gs_sim.rigid_solver
+    for arg1_max, arg2_max, getter, setter in (
+        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_pos, None),
+        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_quat, None),
+        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_vel, None),
+        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_ang, None),
+        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_acc, None),
+        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_COM, None),
+        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_mass_shift, gs_solver.set_links_mass_shift),
+        (gs_solver.n_links, scene.n_envs, gs_solver.get_links_COM_shift, gs_solver.set_links_COM_shift),
+        (gs_solver.n_dofs, scene.n_envs, gs_solver.get_dofs_control_force, gs_solver.control_dofs_force),
+        (gs_solver.n_dofs, scene.n_envs, gs_solver.get_dofs_force, None),
+        (gs_solver.n_dofs, scene.n_envs, gs_solver.get_dofs_velocity, gs_solver.set_dofs_velocity),
+        (gs_solver.n_dofs, scene.n_envs, gs_solver.get_dofs_position, gs_solver.set_dofs_position),
+        (gs_solver.n_geoms, scene.n_envs, gs_solver.get_geoms_pos, None),
+        (gs_solver.n_qs, scene.n_envs, gs_solver.get_qpos, gs_solver.set_qpos),
+        (gs_solver.n_geoms, -1, gs_solver.get_geoms_friction, gs_solver.set_geoms_friction),
+        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_pos, None),
+        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_quat, None),
+        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_vel, None),
+        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_ang, None),
+        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_acc, None),
+        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_control_force, None),
+        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_force, None),
+        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_velocity, gs_robot.set_dofs_velocity),
+        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_position, gs_robot.set_dofs_position),
+        (gs_robot.n_qs, scene.n_envs, gs_robot.get_qpos, gs_robot.set_qpos),
+        (-1, scene.n_envs, gs_robot.get_links_net_contact_force, None),
     ):
-        datas = accessor().cpu()
+        datas = getter().cpu()
+        if setter is not None:
+            setter(datas)
         if arg1_max > 0:
-            datas_ = accessor(range(arg1_max)).cpu()
+            datas_ = getter(range(arg1_max)).cpu()
             np.testing.assert_allclose(datas_, datas, atol=1e-9)
         for i in range(arg1_max) if arg1_max > 0 else (None,):
             for arg1 in (
@@ -582,12 +587,18 @@ def test_data_accessor(n_envs):
                         else (None,)
                     ):
                         if arg1 is None:
-                            data = accessor(arg2).cpu()
-                            data_ = datas[[j]] if n_envs else datas
+                            data = getter(arg2).cpu()
+                            if setter is not None:
+                                setter(data, arg2)
+                            data_ = datas[[j]]
                         elif arg2 is None:
-                            data = accessor(arg1).cpu()
+                            data = getter(arg1).cpu()
+                            if setter is not None:
+                                setter(data, arg1)
                             data_ = datas[[i]]
                         else:
-                            data = accessor(arg1, arg2).cpu()
+                            data = getter(arg1, arg2).cpu()
+                            if setter is not None:
+                                setter(data, arg1, arg2)
                             data_ = datas[[j], :][:, [i]]
                         np.testing.assert_allclose(data_, data, atol=1e-9)

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -555,7 +555,17 @@ def test_data_accessor(n_envs):
         (gs_sim.rigid_solver.n_geoms, n_envs, gs_sim.rigid_solver.get_geoms_pos),
         (gs_sim.rigid_solver.n_qs, n_envs, gs_sim.rigid_solver.get_qpos),
         (gs_sim.rigid_solver.n_geoms, -1, gs_sim.rigid_solver.get_geoms_friction),
-        (-1, n_envs, gs_robot.get_links_net_contact_force),
+        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_pos),
+        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_quat),
+        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_vel),
+        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_ang),
+        (gs_robot.n_links, scene.n_envs, gs_robot.get_links_acc),
+        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_control_force),
+        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_force),
+        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_velocity),
+        (gs_robot.n_dofs, scene.n_envs, gs_robot.get_dofs_position),
+        (gs_robot.n_qs, scene.n_envs, gs_robot.get_qpos),
+        (-1, scene.n_envs, gs_robot.get_links_net_contact_force),
     ):
         datas = accessor().cpu()
         if arg1_max > 0:

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -557,8 +557,8 @@ def test_data_accessor(n_envs):
         (gs_solver.n_links, n_envs, gs_solver.get_links_COM, None),
         (gs_solver.n_links, n_envs, gs_solver.get_links_mass_shift, gs_solver.set_links_mass_shift),
         (gs_solver.n_links, n_envs, gs_solver.get_links_COM_shift, gs_solver.set_links_COM_shift),
-        (gs_solver.n_links, -1, gs_solver.get_links_inertial_mass, None),
-        (gs_solver.n_links, -1, gs_solver.get_links_invweight, None),
+        (gs_solver.n_links, -1, gs_solver.get_links_inertial_mass, gs_solver.set_links_inertial_mass),
+        (gs_solver.n_links, -1, gs_solver.get_links_invweight, gs_solver.set_links_invweight),
         (gs_solver.n_dofs, n_envs, gs_solver.get_dofs_control_force, gs_solver.control_dofs_force),
         (gs_solver.n_dofs, n_envs, gs_solver.get_dofs_force, None),
         (gs_solver.n_dofs, n_envs, gs_solver.get_dofs_velocity, gs_solver.set_dofs_velocity),
@@ -579,8 +579,8 @@ def test_data_accessor(n_envs):
         (gs_robot.n_links, n_envs, gs_robot.get_links_vel, None),
         (gs_robot.n_links, n_envs, gs_robot.get_links_ang, None),
         (gs_robot.n_links, n_envs, gs_robot.get_links_acc, None),
-        (gs_robot.n_links, -1, gs_robot.get_links_inertial_mass, None),
-        (gs_robot.n_links, -1, gs_robot.get_links_invweight, None),
+        (gs_robot.n_links, -1, gs_robot.get_links_inertial_mass, gs_robot.set_links_inertial_mass),
+        (gs_robot.n_links, -1, gs_robot.get_links_invweight, gs_robot.set_links_invweight),
         (gs_robot.n_dofs, n_envs, gs_robot.get_dofs_control_force, None),
         (gs_robot.n_dofs, n_envs, gs_robot.get_dofs_force, None),
         (gs_robot.n_dofs, n_envs, gs_robot.get_dofs_velocity, gs_robot.set_dofs_velocity),
@@ -612,6 +612,7 @@ def test_data_accessor(n_envs):
         for i in range(arg1_max) if arg1_max > 0 else (None,):
             for arg1 in (
                 (
+                    i,
                     [i],
                     slice(i, i + 1),
                     range(i, i + 1),
@@ -625,6 +626,7 @@ def test_data_accessor(n_envs):
                 for j in range(max(arg2_max, 1)) if arg2_max >= 0 else (None,):
                     for arg2 in (
                         (
+                            j,
                             [j],
                             slice(j, j + 1),
                             range(j, j + 1),


### PR DESCRIPTION
## Description

This PR refactors all the data accessors related to the Rigid Body solver to directly copy the original data buffer, removing any unnecessary level of indirection. At this point, it does not implement any other optimisation than adding an 'unsafe' mode that disable runtime checks. The next step would be to add some optional 'out' and 'non_blocking' arguments in a torch-like fashion to avoid dynamic memory allocation and implicit synchronisation points altogether.

## Motivation and Context

Currently, data accessors are taking a big part of the whole computation time, for several reasons. First, memory is systematically preallocated. Seconds, there are many runtime checks that are done systematically while they are only necessary for the first simulation step in RL applications. Finally, all operations are blocking, with explicit synchronisation. 

## How Has This Been / Can This Be Tested?

The unit tests are already partially checking the validity of the data accessors, but not if the return value of the getters are correct for now.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

