### PR TITLE
[FEATURE] Enable back convexify by default.

### DIFF
--- a/genesis/engine/mesh.py
+++ b/genesis/engine/mesh.py
@@ -77,17 +77,17 @@ class Mesh(RBC):
             self._mesh = trimesh.convex.convex_hull(self._mesh)
         self.clear_visuals()
 
-    def decimate(self, target_face_num, convexify):
+    def decimate(self, decimate_face_num, convexify):
         """
         Decimate the mesh.
         """
-        if self._mesh.vertices.shape[0] > 3 and self._mesh.faces.shape[0] > target_face_num:
+        if self._mesh.vertices.shape[0] > 3 and self._mesh.faces.shape[0] > decimate_face_num:
             self._mesh = trimesh.Trimesh(
                 *fast_simplification.simplify(
-                    sdf_mesh.vertices,
-                    sdf_mesh.faces,
-                    target_count=target_face_num,
-                    lossless=True,
+                    self._mesh.vertices,
+                    self._mesh.faces,
+                    target_count=decimate_face_num,
+                    agg=0,
                 )
             )
 

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -343,6 +343,13 @@ class Scene(RBC):
         else:
             gs.raise_exception()
 
+        # Rigid entities will convexify geom by default
+        if hasattr(morph, "convexify") and morph.convexify is None:
+            if isinstance(material, (gs.materials.Rigid, gs.materials.Avatar)):
+                morph.convexify = True
+            else:
+                morph.convexify = False
+
         entity = self._sim._add_entity(morph, material, surface, visualize_contact)
 
         return entity

--- a/genesis/engine/solvers/rigid/mpr_decomp.py
+++ b/genesis/engine/solvers/rigid/mpr_decomp.py
@@ -17,7 +17,7 @@ class MPR:
         self._para_level = rigid_solver._para_level
 
         if gs.ti_float == ti.f32:
-            self.CCD_EPS = 1e-6
+            self.CCD_EPS = 1e-7
         else:
             self.CCD_EPS = 1e-10
         self.CCD_TOLERANCE = 1e-6

--- a/genesis/options/misc.py
+++ b/genesis/options/misc.py
@@ -20,7 +20,10 @@ class CoacdOptions(Options):
     Reference: https://github.com/SarahWeiii/CoACD
     """
 
-    threshold: float = 0.05
+    # Main parameter to tune to improve the accuracy.
+    # As a rule of thumbs, dividing the threshold by two would double the number of convex hulls.
+    threshold: float = 0.1
+
     max_convex_hull: int = -1
     preprocess_mode: str = "auto"  # ['on', 'off', 'auto']
     preprocess_resolution: int = 30

--- a/genesis/options/misc.py
+++ b/genesis/options/misc.py
@@ -21,19 +21,19 @@ class CoacdOptions(Options):
     """
 
     threshold: float = 0.1
-    max_convex_hull: int = -1
+    max_convex_hull: int = 40
     preprocess_mode: str = "auto"  # ['on', 'off', 'auto']
     preprocess_resolution: int = 30
-    resolution: int = 2000
+    resolution: int = 1000
     mcts_nodes: int = 20
-    mcts_iterations: int = 150
+    mcts_iterations: int = 100
     mcts_max_depth: int = 3
     pca: int = False
     merge: bool = True
     decimate: bool = False
     max_ch_vertex: int = 256
     extrude: bool = False
-    extrude_margin: float = 0.01
+    extrude_margin: float = 0.05
     apx_mode: str = "ch"  # ['ch', 'box']
     seed: int = 0
 

--- a/genesis/options/misc.py
+++ b/genesis/options/misc.py
@@ -20,8 +20,8 @@ class CoacdOptions(Options):
     Reference: https://github.com/SarahWeiii/CoACD
     """
 
-    threshold: float = 0.1
-    max_convex_hull: int = 40
+    threshold: float = 0.05
+    max_convex_hull: int = -1
     preprocess_mode: str = "auto"  # ['on', 'off', 'auto']
     preprocess_resolution: int = 30
     resolution: int = 1000
@@ -33,7 +33,7 @@ class CoacdOptions(Options):
     decimate: bool = False
     max_ch_vertex: int = 256
     extrude: bool = False
-    extrude_margin: float = 0.05
+    extrude_margin: float = 0.1
     apx_mode: str = "ch"  # ['ch', 'box']
     seed: int = 0
 

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -312,7 +312,7 @@ class FileMorph(Morph):
         This parameter is deprecated. Please refers to 'convexify' and 'decompose_error_threshold' instead.
     decompose_error_threshold : bool, optional:
         Skip decompose if the relative difference between the volume of original mesh and its convex hull is lower than
-        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.15 (15%).
+        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.2 (20%).
     coacd_options : CoacdOptions, optional
         Options for configuring coacd convex decomposition. Needs to be a `gs.options.CoacdOptions` object.
     visualization : bool, optional
@@ -329,7 +329,7 @@ class FileMorph(Morph):
     decimate_face_num: int = 500
     convexify: bool = True
     decompose_nonconvex: Optional[bool] = None
-    decompose_error_threshold: float = 0.15
+    decompose_error_threshold: float = 0.2
     coacd_options: Optional[CoacdOptions] = None
     recompute_inertia: bool = False
 
@@ -411,7 +411,7 @@ class Mesh(FileMorph):
         This parameter is deprecated. Please refers to 'convexify' and 'decompose_error_threshold' instead.
     decompose_error_threshold : bool, optional:
         Skip decompose if the relative difference between the volume of original mesh and its convex hull is lower than
-        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.15 (15%).
+        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.2 (20%).
     coacd_options : CoacdOptions, optional
         Options for configuring coacd convex decomposition. Needs to be a `gs.options.CoacdOptions` object.
     merge_submeshes_for_collision : bool, optional
@@ -510,7 +510,7 @@ class MJCF(FileMorph):
         This parameter is deprecated. Please refers to 'convexify' and 'decompose_error_threshold' instead.
     decompose_error_threshold : bool, optional:
         Skip decompose if the relative difference between the volume of original mesh and its convex hull is lower than
-        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.15 (15%).
+        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.2 (20%).
     coacd_options : CoacdOptions, optional
         Options for configuring coacd convex decomposition. Needs to be a `gs.options.CoacdOptions` object.
     visualization : bool, optional
@@ -568,7 +568,7 @@ class URDF(FileMorph):
         This parameter is deprecated. Please refers to 'convexify' and 'decompose_error_threshold' instead.
     decompose_error_threshold : bool, optional:
         Skip decompose if the relative difference between the volume of original mesh and its convex hull is lower than
-        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.15 (15%).
+        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.2 (20%).
     coacd_options : CoacdOptions, optional
         Options for configuring coacd convex decomposition. Needs to be a `gs.options.CoacdOptions` object.
     visualization : bool, optional
@@ -633,7 +633,7 @@ class Drone(FileMorph):
         This parameter is deprecated. Please refers to 'convexify' and 'decompose_error_threshold' instead.
     decompose_error_threshold : bool, optional:
         Skip decompose if the relative difference between the volume of original mesh and its convex hull is lower than
-        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.15 (15%).
+        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.2 (20%).
     coacd_options : CoacdOptions, optional
         Options for configuring coacd convex decomposition. Needs to be a `gs.options.CoacdOptions` object.
     visualization : bool, optional

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -298,8 +298,23 @@ class FileMorph(Morph):
         The euler angle of the entity in degrees. This follows scipy's extrinsic x-y-z rotation convention. Defaults to (0.0, 0.0, 0.0).
     quat : tuple, shape (4,), optional
         The quaternion (w-x-y-z convention) of the entity. If specified, `euler` will be ignored. Defaults to None.
+    decimate : bool, optional
+        Whether to decimate (simplify) the mesh. Defaults to True. **This is only used for RigidEntity.**
+    decimate_face_num : int, optional
+        The number of faces to decimate to. Defaults to 500. **This is only used for RigidEntity.**
     convexify : bool, optional
-        Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted to a convex hull. False by default.
+        Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
+        to a set of convex hulls. The mesh with be decomposed into multiple convex components if a single one is not
+        sufficient to met the desired accuracy (see 'decompose_error_threshold' documentation). The module 'coacd' is
+        used for this decomposition process. If not given, it defaults to `True` for `RigidEntity` and `False` for
+        other deformable entities.
+    decompose_nonconvex: bool, optional
+        This parameter is deprecated. Please refers to 'convexify' and 'decompose_error_threshold' instead.
+    decompose_error_threshold : bool, optional:
+        Skip decompose if the relative difference between the volume of original mesh and its convex hull is lower than
+        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.15 (15%).
+    coacd_options : CoacdOptions, optional
+        Options for configuring coacd convex decomposition. Needs to be a `gs.options.CoacdOptions` object.
     visualization : bool, optional
         Whether the entity needs to be visualized. Set it to False if you need a invisible object only for collision purposes. Defaults to True. `visualization` and `collision` cannot both be False. **This is only used for RigidEntity.**
     collision : bool, optional
@@ -310,11 +325,35 @@ class FileMorph(Morph):
 
     file: Any = ""
     scale: Union[float, tuple] = 1.0
-    convexify: bool = False
+    decimate: bool = False
+    decimate_face_num: int = 500
+    convexify: bool = True
+    decompose_nonconvex: Optional[bool] = None
+    decompose_error_threshold: float = 0.15
+    coacd_options: Optional[CoacdOptions] = None
     recompute_inertia: bool = False
 
     def __init__(self, **data):
         super().__init__(**data)
+
+        if self.decompose_nonconvex is not None:
+            if self.decompose_nonconvex:
+                self.convexify = True
+                self.decompose_error_threshold = 0.0
+            else:
+                self.convexify = False
+                self.decompose_error_threshold = float("inf")
+            gs.warning(
+                "`decompose_nonconvex` is deprecated. Please use 'convexify' and 'decompose_error_threshold' instead."
+            )
+
+        if self.decimate and self.decimate_face_num < 100:
+            gs.raise_exception(
+                "`decimate_face_num` should be greater than 100 to ensure sufficient geometry details are preserved."
+            )
+
+        if self.coacd_options is None:
+            self.coacd_options = CoacdOptions()
 
         if isinstance(self.file, str):
             file = os.path.abspath(self.file)
@@ -358,12 +397,25 @@ class Mesh(FileMorph):
         The euler angle of the entity in degrees. This follows scipy's extrinsic x-y-z rotation convention. Defaults to (0.0, 0.0, 0.0).
     quat : tuple, shape (4,), optional
         The quaternion (w-x-y-z convention) of the entity. If specified, `euler` will be ignored. Defaults to None.
+    decimate : bool, optional
+        Whether to decimate (simplify) the mesh. Defaults to True. **This is only used for RigidEntity.**
+    decimate_face_num : int, optional
+        The number of faces to decimate to. Defaults to 500. **This is only used for RigidEntity.**
     convexify : bool, optional
-        Whether to convexify the entity. When convexify is True, all the meshes in the entity will be converted to a convex hull. False by default.
-    decompose_nonconvex : bool, optional
-        Whether to decompose meshes into convex components, if input mesh is nonconvex and `convexify=False`. We use coacd for this decomposition process. False by default.
+        Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
+        to a set of convex hulls. The mesh with be decomposed into multiple convex components if a single one is not
+        sufficient to met the desired accuracy (see 'decompose_error_threshold' documentation). The module 'coacd' is
+        used for this decomposition process. If not given, it defaults to `True` for `RigidEntity` and `False` for
+        other deformable entities.
+    decompose_nonconvex: bool, optional
+        This parameter is deprecated. Please refers to 'convexify' and 'decompose_error_threshold' instead.
+    decompose_error_threshold : bool, optional:
+        Skip decompose if the relative difference between the volume of original mesh and its convex hull is lower than
+        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.15 (15%).
     coacd_options : CoacdOptions, optional
         Options for configuring coacd convex decomposition. Needs to be a `gs.options.CoacdOptions` object.
+    merge_submeshes_for_collision : bool, optional
+        Whether to merge submeshes for collision. Defaults to True. **This is only used for RigidEntity.**
     visualization : bool, optional
         Whether the entity needs to be visualized. Set it to False if you need a invisible object only for collision purposes. Defaults to True. `visualization` and `collision` cannot both be False. **This is only used for RigidEntity.**
     collision : bool, optional
@@ -376,12 +428,6 @@ class Mesh(FileMorph):
         Whether the baselink of the entity should be fixed. Defaults to False. **This is only used for RigidEntity.**
     group_by_material : bool, optional
         Whether to group submeshes by their visual material type defined in the asset file. Defaults to True. **This is only used for RigidEntity.**
-    merge_submeshes_for_collision : bool, optional
-        Whether to merge submeshes for collision. Defaults to True. **This is only used for RigidEntity.**
-    decimate : bool, optional
-        Whether to decimate (simplify) the mesh. Defaults to True. **This is only used for RigidEntity.**
-    decimate_face_num : int, optional
-        The number of faces to decimate to. Defaults to 500. **This is only used for RigidEntity.**
     order : int, optional
         The order of the FEM mesh. Defaults to 1. **This is only used for FEMEntity.**
     mindihedral : int, optional
@@ -405,10 +451,6 @@ class Mesh(FileMorph):
     fixed: bool = False
     group_by_material: bool = True
     merge_submeshes_for_collision: bool = True
-    decimate: bool = False
-    decimate_face_num: int = 500
-    decompose_nonconvex: bool = False
-    coacd_options: Optional[CoacdOptions] = None
 
     # FEM specific
     order: int = 1
@@ -421,16 +463,6 @@ class Mesh(FileMorph):
     verbose: int = 0
 
     force_retet: bool = False
-
-    def __init__(self, **data):
-        super().__init__(**data)
-        if self.decimate and self.decimate_face_num < 100:
-            gs.raise_exception(
-                "`decimate_face_num` should be greater than 100 to ensure sufficient geometry details are preserved."
-            )
-
-        if self.coacd_options is None:
-            self.coacd_options = CoacdOptions()
 
 
 class MeshSet(Mesh):
@@ -464,8 +496,23 @@ class MJCF(FileMorph):
         The euler angle of the entity's baselink in degrees. This follows scipy's extrinsic x-y-z rotation convention. Defaults to (0.0, 0.0, 0.0).
     quat : tuple, shape (4,), optional
         The quaternion (w-x-y-z convention) of the entity's baselink. If specified, `euler` will be ignored. Defaults to None.
+    decimate : bool, optional
+        Whether to decimate (simplify) the mesh. Defaults to True. **This is only used for RigidEntity.**
+    decimate_face_num : int, optional
+        The number of faces to decimate to. Defaults to 500. **This is only used for RigidEntity.**
     convexify : bool, optional
-        Whether to convexify the entity. When convexify is True, all the meshes in the entity will be converted to a convex hull. If not given, it defaults to `True` for `RigidEntity` and `False` for other deformable entities.
+        Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
+        to a set of convex hulls. The mesh with be decomposed into multiple convex components if a single one is not
+        sufficient to met the desired accuracy (see 'decompose_error_threshold' documentation). The module 'coacd' is
+        used for this decomposition process. If not given, it defaults to `True` for `RigidEntity` and `False` for
+        other deformable entities.
+    decompose_nonconvex: bool, optional
+        This parameter is deprecated. Please refers to 'convexify' and 'decompose_error_threshold' instead.
+    decompose_error_threshold : bool, optional:
+        Skip decompose if the relative difference between the volume of original mesh and its convex hull is lower than
+        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.15 (15%).
+    coacd_options : CoacdOptions, optional
+        Options for configuring coacd convex decomposition. Needs to be a `gs.options.CoacdOptions` object.
     visualization : bool, optional
         Whether the entity needs to be visualized. Set it to False if you need a invisible object only for collision purposes. Defaults to True. `visualization` and `collision` cannot both be False.
     collision : bool, optional
@@ -507,8 +554,23 @@ class URDF(FileMorph):
         The euler angle of the entity in degrees. This follows scipy's extrinsic x-y-z rotation convention. Defaults to (0.0, 0.0, 0.0).
     quat : tuple, shape (4,), optional
         The quaternion (w-x-y-z convention) of the entity. If specified, `euler` will be ignored. Defaults to None.
+    decimate : bool, optional
+        Whether to decimate (simplify) the mesh. Defaults to True. **This is only used for RigidEntity.**
+    decimate_face_num : int, optional
+        The number of faces to decimate to. Defaults to 500. **This is only used for RigidEntity.**
     convexify : bool, optional
-        Whether to convexify the entity. When convexify is True, all the meshes in the entity will be converted to a convex hull. If not given, it defaults to `True` for `RigidEntity` and `False` for other deformable entities.
+        Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
+        to a set of convex hulls. The mesh with be decomposed into multiple convex components if a single one is not
+        sufficient to met the desired accuracy (see 'decompose_error_threshold' documentation). The module 'coacd' is
+        used for this decomposition process. If not given, it defaults to `True` for `RigidEntity` and `False` for
+        other deformable entities.
+    decompose_nonconvex: bool, optional
+        This parameter is deprecated. Please refers to 'convexify' and 'decompose_error_threshold' instead.
+    decompose_error_threshold : bool, optional:
+        Skip decompose if the relative difference between the volume of original mesh and its convex hull is lower than
+        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.15 (15%).
+    coacd_options : CoacdOptions, optional
+        Options for configuring coacd convex decomposition. Needs to be a `gs.options.CoacdOptions` object.
     visualization : bool, optional
         Whether the entity needs to be visualized. Set it to False if you need a invisible object only for collision purposes. Defaults to True. `visualization` and `collision` cannot both be False.
     collision : bool, optional
@@ -557,8 +619,23 @@ class Drone(FileMorph):
         The euler angle of the entity in degrees. This follows scipy's extrinsic x-y-z rotation convention. Defaults to (0.0, 0.0, 0.0).
     quat : tuple, shape (4,), optional
         The quaternion (w-x-y-z convention) of the entity. If specified, `euler` will be ignored. Defaults to None.
+    decimate : bool, optional
+        Whether to decimate (simplify) the mesh. Defaults to True. **This is only used for RigidEntity.**
+    decimate_face_num : int, optional
+        The number of faces to decimate to. Defaults to 500. **This is only used for RigidEntity.**
     convexify : bool, optional
-        Whether to convexify the entity. When convexify is True, all the meshes in the entity will be converted to a convex hull. If not given, it defaults to `True` for `RigidEntity` and `False` for other deformable entities.
+        Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
+        to a set of convex hulls. The mesh with be decomposed into multiple convex components if a single one is not
+        sufficient to met the desired accuracy (see 'decompose_error_threshold' documentation). The module 'coacd' is
+        used for this decomposition process. If not given, it defaults to `True` for `RigidEntity` and `False` for
+        other deformable entities.
+    decompose_nonconvex: bool, optional
+        This parameter is deprecated. Please refers to 'convexify' and 'decompose_error_threshold' instead.
+    decompose_error_threshold : bool, optional:
+        Skip decompose if the relative difference between the volume of original mesh and its convex hull is lower than
+        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.15 (15%).
+    coacd_options : CoacdOptions, optional
+        Options for configuring coacd convex decomposition. Needs to be a `gs.options.CoacdOptions` object.
     visualization : bool, optional
         Whether the entity needs to be visualized. Set it to False if you need a invisible object only for collision purposes. Defaults to True. `visualization` and `collision` cannot both be False.
     collision : bool, optional

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -171,17 +171,16 @@ def surface_uvs_to_trimesh_visual(surface, uvs=None, n_verts=None):
     return visual
 
 
-def convex_decompose(mesh, morph):
-    if morph.decimate:
+def convex_decompose(mesh, decimate, decimate_face_num, coacd_options):
+    if decimate:
         if mesh.vertices.shape[0] > 3:
-            mesh = trimesh.Trimesh(
-                *fast_simplification.simplify(
-                    mesh.vertices, mesh.faces, target_count=morph.decimate_face_num, lossless=True
+            if len(mesh.faces) > decimate_face_num:
+                mesh = trimesh.Trimesh(
+                    *fast_simplification.simplify(mesh.vertices, mesh.faces, target_count=decimate_face_num, agg=0)
                 )
-            )
 
     # compute file name via hashing for caching
-    cvx_path = get_cvx_path(mesh.vertices, mesh.faces, morph.coacd_options)
+    cvx_path = get_cvx_path(mesh.vertices, mesh.faces, coacd_options)
 
     # loading pre-computed cache if available
     is_cached_loaded = False
@@ -197,7 +196,7 @@ def convex_decompose(mesh, morph):
     if not is_cached_loaded:
         with gs.logger.timer("Running convex decomposition."):
             mesh = coacd.Mesh(mesh.vertices, mesh.faces)
-            args = morph.coacd_options
+            args = coacd_options
             result = coacd.run_coacd(
                 mesh,
                 threshold=args.threshold,
@@ -228,86 +227,37 @@ def convex_decompose(mesh, morph):
     return mesh_parts
 
 
-def parse_visual_and_col_mesh(morph, surface):
-    """
-    Returns a list of meshes, each will be stored in as a `RigidGeom`.
-    We parse all the submeshes in the obj file.
-    If group_by_material=True, we group them based on their associated materials. This will dramatically speed up parsing, since we only need to load texture images on a group basis.
-    """
-    vms = gs.Mesh.from_morph_surface(morph, surface)
+def postprocess_mesh(mesh, decimate, decimate_face_num, convexify, decompose_error_threshold, coacd_options):
+    # Compute non-convex morph if enabled and deemed necessary
+    tmesh = mesh.trimesh
+    tmeshes = (tmesh,)
+    if convexify and not tmesh.is_convex:
+        # Compute convex hull approximation error.
+        # If not that bad then use the convex hull directly, it would save a lot of time!
+        cmesh = trimesh.convex.convex_hull(tmesh)
+        if cmesh.volume / tmesh.volume > 1.0 + decompose_error_threshold:
+            tmeshes = convex_decompose(tmesh, decimate, decimate_face_num, coacd_options)
 
-    # compute collision mesh
-    ms = list()
-
-    if not morph.collision:
-        return vms, ms
-
-    if morph.merge_submeshes_for_collision:
-        tmeshes = []
-        for vm in vms:
-            tmeshes.append(vm.trimesh)
-        tmesh = trimesh.util.concatenate(tmeshes)
-
+    # Process of meshes sequentially
+    ms = []
+    for tmesh in tmeshes:
         num_vertices = len(tmesh.vertices)
-        if num_vertices > 5000:
+        if not convexify and not decimate and num_vertices > 5000:
             gs.logger.warning(
-                f"Mesh '{morph.file}' contains many vertices ({num_vertices}). Consider setting "
-                "'morph.decimate=True' to speed up collision detection."
+                f"At least one of the meshes contain many vertices ({num_vertices}). Consider setting "
+                "'morph.decimate=True' or 'morph.convexify=True' to speed up collision detection and improve numerical "
+                "stability."
             )
-        if not tmesh.is_convex and not (morph.convexify or morph.decompose_nonconvex):
-            gs.logger.warning(
-                f"Mesh '{morph.file}' is non-convex. Consider setting 'morph.decompose_nonconvex=True' "
-                "or 'morph.convexify=True' to speed up collision detection."
+        ms.append(
+            gs.Mesh.from_trimesh(
+                mesh=tmesh,
+                convexify=convexify,
+                decimate=decimate,
+                decimate_face_num=decimate_face_num,
+                surface=gs.surfaces.Collision(),
             )
-
-        if morph.convexify or tmesh.is_convex or not morph.decompose_nonconvex:
-            ms.append(
-                gs.Mesh.from_trimesh(
-                    mesh=tmesh,
-                    convexify=morph.convexify,
-                    decimate=morph.decimate,
-                    decimate_face_num=morph.decimate_face_num,
-                    surface=gs.surfaces.Collision(),
-                )
-            )
-        else:
-            tmeshes = convex_decompose(tmesh, morph)
-            for tmesh in tmeshes:
-                ms.append(
-                    gs.Mesh.from_trimesh(
-                        mesh=tmesh,
-                        convexify=True,  # just to make sure
-                        decimate=morph.decimate,
-                        surface=gs.surfaces.Collision(),
-                    )
-                )
-
-    else:
-        for vm in vms:
-            if morph.convexify or vm.trimesh.is_convex or not morph.decompose_nonconvex:
-                ms.append(
-                    gs.Mesh.from_trimesh(
-                        mesh=vm.trimesh,
-                        convexify=morph.convexify,
-                        decimate=morph.decimate,
-                        decimate_face_num=morph.decimate_face_num,
-                        surface=gs.surfaces.Collision(),
-                    )
-                )
-            else:
-                tmeshes = convex_decompose(vm.trimesh, morph)
-                for tmesh in tmeshes:
-                    ms.append(
-                        gs.Mesh.from_trimesh(
-                            mesh=tmesh,
-                            convexify=True,  # just to make sure
-                            decimate=morph.decimate,
-                            decimate_face_num=morph.decimate_face_num,
-                            surface=gs.surfaces.Collision(),
-                        )
-                    )
-
-    return vms, ms
+        )
+    return ms
 
 
 def parse_mesh_trimesh(path, group_by_material, scale, surface):

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -235,7 +235,12 @@ def postprocess_mesh(mesh, decimate, decimate_face_num, convexify, decompose_err
         # Compute convex hull approximation error.
         # If not that bad then use the convex hull directly, it would save a lot of time!
         cmesh = trimesh.convex.convex_hull(tmesh)
-        if cmesh.volume / tmesh.volume > 1.0 + decompose_error_threshold:
+        volume_err = cmesh.volume / tmesh.volume - 1.0
+        if volume_err > decompose_error_threshold:
+            gs.logger.info(
+                f"Convex hull is not accurate enough for collision detection ({volume_err:.3f}). "
+                "Falling back to more expensive convex decomposition (see FileMorph options)."
+            )
             tmeshes = convex_decompose(tmesh, decimate, decimate_face_num, coacd_options)
 
     # Process of meshes sequentially

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -252,7 +252,7 @@ def parse_links(mj, scale):
     return l_infos, j_infos
 
 
-def parse_geom(mj, i_g, scale, convexify, surface, xml_path):
+def parse_geom(mj, i_g, scale, surface, xml_path):
     mj_geom = mj.geom(i_g)
 
     geom_size = mj_geom.size
@@ -388,18 +388,9 @@ def parse_geom(mj, i_g, scale, convexify, surface, xml_path):
         gs.logger.warning(f"Unsupported MJCF geom type '{mj_geom.type}'.")
         return None
 
-    # Turn on convexify for all primitive shapes
-    if mj_geom.type != mujoco.mjtGeom.mjGEOM_MESH:
-        convexify = True
-
-    # Disable convexify for visual geometries
-    if not is_col:
-        convexify = False
-
     mesh = gs.Mesh.from_trimesh(
         tmesh,
         scale=scale,
-        convexify=convexify,
         surface=gs.surfaces.Collision() if is_col else surface,
     )
 
@@ -416,7 +407,6 @@ def parse_geom(mj, i_g, scale, convexify, surface, xml_path):
         "contype": mj_geom.contype[0],
         "conaffinity": mj_geom.conaffinity[0],
         "group": mj_geom.group[0],
-        "is_convex": convexify,
         "data": geom_size,
         "friction": mj_geom.friction[0],
         "sol_params": np.concatenate((mj_geom.solref, mj_geom.solimp)),
@@ -429,7 +419,7 @@ def parse_geom(mj, i_g, scale, convexify, surface, xml_path):
     return info
 
 
-def parse_geoms(mj, scale, convexify, surface, xml_path):
+def parse_geoms(mj, scale, surface, xml_path):
     links_g_info = [[] for _ in range(mj.nbody)]
 
     # Loop over all geometries sequentially
@@ -439,7 +429,7 @@ def parse_geoms(mj, scale, convexify, surface, xml_path):
             continue
 
         # try parsing a given geometry
-        g_info = parse_geom(mj, i_g, scale, convexify, surface, xml_path)
+        g_info = parse_geom(mj, i_g, scale, surface, xml_path)
         if g_info is None:
             continue
 

--- a/genesis/utils/terrain.py
+++ b/genesis/utils/terrain.py
@@ -345,14 +345,10 @@ def convert_heightfield_to_watertight_trimesh(height_field_raw, horizontal_scale
     # This a uniformly-distributed full mesh, which gives faster sdf generation
     sdf_mesh = trimesh.Trimesh(vertices, triangles, process=False)
 
-    # This is the mesh used for non-sdf purposes
+    # This is the mesh used for non-sdf purposes.
+    # It's losslessly simplified from the full mesh, to save memory cost for storing verts and faces.
     mesh = trimesh.Trimesh(
-        *fast_simplification.simplify(
-            sdf_mesh.vertices,
-            sdf_mesh.faces,
-            target_count=0,
-            lossless=True,
-        )
+        *fast_simplification.simplify(sdf_mesh.vertices, sdf_mesh.faces, target_count=0, lossless=True)
     )
 
     return mesh, sdf_mesh

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -527,6 +527,7 @@ def test_nonconvex_collision(show_viewer):
         scene.viewer.stop()
 
 
+@pytest.mark.xfail(reason="Need to fine a way to download these assets from somewhere else.")
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu], indirect=True)
 def test_convexify(show_viewer):
     # The test check that the volume difference is under a given threshold and
@@ -572,12 +573,12 @@ def test_convexify(show_viewer):
     assert len(mug.geoms) > 15
     assert len(donut.geoms) > 30
 
-    for i in range(4000):
+    for i in range(5000):
         scene.step()
 
     for obj in objs:
         qvel = obj.get_dofs_velocity().cpu()
-        np.testing.assert_allclose(qvel, 0, atol=5e-2)
+        np.testing.assert_allclose(qvel, 0, atol=0.1)
         qpos = obj.get_dofs_position().cpu()
         np.testing.assert_array_less(0, qpos[2])
         np.testing.assert_array_less(torch.linalg.norm(qpos[:2]), 0.5)

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -555,9 +555,6 @@ def test_convexify(show_viewer):
                 file=f"meshes/{asset_name}/output.xml",
                 pos=(0.0, 0.15 * (i - 1.5), 0.4),
             ),
-            surface=gs.surfaces.Default(
-                color=(*np.random.rand(3), 1.0),
-            ),
             vis_mode="collision",
         )
         objs.append(obj)

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -527,7 +527,7 @@ def test_nonconvex_collision(show_viewer):
         scene.viewer.stop()
 
 
-@pytest.mark.parametrize("backend", [gs.cpu], indirect=True)
+@pytest.mark.parametrize("backend", [gs.gpu, gs.cpu], indirect=True)
 def test_convexify(show_viewer):
     # The test check that the volume difference is under a given threshold and
     # that convex decomposition is only used whenever it is necessary.
@@ -539,7 +539,6 @@ def test_convexify(show_viewer):
         show_viewer=show_viewer,
         show_FPS=False,
     )
-    scene.add_entity(gs.morphs.Plane())
     tank = scene.add_entity(
         gs.morphs.Mesh(
             file="meshes/tank.obj",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description

* Support mesh post-processing for all file morphs.
* Improve convexify VS decompose switch logics. 
* Enable back convexify by default.
* Add convex collision detection unit test.

## Related Issue

Resolves  Genesis-Embodied-AI/Genesis/issues/614
Resolves Genesis-Embodied-AI/Genesis/issues/951
Related to Genesis-Embodied-AI/Genesis/issues/602

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I read the **CONTRIBUTING** document.
- [ ] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [ ] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
