### PR TITLE
[FEATURE] Merge meshes before convex decomposition.

### DIFF
--- a/examples/rigid/convex_decomposition.py
+++ b/examples/rigid/convex_decomposition.py
@@ -1,0 +1,50 @@
+import argparse
+
+import genesis as gs
+
+
+def main():
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--vis", action="store_true", default=False)
+    parser.add_argument("-c", "--cpu", action="store_true", default=False)
+    args = parser.parse_args()
+
+    ########################## init ##########################
+    gs.init(backend=gs.cpu if args.cpu else gs.gpu)
+
+    ########################## create a scene ##########################
+    scene = gs.Scene(
+        rigid_options=gs.options.RigidOptions(
+            dt=0.005,
+        ),
+        show_viewer=args.vis,
+    )
+
+    ########################## entities ##########################
+    scene.add_entity(
+        gs.morphs.Mesh(
+            file="meshes/tank.obj",
+            scale=5.0,
+            fixed=True,
+            euler=(90, 0, 90),
+        ),
+        # vis_mode="collision",
+    )
+    for i, asset_name in enumerate(("donut_0", "mug_1", "cup_2", "apple_15")):
+        scene.add_entity(
+            gs.morphs.MJCF(
+                file=f"meshes/{asset_name}/output.xml",
+                pos=(0.0, 0.15 * (i - 1.5), 0.4),
+            ),
+            # vis_mode="collision",
+        )
+
+    ########################## build ##########################
+    scene.build()
+    for i in range(4000):
+        scene.step()
+
+
+if __name__ == "__main__":
+    main()

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -312,7 +312,7 @@ class FileMorph(Morph):
         This parameter is deprecated. Please refers to 'convexify' and 'decompose_error_threshold' instead.
     decompose_error_threshold : bool, optional:
         Skip decompose if the relative difference between the volume of original mesh and its convex hull is lower than
-        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.2 (20%).
+        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.15 (15%).
     coacd_options : CoacdOptions, optional
         Options for configuring coacd convex decomposition. Needs to be a `gs.options.CoacdOptions` object.
     visualization : bool, optional
@@ -329,7 +329,7 @@ class FileMorph(Morph):
     decimate_face_num: int = 500
     convexify: bool = True
     decompose_nonconvex: Optional[bool] = None
-    decompose_error_threshold: float = 0.2
+    decompose_error_threshold: float = 0.15
     coacd_options: Optional[CoacdOptions] = None
     recompute_inertia: bool = False
 
@@ -411,7 +411,7 @@ class Mesh(FileMorph):
         This parameter is deprecated. Please refers to 'convexify' and 'decompose_error_threshold' instead.
     decompose_error_threshold : bool, optional:
         Skip decompose if the relative difference between the volume of original mesh and its convex hull is lower than
-        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.2 (20%).
+        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.15 (15%).
     coacd_options : CoacdOptions, optional
         Options for configuring coacd convex decomposition. Needs to be a `gs.options.CoacdOptions` object.
     merge_submeshes_for_collision : bool, optional
@@ -510,7 +510,7 @@ class MJCF(FileMorph):
         This parameter is deprecated. Please refers to 'convexify' and 'decompose_error_threshold' instead.
     decompose_error_threshold : bool, optional:
         Skip decompose if the relative difference between the volume of original mesh and its convex hull is lower than
-        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.2 (20%).
+        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.15 (15%).
     coacd_options : CoacdOptions, optional
         Options for configuring coacd convex decomposition. Needs to be a `gs.options.CoacdOptions` object.
     visualization : bool, optional
@@ -568,7 +568,7 @@ class URDF(FileMorph):
         This parameter is deprecated. Please refers to 'convexify' and 'decompose_error_threshold' instead.
     decompose_error_threshold : bool, optional:
         Skip decompose if the relative difference between the volume of original mesh and its convex hull is lower than
-        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.2 (20%).
+        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.15 (15%).
     coacd_options : CoacdOptions, optional
         Options for configuring coacd convex decomposition. Needs to be a `gs.options.CoacdOptions` object.
     visualization : bool, optional
@@ -633,7 +633,7 @@ class Drone(FileMorph):
         This parameter is deprecated. Please refers to 'convexify' and 'decompose_error_threshold' instead.
     decompose_error_threshold : bool, optional:
         Skip decompose if the relative difference between the volume of original mesh and its convex hull is lower than
-        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.2 (20%).
+        this threashold. 0.0 to enforce decomposition, float("inf") to disable it completly. Defaults to 0.15 (15%).
     coacd_options : CoacdOptions, optional
         Options for configuring coacd convex decomposition. Needs to be a `gs.options.CoacdOptions` object.
     visualization : bool, optional

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -569,9 +569,9 @@ def test_convexify(show_viewer):
     # but for the others it is hard to tell... Let's use some reasonable guess.
     mug, donut, cup, apple = objs
     assert len(apple.geoms) == 1
-    assert len(cup.geoms) > 5
-    assert len(mug.geoms) > 15
-    assert len(donut.geoms) > 30
+    assert 5 <= len(donut.geoms) <= 10
+    assert 5 <= len(cup.geoms) <= 20
+    assert 5 <= len(mug.geoms) <= 40
 
     for i in range(5000):
         scene.step()
@@ -581,6 +581,7 @@ def test_convexify(show_viewer):
         np.testing.assert_allclose(qvel, 0, atol=0.1)
         qpos = obj.get_dofs_position().cpu()
         np.testing.assert_array_less(0, qpos[2])
+        np.testing.assert_array_less(qpos[2], 0.15)
         np.testing.assert_array_less(torch.linalg.norm(qpos[:2]), 0.5)
 
     if show_viewer:


### PR DESCRIPTION
## Description

Check if each geometry can be convexified independently without resorting on convex decomposition. If so, the original geometries are preserve. If not, then they are all merged as one. The resulting geometry is convexify without resorting on convex decomposition if possible. 

## Motivation and Context

Several collision meshes may be attached to a single body. This is fine as long as there is no need to rely on convex decomposition. Otherwise, the final number of collision geometries may be very large, typically more than 50. These  impedes runtime performance, numerical stability and compilation time, without significant benefit. It would be much better to merge all the meshes before applying convex decomposition. It also gives one last opportunity to check whether the convex hull of the merged mesh is accurate enough, and eventually skip convex decomposition completely. 

Destroying the original geometries should be avoided if possible as it will change the way objects interact with the world due to only computing one contact point per convex geometry. As a result, this merging procedure should only be applied in last resort instead of systematically.

## How Has This Been / Can This Be Tested?

Running the unit test "tests/test_rigid_physics.py::test_convexify[cpu]" with installed assets.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
