### PR TITLE
[BUG FIX] Fix terrain support.

### DIFF
--- a/examples/rigid/terrain_subterrain.py
+++ b/examples/rigid/terrain_subterrain.py
@@ -57,16 +57,7 @@ def main():
     ########################## build ##########################
     scene.build(n_envs=100)
 
-    ball.set_pos(
-        torch.cat(
-            [
-                torch.range(1, 10, 1).unsqueeze(1).repeat(1, 10).unsqueeze(-1),
-                torch.range(1, 10, 1).unsqueeze(0).repeat(10, 1).unsqueeze(-1),
-                torch.ones(10, 10, 1),
-            ],
-            dim=-1,
-        ).reshape(-1, 3)
-    )
+    ball.set_pos(torch.cartesian_prod(*(torch.arange(1, 11),) * 2, torch.tensor((1,))))
 
     height_field = terrain.geoms[0].metadata["height_field"]
     rows = horizontal_scale * torch.range(0, height_field.shape[0] - 1, 1).unsqueeze(1).repeat(
@@ -80,7 +71,6 @@ def main():
     poss = torch.cat([rows, cols, heights], dim=-1).reshape(-1, 3)
     scene.draw_debug_spheres(poss=poss, radius=0.05, color=(0, 0, 1, 0.7))
     for _ in range(1000):
-        time.sleep(0.5)
         scene.step()
 
 

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -264,30 +264,6 @@ class RigidEntity(Entity):
         )
 
     def _load_terrain(self, morph, surface):
-        link, (joint,) = self._add_by_info(
-            l_info=dict(
-                name="baselink",
-                pos=np.array(morph.pos),
-                quat=np.array(morph.quat),
-                inertial_pos=None,
-                inertial_quat=gu.identity_quat(),
-                inertial_i=None,
-                inertial_mass=None,
-                parent_idx=-1,
-                invweight=None,
-            ),
-            j_infos=[
-                dict(
-                    name="joint_baselink",
-                    n_qs=0,
-                    n_dofs=0,
-                    type=gs.JOINT_TYPE.FIXED,
-                )
-            ],
-            morph=morph,
-            surface=surface,
-        )
-
         vmesh, mesh, self.terrain_hf = tu.parse_terrain(morph, surface)
         self.terrain_scale = np.array([morph.horizontal_scale, morph.vertical_scale])
 
@@ -310,6 +286,31 @@ class RigidEntity(Entity):
                     sol_params=gu.default_solver_params(n=1)[0],
                 )
             )
+
+        link, (joint,) = self._add_by_info(
+            l_info=dict(
+                name="baselink",
+                pos=np.array(morph.pos),
+                quat=np.array(morph.quat),
+                inertial_pos=None,
+                inertial_quat=gu.identity_quat(),
+                inertial_i=None,
+                inertial_mass=None,
+                parent_idx=-1,
+                invweight=None,
+            ),
+            j_infos=[
+                dict(
+                    name="joint_baselink",
+                    n_qs=0,
+                    n_dofs=0,
+                    type=gs.JOINT_TYPE.FIXED,
+                )
+            ],
+            g_infos=g_infos,
+            morph=morph,
+            surface=surface,
+        )
 
     def _load_MJCF(self, morph, surface):
         mj = mju.parse_mjcf(morph.file)

--- a/genesis/engine/mesh.py
+++ b/genesis/engine/mesh.py
@@ -10,6 +10,7 @@ import trimesh
 import genesis as gs
 import genesis.utils.mesh as mu
 import genesis.utils.particle as pu
+from genesis.ext import fast_simplification
 from genesis.repr_base import RBC
 
 
@@ -81,7 +82,14 @@ class Mesh(RBC):
         Decimate the mesh.
         """
         if self._mesh.vertices.shape[0] > 3 and self._mesh.faces.shape[0] > target_face_num:
-            self._mesh = self._mesh.simplify_quadric_decimation(target_face_num)
+            self._mesh = trimesh.Trimesh(
+                *fast_simplification.simplify(
+                    sdf_mesh.vertices,
+                    sdf_mesh.faces,
+                    target_count=target_face_num,
+                    lossless=True,
+                )
+            )
 
             # need to run convexify again after decimation, because sometimes decimating a convex-mesh can make it non-convex...
             if convexify:

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -14,6 +14,7 @@ import trimesh
 from PIL import Image
 
 import genesis as gs
+from genesis.ext import fast_simplification
 
 from . import geom as gu
 from .misc import (
@@ -173,7 +174,11 @@ def surface_uvs_to_trimesh_visual(surface, uvs=None, n_verts=None):
 def convex_decompose(mesh, morph):
     if morph.decimate:
         if mesh.vertices.shape[0] > 3:
-            mesh = mesh.simplify_quadric_decimation(morph.decimate_face_num)
+            mesh = trimesh.Trimesh(
+                *fast_simplification.simplify(
+                    mesh.vertices, mesh.faces, target_count=morph.decimate_face_num, lossless=True
+                )
+            )
 
     # compute file name via hashing for caching
     cvx_path = get_cvx_path(mesh.vertices, mesh.faces, morph.coacd_options)

--- a/genesis/utils/terrain.py
+++ b/genesis/utils/terrain.py
@@ -5,6 +5,7 @@ import pickle
 import trimesh
 
 import genesis as gs
+from genesis.ext import fast_simplification
 from genesis.ext.isaacgym import terrain_utils as isaacgym_terrain_utils
 from genesis.options.morphs import Terrain
 
@@ -343,7 +344,15 @@ def convert_heightfield_to_watertight_trimesh(height_field_raw, horizontal_scale
 
     # This a uniformly-distributed full mesh, which gives faster sdf generation
     sdf_mesh = trimesh.Trimesh(vertices, triangles, process=False)
-    # This is the mesh used for non-sdf purposes. It's losslessly simplified from the full mesh, to save memory cost for storing verts and faces
-    mesh = sdf_mesh.simplify_quadric_decimation(face_count=0, lossless=True)
+
+    # This is the mesh used for non-sdf purposes
+    mesh = trimesh.Trimesh(
+        *fast_simplification.simplify(
+            sdf_mesh.vertices,
+            sdf_mesh.faces,
+            target_count=0,
+            lossless=True,
+        )
+    )
 
     return mesh, sdf_mesh


### PR DESCRIPTION
## Description

This PR stops relying on high-level trimesh API `simplify_quadric_decimation` to call directly Genesis internally managed version of `fast_simplification`. Moreover, it fixes the API changes `_add_by_info` in `_load_terrain`. Finally, a unit test has been added to make sure this issue does not happen again.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/944

## Motivation and Context

Terrain support is currently broken. First, because of the implementation of compound joints that changed the API of `_add_by_info`. Second, because trimesh is no longer internally managed, and the internal API for `simplify_quadric_decimation` has not been backported as it should. 

## How Has This Been / Can This Be Tested?

Adding a unit test based on `examples/rigid/terrain_subterrain.py` example.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
