### PR TITLE
[BUG FIX] Improve numerical stability of collision detection

### DIFF
--- a/examples/rigid/convex_decomposition.py
+++ b/examples/rigid/convex_decomposition.py
@@ -13,14 +13,15 @@ def main():
     args = parser.parse_args()
 
     ########################## init ##########################
-    gs.init(backend=gs.cpu if args.cpu else gs.gpu)
+    gs.init(backend=gs.cpu if args.cpu else gs.gpu, seed=0)
 
     ########################## create a scene ##########################
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(
-            dt=0.005,
+            dt=0.004,
         ),
         show_viewer=args.vis,
+        show_FPS=False,
     )
 
     ########################## entities ##########################
@@ -29,9 +30,10 @@ def main():
             file="meshes/tank.obj",
             scale=5.0,
             fixed=True,
-            euler=(90, 0, 90),
+            euler=(80, 10, 90),
+            pos=(0.05, -0.1, 0.0),
         ),
-        # vis_mode="collision",
+        vis_mode="collision",
     )
     for i, asset_name in enumerate(("donut_0", "mug_1", "cup_2", "apple_15")):
         asset_path = snapshot_download(
@@ -40,14 +42,15 @@ def main():
         scene.add_entity(
             gs.morphs.MJCF(
                 file=f"{asset_path}/{asset_name}/output.xml",
-                pos=(0.0, 0.15 * (i - 1.5), 0.4),
+                pos=(0.0, 0.15 * (i - 1.5), 0.7),
             ),
-            # vis_mode="collision",
+            vis_mode="collision",
+            # visualize_contact=True,
         )
 
     ########################## build ##########################
     scene.build()
-    for i in range(4000):
+    for i in range(2000):
         scene.step()
 
 

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -343,13 +343,21 @@ class RigidEntity(Entity):
             if l_info["parent_idx"] < 0:
                 for j_info in link_j_infos:
                     if j_info["type"] != gs.JOINT_TYPE.FIXED:  # base link
-                        if morph.pos is not None:
-                            l_info["pos"] = np.array(morph.pos)
-                            gs.logger.warning("Overriding base link's pos with user provided value in morph.")
-                        if morph.quat is not None:
-                            l_info["quat"] = np.array(morph.quat)
-                            gs.logger.warning("Overriding base link's quat with user provided value in morph.")
-
+                        if morph.pos is not None or morph.quat is not None:
+                            gs.logger.info("Applying offset to base link's pose with user provided value in morph.")
+                            pos = np.asarray(l_info.get("pos", (0.0, 0.0, 0.0)))
+                            quat = np.asarray(l_info.get("quat", (1.0, 0.0, 0.0, 0.0)))
+                            if morph.pos is None:
+                                pos_offset = np.zeros((3,))
+                            else:
+                                pos_offset = np.asarray(morph.pos)
+                            if morph.quat is None:
+                                quat_offset = np.array((1.0, 0.0, 0.0, 0.0))
+                            else:
+                                quat_offset = np.asarray(morph.quat)
+                            l_info["pos"], l_info["quat"] = gu.transform_pos_quat_by_trans_quat(
+                                pos, quat, pos_offset, quat_offset
+                            )
                     if j_info["type"] == gs.JOINT_TYPE.FREE:
                         # in this case, l_info['pos'] and l_info['quat'] are actually not used in solver,
                         # but this initial value will be reflected

--- a/genesis/engine/mesh.py
+++ b/genesis/engine/mesh.py
@@ -88,7 +88,7 @@ class Mesh(RBC):
                     self._mesh.vertices,
                     self._mesh.faces,
                     target_count=decimate_face_num,
-                    agg=0,
+                    agg=2,
                 )
             )
 

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -350,6 +350,10 @@ class Scene(RBC):
             else:
                 morph.convexify = False
 
+        # Decimate if convexify by default
+        if hasattr(morph, "decimate") and morph.decimate is None:
+            morph.decimate = morph.convexify
+
         entity = self._sim._add_entity(morph, material, surface, visualize_contact)
 
         return entity

--- a/genesis/engine/solvers/rigid/collider_decomp.py
+++ b/genesis/engine/solvers/rigid/collider_decomp.py
@@ -178,7 +178,11 @@ class Collider:
 
         ##---------------- box box
         if self._solver._box_box_detection:
-            self.box_MAXCONPAIR = 8
+            # With the existing Box-Box collision detection algorithm, it is not clear where the contact points are
+            # located depending of the pose and size of each box. In practice, up to 11 contact points have been
+            # observed. The theoretical worst case scenario would be 2 cubes roughly the same size and same center,
+            # with transform RPY = (45, 45, 45), resulting in 3 contact points per faces for a total of 16 points.
+            self.box_MAXCONPAIR = 16
             self.box_depth = ti.field(dtype=gs.ti_float, shape=self._solver._batch_shape(self.box_MAXCONPAIR))
             self.box_points = ti.field(gs.ti_vec3, shape=self._solver._batch_shape(self.box_MAXCONPAIR))
             self.box_pts = ti.field(gs.ti_vec3, shape=self._solver._batch_shape(6))
@@ -1093,7 +1097,7 @@ class Collider:
     def _func_compute_tolerance(self, i_ga, i_gb, i_b):
         aabb_size_a = self._solver.geoms_state[i_ga, i_b].aabb_max - self._solver.geoms_state[i_ga, i_b].aabb_min
         aabb_size_b = self._solver.geoms_state[i_gb, i_b].aabb_max - self._solver.geoms_state[i_gb, i_b].aabb_min
-        tolerance = self._mc_tolerance * ti.min(aabb_size_a.norm(), aabb_size_b.norm())
+        tolerance = self._mc_tolerance * ti.min(aabb_size_a.norm(), aabb_size_b.norm()) / 2
         return tolerance
 
     ## only one mpr

--- a/genesis/engine/solvers/rigid/collider_decomp.py
+++ b/genesis/engine/solvers/rigid/collider_decomp.py
@@ -178,7 +178,7 @@ class Collider:
 
         ##---------------- box box
         if self._solver._box_box_detection:
-            self.box_MAXCONPAIR = 32
+            self.box_MAXCONPAIR = 8
             self.box_depth = ti.field(dtype=gs.ti_float, shape=self._solver._batch_shape(self.box_MAXCONPAIR))
             self.box_points = ti.field(gs.ti_vec3, shape=self._solver._batch_shape(self.box_MAXCONPAIR))
             self.box_pts = ti.field(gs.ti_vec3, shape=self._solver._batch_shape(6))
@@ -1053,7 +1053,6 @@ class Collider:
                         contact_pos = pos_neighbor - normal * penetration * 0.5
 
                         if (contact_pos - contact_pos_0).norm() > tolerance:
-
                             self._func_add_contact(i_ga, i_gb, normal, contact_pos, penetration, i_b)
                             n_con = n_con + 1
 
@@ -1094,7 +1093,7 @@ class Collider:
     def _func_compute_tolerance(self, i_ga, i_gb, i_b):
         aabb_size_a = self._solver.geoms_state[i_ga, i_b].aabb_max - self._solver.geoms_state[i_ga, i_b].aabb_min
         aabb_size_b = self._solver.geoms_state[i_gb, i_b].aabb_max - self._solver.geoms_state[i_gb, i_b].aabb_min
-        tolerance = self._mc_tolerance * ti.min(aabb_size_a.norm(), aabb_size_b.norm()) / 2
+        tolerance = self._mc_tolerance * ti.min(aabb_size_a.norm(), aabb_size_b.norm())
         return tolerance
 
     ## only one mpr

--- a/genesis/engine/solvers/rigid/mpr_decomp.py
+++ b/genesis/engine/solvers/rigid/mpr_decomp.py
@@ -17,7 +17,9 @@ class MPR:
         self._para_level = rigid_solver._para_level
 
         if gs.ti_float == ti.f32:
-            self.CCD_EPS = 1e-7
+            # It has been observed in practice that increasing this threshold makes collision detection instable,
+            # which is surprising since 1e-8 is above single precision (which has only 7 digits of precision).
+            self.CCD_EPS = 1e-9
         else:
             self.CCD_EPS = 1e-10
         self.CCD_TOLERANCE = 1e-6
@@ -27,7 +29,6 @@ class MPR:
         self.init_support()
 
     def init_support(self):
-
         struct_support = ti.types.struct(
             v1=gs.ti_vec3,
             v2=gs.ti_vec3,

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -23,13 +23,20 @@ IMP_MIN = 0.0001
 # maximum constraint impedance
 IMP_MAX = 0.9999
 
+TIME_CONSTANT_TO_SUBSTEP_RATIO = 3.0
+
 
 def _sanitize_sol_params(sol_params, substep_dt, default_resolve_time=None):
     timeconst, dampratio, dmin, dmax, width, mid, power = sol_params.T
     if default_resolve_time is not None:
         # Use default default resolve time if and only if solref is not set
         timeconst[timeconst == 0.0] = default_resolve_time
-    timeconst = np.maximum(timeconst, 2 * substep_dt)
+    if (timeconst < TIME_CONSTANT_TO_SUBSTEP_RATIO * substep_dt).any():
+        gs.logger.warning(
+            "Constraint solver time constant was increased to avoid numerical instability. Decrease simulation "
+            "timestep to avoid altering the original value."
+        )
+    timeconst = np.maximum(timeconst, TIME_CONSTANT_TO_SUBSTEP_RATIO * substep_dt)
     dmin = np.clip(dmin, IMP_MIN, IMP_MAX)
     dmax = np.clip(dmax, IMP_MIN, IMP_MAX)
     mid = np.clip(mid, IMP_MIN, IMP_MAX)

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -23,20 +23,21 @@ IMP_MIN = 0.0001
 # maximum constraint impedance
 IMP_MAX = 0.9999
 
-TIME_CONSTANT_TO_SUBSTEP_RATIO = 3.0
+# Minimum ratio between simulation timestep `_substep_dt` and time constant of constraints
+TIME_CONSTANT_SAFETY_FACTOR = 2.0
 
 
-def _sanitize_sol_params(sol_params, substep_dt, default_resolve_time=None):
+def _sanitize_sol_params(sol_params, min_resolve_time, force_resolve_time=None):
     timeconst, dampratio, dmin, dmax, width, mid, power = sol_params.T
-    if default_resolve_time is not None:
-        # Use default default resolve time if and only if solref is not set
-        timeconst[timeconst == 0.0] = default_resolve_time
-    if (timeconst < TIME_CONSTANT_TO_SUBSTEP_RATIO * substep_dt).any():
+    if force_resolve_time is not None:
+        timeconst = np.full_like(timeconst, force_resolve_time)
+    min_timeconst = np.min(timeconst)
+    if (min_timeconst + 1e-6 < min_resolve_time).any():
         gs.logger.warning(
-            "Constraint solver time constant was increased to avoid numerical instability. Decrease simulation "
-            "timestep to avoid altering the original value."
+            f"Constraint solver time constant was increased to avoid numerical instability (from `{min_timeconst:0.6g}` "
+            f"to `{min_resolve_time:0.6g}`). Decrease simulation timestep to avoid altering the original value."
         )
-    timeconst = np.maximum(timeconst, TIME_CONSTANT_TO_SUBSTEP_RATIO * substep_dt)
+    timeconst = np.maximum(timeconst, min_resolve_time)
     dmin = np.clip(dmin, IMP_MIN, IMP_MAX)
     dmax = np.clip(dmax, IMP_MIN, IMP_MAX)
     mid = np.clip(mid, IMP_MIN, IMP_MAX)
@@ -74,10 +75,8 @@ class RigidSolver(Solver):
         self._hibernation_thresh_vel = options.hibernation_thresh_vel
         self._hibernation_thresh_acc = options.hibernation_thresh_acc
 
-        if options.constraint_resolve_time is None:
-            self._sol_constraint_resolve_time = 2 * self._substep_dt
-        else:
-            self._sol_constraint_resolve_time = options.constraint_resolve_time
+        self._sol_constraint_min_resolve_time = TIME_CONSTANT_SAFETY_FACTOR * self._substep_dt
+        self._sol_constraint_resolve_time = options.constraint_resolve_time
 
         if options.contact_resolve_time is not None:
             self._sol_contact_resolve_time = options.contact_resolve_time
@@ -379,7 +378,9 @@ class RigidSolver(Solver):
         if is_nonempty:  # handle the case where there is a link with no dofs -- otherwise may cause invalid memory
             # Make sure that the constraints parameters are valid
             dofs_sol_params = np.concatenate([joint.dofs_sol_params for joint in joints], dtype=gs.np_float)
-            dofs_sol_params = _sanitize_sol_params(dofs_sol_params, self._substep_dt, self._sol_constraint_resolve_time)
+            dofs_sol_params = _sanitize_sol_params(
+                dofs_sol_params, self._sol_constraint_min_resolve_time, self._sol_constraint_resolve_time
+            )
 
             self._kernel_init_dof_fields(
                 dofs_motion_ang=np.concatenate([joint.dofs_motion_ang for joint in joints], dtype=gs.np_float),
@@ -569,7 +570,9 @@ class RigidSolver(Solver):
         # Make sure that the constraints parameters are valid
         joints = tuple(chain.from_iterable(self.joints))
         joints_sol_params = np.concatenate([joint.sol_params for joint in joints], dtype=gs.np_float)
-        joints_sol_params = _sanitize_sol_params(joints_sol_params, self._substep_dt)
+        joints_sol_params = _sanitize_sol_params(
+            joints_sol_params, self._sol_constraint_min_resolve_time, self._sol_constraint_resolve_time
+        )
 
         self._kernel_init_joint_fields(
             joints_type=np.array([joint.type for joint in joints], dtype=gs.np_int),
@@ -888,7 +891,7 @@ class RigidSolver(Solver):
             geoms = self.geoms
             geoms_sol_params = np.array([geom.sol_params for geom in geoms], dtype=gs.np_float)
             geoms_sol_params = _sanitize_sol_params(
-                geoms_sol_params, self._substep_dt, self._sol_constraint_resolve_time
+                geoms_sol_params, self._sol_constraint_min_resolve_time, self._sol_constraint_resolve_time
             )
 
             self._kernel_init_geom_fields(
@@ -1197,7 +1200,9 @@ class RigidSolver(Solver):
 
             equalities_sol_params = np.array([equality.sol_params for equality in equalities], dtype=gs.np_float)
             equalities_sol_params = _sanitize_sol_params(
-                equalities_sol_params, self._substep_dt, self._sol_constraint_resolve_time
+                equalities_sol_params,
+                self._sol_constraint_min_resolve_time,
+                self._sol_constraint_resolve_time,
             )
 
             self._kernel_init_equality_fields(
@@ -3984,7 +3989,9 @@ class RigidSolver(Solver):
         assert len(sol_params) == 7
 
         # Make sure that the constraints parameters are valid
-        sol_params = _sanitize_sol_params(sol_params)
+        sol_params = _sanitize_sol_params(
+            sol_params, self._sol_constraint_min_resolve_time, self._sol_constraint_resolve_time
+        )
 
         self._kernel_set_global_sol_params(sol_params)
 

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -299,7 +299,7 @@ class FileMorph(Morph):
     quat : tuple, shape (4,), optional
         The quaternion (w-x-y-z convention) of the entity. If specified, `euler` will be ignored. Defaults to None.
     decimate : bool, optional
-        Whether to decimate (simplify) the mesh. Defaults to True. **This is only used for RigidEntity.**
+        Whether to decimate (simplify) the mesh. If not given, it defaults to `convexify`. **This is only used for RigidEntity.**
     decimate_face_num : int, optional
         The number of faces to decimate to. Defaults to 500. **This is only used for RigidEntity.**
     convexify : bool, optional
@@ -325,9 +325,9 @@ class FileMorph(Morph):
 
     file: Any = ""
     scale: Union[float, tuple] = 1.0
-    decimate: bool = False
+    decimate: Optional[bool] = None
     decimate_face_num: int = 500
-    convexify: bool = True
+    convexify: Optional[bool] = None
     decompose_nonconvex: Optional[bool] = None
     decompose_error_threshold: float = 0.15
     coacd_options: Optional[CoacdOptions] = None
@@ -349,11 +349,6 @@ class FileMorph(Morph):
 
         # Make sure that this threshold is positive to avoid decomposition of convex and primivie shapes
         self.decompose_error_threshold = max(self.decompose_error_threshold, gs.EPS)
-
-        if self.decimate and self.decimate_face_num < 100:
-            gs.raise_exception(
-                "`decimate_face_num` should be greater than 100 to ensure sufficient geometry details are preserved."
-            )
 
         if self.coacd_options is None:
             self.coacd_options = CoacdOptions()

--- a/genesis/options/solvers.py
+++ b/genesis/options/solvers.py
@@ -191,7 +191,7 @@ class RigidOptions(Options):
     enable_self_collision: bool = False
     enable_adjacent_collision: bool = False
     disable_constraint: bool = False
-    max_collision_pairs: int = 100
+    max_collision_pairs: int = 300
     integrator: gs.integrator = gs.integrator.approximate_implicitfast
     IK_max_targets: int = 6
 
@@ -252,7 +252,7 @@ class AvatarOptions(Options):
     enable_collision: bool = False
     enable_self_collision: bool = False
     enable_adjacent_collision: bool = False
-    max_collision_pairs: int = 100
+    max_collision_pairs: int = 300
     IK_max_targets: int = 6  # Increasing this doesn't affect IK solving speed, but will increase memory usage
 
     # for dynamic properties

--- a/genesis/options/surfaces.py
+++ b/genesis/options/surfaces.py
@@ -633,12 +633,14 @@ class Reflective(Plastic):
 
 class Collision(Plastic):
     """
-    Default surface type for collision geometry with a grey color.
+    Default surface type for collision geometry with a grey color by default.
     """
+
+    color: tuple = (0.5, 0.5, 0.5)
 
     def __init__(self, **data):
         super().__init__(**data)
-        self.diffuse_texture = ColorTexture(color=(0.5, 0.5, 0.5))
+        self.diffuse_texture = ColorTexture(color=self.color)
 
 
 class Water(Glass):

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -4,14 +4,15 @@ import pickle as pkl
 from io import BytesIO
 from urllib import request
 
+import numpy as np
+import trimesh
+from PIL import Image
+
 import coacd
 import igl
-import numpy as np
 import pygltflib
 import pyvista as pv
 import tetgen
-import trimesh
-from PIL import Image
 
 import genesis as gs
 from genesis.ext import fast_simplification
@@ -326,6 +327,8 @@ def postprocess_collision_geoms(
             decimate_face_num=decimate_face_num,
             surface=gs.surfaces.Collision(),
         )
+        # Randomize collision mesh colors. The is especially useful to check convex decomposition.
+        mesh.set_color((*np.random.rand(3), 1.0))
         _g_infos.append({**g_info, **dict(mesh=mesh)})
 
     return _g_infos

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -310,8 +310,7 @@ def postprocess_collision_geoms(
         if not decimate and num_vertices > 5000:
             gs.logger.warning(
                 f"At least one of the meshes contain many vertices ({num_vertices}). Consider setting "
-                "'morph.decimate=True' or 'morph.convexify=True' to speed up collision detection and improve numerical "
-                "stability."
+                "'morph.decimate=True' to speed up collision detection and improve numerical stability."
             )
         if decimate and decimate_face_num < 100:
             gs.logger.warning(

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -172,14 +172,7 @@ def surface_uvs_to_trimesh_visual(surface, uvs=None, n_verts=None):
     return visual
 
 
-def convex_decompose(mesh, decimate, decimate_face_num, coacd_options):
-    if decimate:
-        if mesh.vertices.shape[0] > 3:
-            if len(mesh.faces) > decimate_face_num:
-                mesh = trimesh.Trimesh(
-                    *fast_simplification.simplify(mesh.vertices, mesh.faces, target_count=decimate_face_num, agg=0)
-                )
-
+def convex_decompose(mesh, coacd_options):
     # compute file name via hashing for caching
     cvx_path = get_cvx_path(mesh.vertices, mesh.faces, coacd_options)
 
@@ -301,7 +294,7 @@ def postprocess_collision_geoms(
                 cmesh = trimesh.convex.convex_hull(tmesh)
                 volume_err = cmesh.volume / tmesh.volume - 1.0
             if volume_err > decompose_error_threshold:
-                tmeshes = convex_decompose(tmesh, decimate, decimate_face_num, coacd_options)
+                tmeshes = convex_decompose(tmesh, coacd_options)
                 meshes = [gs.Mesh.from_trimesh(tmesh, surface=gs.surfaces.Collision()) for tmesh in tmeshes]
                 _g_infos += [{**g_info, **dict(mesh=mesh)} for mesh in meshes]
             else:
@@ -314,11 +307,15 @@ def postprocess_collision_geoms(
         mesh = g_info["mesh"]
         tmesh = mesh.trimesh
         num_vertices = len(tmesh.vertices)
-        if not convexify and not decimate and num_vertices > 5000:
+        if not decimate and num_vertices > 5000:
             gs.logger.warning(
                 f"At least one of the meshes contain many vertices ({num_vertices}). Consider setting "
                 "'morph.decimate=True' or 'morph.convexify=True' to speed up collision detection and improve numerical "
                 "stability."
+            )
+        if decimate and decimate_face_num < 100:
+            gs.logger.warning(
+                "`decimate_face_num` should be greater than 100 to ensure sufficient geometry details are preserved."
             )
         mesh = gs.Mesh.from_trimesh(
             mesh=tmesh,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,7 +173,6 @@ def gs_sim(xml_path, gs_solver, gs_integrator, adjacent_collision, dof_damping, 
             box_box_detection=True,
             enable_self_collision=True,
             enable_adjacent_collision=adjacent_collision,
-            constraint_resolve_time=0.02,
             iterations=mj_sim.model.opt.iterations,
             tolerance=mj_sim.model.opt.tolerance,
             ls_iterations=mj_sim.model.opt.ls_iterations,
@@ -186,6 +185,11 @@ def gs_sim(xml_path, gs_solver, gs_integrator, adjacent_collision, dof_damping, 
         gs.morphs.MJCF(file=xml_path),
         visualize_contact=True,
     )
+    gs_sim = scene.sim
+
+    # Force matching Mujoco safety factor for constraint time constant.
+    # Note that this time constant affects the penetration depth at rest.
+    gs_sim.rigid_solver._sol_constraint_min_resolve_time = 2.0 * scene.sim._substep_dt
 
     # Joint damping is not properly supported in Genesis for now
     if not dof_damping:
@@ -194,7 +198,7 @@ def gs_sim(xml_path, gs_solver, gs_integrator, adjacent_collision, dof_damping, 
 
     scene.build()
 
-    yield scene.sim
+    yield gs_sim
 
     if show_viewer:
         scene.viewer.stop()

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -238,7 +238,7 @@ def test_box_box_dynamics(gs_sim):
         qvel = gs_robot.get_dofs_velocity().cpu()
         np.testing.assert_allclose(qvel, 0, atol=1e-2)
         qpos = gs_robot.get_dofs_position().cpu()
-        np.testing.assert_allclose(qpos[8], 0.6, atol=1e-3)
+        np.testing.assert_allclose(qpos[8], 0.6, atol=2e-3)
 
 
 @pytest.mark.parametrize("box_box_detection, dynamics", [(False, False), (False, True), (True, False)])
@@ -315,6 +315,8 @@ def test_simple_kinematic_chain(gs_sim, mj_sim, atol):
 @pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
 @pytest.mark.parametrize("backend", [gs.cpu])
 def test_walker(gs_sim, mj_sim, atol):
+    # Force numpy seed because this test is very sensitive to the initial condition
+    np.random.seed(0)
     (gs_robot,) = gs_sim.entities
     qpos = np.zeros((gs_robot.n_qs,))
     qpos[2] += 0.5
@@ -359,12 +361,12 @@ def test_stickman(gs_sim, mj_sim, atol):
     init_simulators(gs_sim)
 
     # Run the simulation for a few steps
-    for i in range(6000):
+    for i in range(2000):
         gs_sim.scene.step()
 
     (gs_robot,) = gs_sim.entities
     qvel = gs_robot.get_dofs_velocity().cpu()
-    np.testing.assert_allclose(qvel, 0, atol=0.1)
+    np.testing.assert_allclose(qvel, 0, atol=0.3)
     qpos = gs_robot.get_dofs_position().cpu()
     assert np.linalg.norm(qpos[:2]) < 1.3
     body_z = gs_sim.rigid_solver.links_state.pos.to_numpy()[:-1, 0, 2]
@@ -498,7 +500,7 @@ def move_cube(use_suction, show_viewer):
     qvel = cube.get_dofs_velocity().cpu()
     np.testing.assert_allclose(qvel, 0, atol=0.05)
     qpos = cube.get_dofs_position().cpu()
-    np.testing.assert_allclose(qpos[2], 0.06, atol=1e-3)
+    np.testing.assert_allclose(qpos[2], 0.06, atol=2e-3)
 
     if show_viewer:
         scene.viewer.stop()
@@ -516,6 +518,7 @@ def test_suction_cup(show_viewer):
     move_cube(use_suction, show_viewer)
 
 
+@pytest.mark.parametrize("backend", [gs.cpu])
 def test_nonconvex_collision(show_viewer):
     scene = gs.Scene(show_viewer=show_viewer, show_FPS=False)
     tank = scene.add_entity(
@@ -543,7 +546,7 @@ def test_nonconvex_collision(show_viewer):
         scene.step()
 
     qvel = scene.sim.rigid_solver.dofs_state.vel.to_numpy()[:, 0]
-    np.testing.assert_allclose(qvel, 0, atol=0.1)
+    np.testing.assert_allclose(qvel, 0, atol=0.15)
 
     if show_viewer:
         scene.viewer.stop()
@@ -601,7 +604,7 @@ def test_convexify(show_viewer):
     assert 5 <= len(cup.geoms) <= 20
     assert 5 <= len(mug.geoms) <= 40
 
-    for i in range(1000):
+    for i in range(1500):
         scene.step()
 
     for obj in objs:
@@ -609,7 +612,7 @@ def test_convexify(show_viewer):
         np.testing.assert_allclose(qvel, 0, atol=0.05)
         qpos = obj.get_dofs_position().cpu()
         np.testing.assert_array_less(-0.1, qpos[2])
-        np.testing.assert_array_less(qpos[2], 0.1)
+        np.testing.assert_array_less(qpos[2], 0.15)
         np.testing.assert_array_less(torch.linalg.norm(qpos[:2]), 0.5)
 
     if show_viewer:
@@ -660,7 +663,7 @@ def test_terrain_generation(show_viewer):
     height_balls = ball.get_pos().cpu()[:, 2]
     height_balls_min = height_balls.min() - 0.1
     height_balls_max = height_balls.max() - 0.1
-    np.testing.assert_allclose(height_balls_min, height_field_min, atol=1e-3)
+    np.testing.assert_allclose(height_balls_min, height_field_min, atol=2e-3)
     assert height_balls_max - height_balls_min > 0.5 * (height_field_max - height_field_min)
 
 

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -556,7 +556,7 @@ def test_convexify(show_viewer):
     # Then run a simulation to see if it explodes, i.e. objects are at reset inside tank.
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(
-            dt=0.005,
+            dt=0.004,
         ),
         show_viewer=show_viewer,
         show_FPS=False,
@@ -566,7 +566,7 @@ def test_convexify(show_viewer):
             file="meshes/tank.obj",
             scale=5.0,
             fixed=True,
-            euler=(90, 0, 90),
+            euler=(75, 15, 90),
         ),
         vis_mode="collision",
     )
@@ -591,6 +591,7 @@ def test_convexify(show_viewer):
 
     # Make sure that all the geometries in the scene are convex
     assert gs_sim.rigid_solver.geoms_info.is_convex.to_numpy().all()
+    assert not gs_sim.rigid_solver.collider._has_nonconvex_nonterrain
 
     # There should be only one geometry for the apple as it can be convexify without decomposition,
     # but for the others it is hard to tell... Let's use some reasonable guess.
@@ -600,15 +601,15 @@ def test_convexify(show_viewer):
     assert 5 <= len(cup.geoms) <= 20
     assert 5 <= len(mug.geoms) <= 40
 
-    for i in range(6000):
+    for i in range(1000):
         scene.step()
 
     for obj in objs:
         qvel = obj.get_dofs_velocity().cpu()
-        np.testing.assert_allclose(qvel, 0, atol=0.5)
+        np.testing.assert_allclose(qvel, 0, atol=0.05)
         qpos = obj.get_dofs_position().cpu()
-        np.testing.assert_array_less(0, qpos[2])
-        np.testing.assert_array_less(qpos[2], 0.15)
+        np.testing.assert_array_less(-0.1, qpos[2])
+        np.testing.assert_array_less(qpos[2], 0.1)
         np.testing.assert_array_less(torch.linalg.norm(qpos[:2]), 0.5)
 
     if show_viewer:


### PR DESCRIPTION
## Description

* Apply morph pose as transform wrt original base pose
* Randomize collision mesh colors
* More challenging convex decomposition example / unit test
* Enable decimation by default if convexify is enabled. 
* Do not decimate before convex decomposition.
* Reduce MPR epsilon threshold (basically disable it for float32) to avoid jerky contact points 
* Enforce option constraint time constant systematically if and if specified.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/751

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?

Running the unit tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
