### PR TITLE
[MISC] Update install procedure on README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,16 @@ Install **PyTorch** first following the [official instructions](https://pytorch.
 
 Then, install Genesis via PyPI:
 ```bash
-pip install genesis-world  # Requires Python >=3.9;
+pip install genesis-world  # Requires Python>=3.10,<3.13;
 ```
 
-For the latest version, clone the repository and install locally:
+For the latest version to date:
+```bash
+pip install git+https://github.com/Genesis-Embodied-AI/Genesis.git
+```
+Note that the package must still be updated manually to sync with main branch.
 
+Users seeking to edit the source code of Genesis are encourage to install Genesis in developper mode. First, make sure that `genesis-world` has been uninstalled, then clone the repository and install locally:
 ```bash
 git clone https://github.com/Genesis-Embodied-AI/Genesis.git
 cd Genesis

--- a/README_FR.md
+++ b/README_FR.md
@@ -69,13 +69,18 @@ Page du projet : <https://genesis-embodied-ai.github.io/>
 Genesis est disponible via PyPI :
 
 ```bash
-pip install genesis-world  # Nécessite Python >=3.9;
+pip install genesis-world  # Nécessite Python>=3.10,<3.10;
 ```
 
 Vous devez également installer **PyTorch** en suivant [les instructions officielles](https://pytorch.org/get-started/locally/).
 
-Pour la dernière version, clonez le dépôt et installez localement :
+Pour la dernière version à ce jour:
+```bash
+pip install git+https://github.com/Genesis-Embodied-AI/Genesis.git
+```
+A noter que le module doit malgré tout être mis à jour manuellement pour rester synchroniser avec la branche principale.
 
+Les utilisateur souhaitant éditer le code source de Genesis sont encouragés à l'installer en mode developpeur/éditable. Assurez vous que `genesis-world` est bien désinstallée, puis clonez le dépôt et installez localement :
 ```bash
 git clone https://github.com/Genesis-Embodied-AI/Genesis.git
 cd Genesis

--- a/README_JA.md
+++ b/README_JA.md
@@ -69,7 +69,7 @@ Genesisの目指すところ：
 GenesisはPyPIで利用可能です：
 
 ```bash
-pip install genesis-world  # Python >=3.9 が必要です;
+pip install genesis-world  # Python>=3.10,<3.13 が必要です;
 ```
 
 また、**PyTorch**を[公式手順](https://pytorch.org/get-started/locally/)に従ってインストールする必要があります。

--- a/README_KR.md
+++ b/README_KR.md
@@ -69,7 +69,7 @@ Genesis의 목표:
 Genesis는 PyPI를 통해 설치할 수 있습니다:
 
 ```bash
-pip install genesis-world  # Python >=3.9 필요
+pip install genesis-world  # Python>=3.10,<3.13 필요
 ```
 
 또한, [공식 설명서](https://pytorch.org/get-started/locally/)에 따라 **PyTorch**를 설치해야 합니다.


### PR DESCRIPTION
## Description

Clarify in README how to install the latest version of Genesis and which version of Python is supported.

## Related Issue

Resolves https://github.com/Genesis-Embodied-AI/Genesis/issues/930

## Motivation and Context

Currently, the proposed approach to install the latest version is not the best one, and breaks if the user already installed the version available on PyPI.

## How Has This Been / Can This Be Tested?

Just fallowing the README should be fine!

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
