### PR TITLE
[BUG FIX] Add fallback when failing to parse actuators from MJCF file.

### DIFF
--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -154,50 +154,73 @@ def parse_link(mj, i_l, scale):
         j_info["dofs_kv"] = np.zeros((n_dofs,), dtype=gs.np_float)
         j_info["dofs_force_range"] = np.zeros((n_dofs, 2), dtype=gs.np_float)
 
-        for i_a in range(len(mj.actuator_trnid)):
-            if mj.actuator_trnid[i_a, 0] == i_j:
-                trntype = mujoco.mjtTrn(mj.actuator_trntype[i_a])
-                if trntype != mujoco.mjtTrn.mjTRN_JOINT:
-                    gs.logger.warning(f"(MJCF) Actuator type '{trntype}' not supported")
-                    break
-                if mj.actuator_dyntype[i_a] != mujoco.mjtDyn.mjDYN_NONE:
-                    gs.logger.warning(f"(MJCF) Actuator internal dynamics not supported")
-                    break
-                gaintype = mujoco.mjtGain(mj.actuator_gaintype[i_a])
-                if gaintype != mujoco.mjtGain.mjGAIN_FIXED:
-                    gs.logger.warning(f"(MJCF) Actuator control gain of type '{gaintype}' not supported")
-                    break
-                biastype = mujoco.mjtBias(mj.actuator_biastype[i_a])
-                if biastype not in (mujoco.mjtBias.mjBIAS_NONE, mujoco.mjtBias.mjBIAS_AFFINE):
-                    gs.logger.warning(f"(MJCF) Actuator control bias of type '{biastype}' not supported")
-                    break
-                if n_dofs > 1 and not (mj.actuator_gear[i_a, :n_dofs] == 1.0).all():
-                    gs.logger.warning("(MJCF) Actuator transmission gear is only supported of 1DoF joints")
-                    break
+        i_a = -1
+        try:
+            actuator_mask_j = (mj.actuator_trnid[:, 0] == i_j) & (mj.actuator_trntype == mujoco.mjtTrn.mjTRN_JOINT)
+            if actuator_mask_j.any():
+                (i_a,) = np.nonzero(actuator_mask_j)[0]
+            else:  # No actuator directly attached to the joint via mechanical transmission
+                # Special case where all tendon are attached to joint
+                if (mj.wrap_type == mujoco.mjtWrap.mjWRAP_JOINT).all():
+                    tendon_to_jnts = mj.wrap_objid.reshape((-1, 2))
+                    if i_j in tendon_to_jnts:
+                        (i_t,) = np.nonzero(tendon_to_jnts == i_j)[0]
+                        actuator_mask_t = (mj.actuator_trnid[:, 0] == i_t) & (
+                            mj.actuator_trntype == mujoco.mjtTrn.mjTRN_TENDON
+                        )
+                        (i_a,) = np.nonzero(actuator_mask_t)[0]
+                        gs.logger.warning(f"(MJCF) Approximating tendon by joint actuator for '{j_info["name"]}'")
+        except ValueError:
+            gs.logger.warning(f"(MJCF) Failed to parse actuator for joint '{j_info["name"]}'.")
 
-                if biastype == mujoco.mjtBias.mjBIAS_NONE:
-                    # Direct-drive
-                    actuator_kp = 0.0
-                    actuator_kv = 0.0
-                else:  # this must be affine
-                    # PD control
-                    gainprm = mj.actuator_gainprm[i_a]
-                    biasprm = mj.actuator_biasprm[i_a]
-                    if gainprm[0] != -biasprm[1] or gainprm[1:].any() or biasprm[0]:
-                        gs.logger.warning("(MJCF) Actuator gain and bias cannot be reduced to PD control")
-                        break
-                    actuator_kp, actuator_kv = biasprm[1:3]
+        if i_a >= 0:
+            if mj.actuator_dyntype[i_a] != mujoco.mjtDyn.mjDYN_NONE:
+                gs.logger.warning(f"(MJCF) Actuator internal dynamics not supported")
+            gaintype = mujoco.mjtGain(mj.actuator_gaintype[i_a])
+            if gaintype != mujoco.mjtGain.mjGAIN_FIXED:
+                gs.logger.warning(f"(MJCF) Actuator control gain of type '{gaintype}' not supported")
+            biastype = mujoco.mjtBias(mj.actuator_biastype[i_a])
+            if biastype not in (mujoco.mjtBias.mjBIAS_NONE, mujoco.mjtBias.mjBIAS_AFFINE):
+                gs.logger.warning(f"(MJCF) Actuator control bias of type '{biastype}' not supported")
+            if n_dofs > 1 and not (mj.actuator_gear[i_a, :n_dofs] == 1.0).all():
+                gs.logger.warning("(MJCF) Actuator transmission gear is only supported of 1DoF joints")
 
-                gear = mj.actuator_gear[i_a, 0]
-                j_info["dofs_kp"] = np.tile(-gear * actuator_kp, (n_dofs,))
-                j_info["dofs_kv"] = np.tile(-gear * actuator_kv, (n_dofs,))
-                if mj.actuator_forcelimited[i_a]:
-                    j_info["dofs_force_range"] = np.tile(mj.actuator_forcerange[i_a], (n_dofs, 1))
-                if mj.actuator_ctrllimited[i_a] and biastype == mujoco.mjtBias.mjBIAS_NONE:
-                    j_info["dofs_force_range"] = np.minimum(
-                        j_info["dofs_force_range"], np.tile(gear * mj.actuator_ctrlrange[i_a], (n_dofs, 1))
+            if biastype == mujoco.mjtBias.mjBIAS_NONE:
+                # Direct-drive
+                actuator_kp = 0.0
+                actuator_kv = 0.0
+            else:  # U = gain_term * ctrl + bias_term
+                # PD control
+                gainprm = mj.actuator_gainprm[i_a]
+                biasprm = mj.actuator_biasprm[i_a]
+                if gainprm[1:].any() or biasprm[0]:
+                    gs.logger.warning(
+                        "(MJCF) Actuator control gain and bias parameters not supported. Using default values."
                     )
-                break
+                    actuator_kp = gu.default_dofs_kp(1)[0]
+                    actuator_kv = gu.default_dofs_kv(1)[0]
+                elif gainprm[0] != -biasprm[1]:
+                    # Doing our best to approximate the expected behavior: g0 * p_target + b1 * p_mes + b2 * v_mes
+                    gs.logger.warning(
+                        "(MJCF) Actuator control gain and bias parameters cannot be reduced to a unique PD control "
+                        "position gain. Using max between gain and bias."
+                    )
+                    actuator_kp = min(-gainprm[0], biasprm[1])
+                    actuator_kv = biasprm[2]
+                else:
+                    actuator_kp, actuator_kv = biasprm[1], biasprm[2]
+
+            gear = mj.actuator_gear[i_a, 0]
+            j_info["dofs_kp"] = np.tile(-gear * actuator_kp, (n_dofs,))
+            j_info["dofs_kv"] = np.tile(-gear * actuator_kv, (n_dofs,))
+            if mj.actuator_forcelimited[i_a]:
+                j_info["dofs_force_range"] = np.tile(mj.actuator_forcerange[i_a], (n_dofs, 1))
+            if mj.actuator_ctrllimited[i_a] and biastype == mujoco.mjtBias.mjBIAS_NONE:
+                j_info["dofs_force_range"] = np.minimum(
+                    j_info["dofs_force_range"], np.tile(gear * mj.actuator_ctrlrange[i_a], (n_dofs, 1))
+                )
+        else:
+            gs.logger.debug(f"(MJCF) No actuator found for joint '{j_info["name"]}'")
 
         j_infos.append(j_info)
 


### PR DESCRIPTION
## Description

This PR restores the original behaviour from before https://github.com/Genesis-Embodied-AI/Genesis/pull/870 for joints whose attached actuator cannot be parsed. In this case, default PD controller gains are used instead of setting them to zeros. In the particular case where there is a mismatch between position gain associated with target and measured position, the maximum value between them is used instead of the default value. Moreover, tendons are now parsed to determine if an actuator is directly or indirectly attached to a joint. More warnings are printed to make sure that the user is aware of the aforementioned discrepancy when they occur.

## Related Issue

Resolves https://github.com/Genesis-Embodied-AI/Genesis/discussions/927

## Motivation and Context

Since https://github.com/Genesis-Embodied-AI/Genesis/pull/870, if no actuator is found for a given joint or it cannot be reduced to a simple PD controller, then the PD controller gains are set to zero, along with the force range for the corresponding DoFs. This is problematic because failing to parse is not uncommon, as some types of actuators are still not implemented or using unsupported parameters. To get around this limitation, it would be better to use default PD controller gains if the parameters cannot be parsed, or even better, some sensible approximation based on the parameters whenever possible.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?

<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.