### PR TITLE
[BUG FIX] Improve multi-point contact stability

### DIFF
--- a/genesis/engine/solvers/rigid/collider_decomp.py
+++ b/genesis/engine/solvers/rigid/collider_decomp.py
@@ -1112,11 +1112,11 @@ class Collider:
         i_lb = self._solver.geoms_info[i_gb].link_idx
         I_la = [i_la, i_b] if ti.static(self._solver._options.batch_links_info) else i_la
         I_lb = [i_lb, i_b] if ti.static(self._solver._options.batch_links_info) else i_lb
-        is_self_pair = self._solver.links_info.root_idx[I_la] == self._solver.links_info.root_idx[I_lb]
         multi_contact = (
             self._solver.geoms_info[i_ga].type != gs.GEOM_TYPE.SPHERE
+            and self._solver.geoms_info[i_ga].type != gs.GEOM_TYPE.ELLIPSOID
             and self._solver.geoms_info[i_gb].type != gs.GEOM_TYPE.SPHERE
-            and not is_self_pair
+            and self._solver.geoms_info[i_gb].type != gs.GEOM_TYPE.ELLIPSOID
         )
         if is_plane:
             self._func_plane_contact(i_ga, i_gb, multi_contact, i_b)

--- a/genesis/engine/solvers/rigid/mpr_decomp.py
+++ b/genesis/engine/solvers/rigid/mpr_decomp.py
@@ -178,6 +178,22 @@ class MPR:
         return sphere_center + direction * sphere_radius
 
     @ti.func
+    def support_ellipsoid(self, direction, i_g, i_b):
+        g_state = self._solver.geoms_state[i_g, i_b]
+        ellipsoid_center = g_state.pos
+        ellipsoid_scaled_axis = ti.Vector(
+            [
+                self._solver.geoms_info[i_g].data[0] ** 2,
+                self._solver.geoms_info[i_g].data[1] ** 2,
+                self._solver.geoms_info[i_g].data[2] ** 2,
+            ],
+            dt=gs.ti_float,
+        )
+        ellipsoid_scaled_axis = gu.ti_transform_by_quat(ellipsoid_scaled_axis, g_state.quat)
+        dist = ellipsoid_scaled_axis / ti.sqrt(direction.dot(1.0 / ellipsoid_scaled_axis))
+        return ellipsoid_center + direction * dist
+
+    @ti.func
     def support_capsule(self, direction, i_g, i_b):
         g_state = self._solver.geoms_state[i_g, i_b]
         capule_center = g_state.pos
@@ -241,6 +257,8 @@ class MPR:
         geom_type = self._solver.geoms_info[i_g].type
         if geom_type == gs.GEOM_TYPE.SPHERE:
             v = self.support_sphere(direction, i_g, i_b)
+        if geom_type == gs.GEOM_TYPE.ELLIPSOID:
+            v = self.support_ellipsoid(direction, i_g, i_b)
         elif geom_type == gs.GEOM_TYPE.CAPSULE:
             v = self.support_capsule(direction, i_g, i_b)
         elif geom_type == gs.GEOM_TYPE.BOX:

--- a/genesis/engine/solvers/rigid/mpr_decomp.py
+++ b/genesis/engine/solvers/rigid/mpr_decomp.py
@@ -93,12 +93,11 @@ class MPR:
         t = AP_AB / AB_AB
         if t < 0.0 or ti.abs(t) < self.CCD_EPS:
             t = gs.ti_float(0.0)
-        elif t > 1.0:
+        elif t > 1.0 or ti.abs(t - 1.0) < self.CCD_EPS:
             t = gs.ti_float(1.0)
         Q = A + AB * t
-        pdir = Q
 
-        return (P - Q).norm() ** 2, pdir
+        return ((P - Q) ** 2).sum(), Q
 
     @ti.func
     def mpr_point_tri_depth(self, P, x0, B, C):
@@ -129,9 +128,8 @@ class MPR:
             and (ti.abs(t + s - 1.0) < self.CCD_EPS or t + s < 1.0)
         ):
             pdir = x0 + d1 * s + d2 * t
-            dist = (P - pdir).norm() ** 2
+            dist = ((P - pdir) ** 2).sum()
         else:
-
             dist, pdir = self.mpr_point_segment_dist2(P, x0, B)
             dist2, pdir2 = self.mpr_point_segment_dist2(P, x0, C)
             if dist2 < dist:

--- a/genesis/engine/solvers/rigid/mpr_decomp.py
+++ b/genesis/engine/solvers/rigid/mpr_decomp.py
@@ -19,7 +19,7 @@ class MPR:
         if gs.ti_float == ti.f32:
             # It has been observed in practice that increasing this threshold makes collision detection instable,
             # which is surprising since 1e-8 is above single precision (which has only 7 digits of precision).
-            self.CCD_EPS = 1e-9
+            self.CCD_EPS = 1e-8
         else:
             self.CCD_EPS = 1e-10
         self.CCD_TOLERANCE = 1e-6

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -720,11 +720,14 @@ class RasterizerContext:
         self.add_external_node(node, pose=pose)
         return node
 
-    def draw_debug_spheres(self, poss, radius=0.01, color=(1.0, 0.0, 0.0, 0.5)):
+    def draw_debug_spheres(self, poss, radius=0.01, color=(1.0, 0.0, 0.0, 0.5), persistent=True):
         mesh = mu.create_sphere(radius=radius, color=color)
         poses = gu.trans_to_T(tensor_to_array(poss))
         node = pyrender.Mesh.from_trimesh(mesh, name=f"debug_spheres_{gs.UID()}", smooth=True, poses=poses)
-        self.add_external_node(node)
+        if persistent:
+            self.add_external_node(node)
+        else:
+            self.add_dynamic_node(node)
         return node
 
     def draw_debug_box(self, bounds, color=(1.0, 0.0, 0.0, 1.0), wireframe=True, wireframe_radius=0.002):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,7 +189,7 @@ def gs_sim(xml_path, gs_solver, gs_integrator, adjacent_collision, dof_damping, 
 
     # Force matching Mujoco safety factor for constraint time constant.
     # Note that this time constant affects the penetration depth at rest.
-    gs_sim.rigid_solver._sol_constraint_min_resolve_time = 2.0 * scene.sim._substep_dt
+    gs_sim.rigid_solver._sol_constraint_min_resolve_time = 2.0 * gs_sim._substep_dt
 
     # Joint damping is not properly supported in Genesis for now
     if not dof_damping:

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -276,7 +276,7 @@ def test_many_boxes_dynamics(box_box_detection, dynamics, show_viewer):
     if dynamics:
         for entity in scene.entities[1:]:
             entity.set_dofs_velocity(4.0 * np.random.rand(6))
-    for i in range(800 if dynamics else 300):
+    for i in range(800 if dynamics else 400):
         scene.step()
 
     for n, entity in enumerate(scene.entities[1:]):
@@ -361,7 +361,7 @@ def test_stickman(gs_sim, mj_sim, atol):
     init_simulators(gs_sim)
 
     # Run the simulation for a few steps
-    for i in range(2000):
+    for i in range(2500):
         gs_sim.scene.step()
 
     (gs_robot,) = gs_sim.entities
@@ -604,7 +604,7 @@ def test_convexify(show_viewer):
     assert 5 <= len(cup.geoms) <= 20
     assert 5 <= len(mug.geoms) <= 40
 
-    for i in range(1500):
+    for i in range(2000):
         scene.step()
 
     for obj in objs:


### PR DESCRIPTION
## Description

* Add support of analytically ellipsoid shape for collision detection
* Do not disable multi-point collision detection for self-collision
  * I see no reason for doing this, and Mujoco does not do it either 
* Add first-order penetration depth correction term for multi-point collision detection
  * This is important to avoid spurious / jerky motion
* Increase CCD epsilon threshold now that collisions are more stable

## Motivation and Context

Improve the numerical stability of the simulation for contact-heavy scenes is very important for learning dexterous manipulation tasks.

## How Has This Been / Can This Be Tested?

Running the unit tests.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
