### PR TITLE
[BUG FIX] Fix MJCF overwrite robot pose.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -341,23 +341,23 @@ class RigidEntity(Entity):
             all_infos.append((world_l_info, world_j_info, world_g_info))
         for l_info, link_j_infos, link_g_infos in all_infos:
             if l_info["parent_idx"] < 0:
+                if morph.pos is not None or morph.quat is not None:
+                    gs.logger.info("Applying offset to base link's pose with user provided value in morph.")
+                    pos = np.asarray(l_info.get("pos", (0.0, 0.0, 0.0)))
+                    quat = np.asarray(l_info.get("quat", (1.0, 0.0, 0.0, 0.0)))
+                    if morph.pos is None:
+                        pos_offset = np.zeros((3,))
+                    else:
+                        pos_offset = np.asarray(morph.pos)
+                    if morph.quat is None:
+                        quat_offset = np.array((1.0, 0.0, 0.0, 0.0))
+                    else:
+                        quat_offset = np.asarray(morph.quat)
+                    l_info["pos"], l_info["quat"] = gu.transform_pos_quat_by_trans_quat(
+                        pos, quat, pos_offset, quat_offset
+                    )
+
                 for j_info in link_j_infos:
-                    if j_info["type"] != gs.JOINT_TYPE.FIXED:  # base link
-                        if morph.pos is not None or morph.quat is not None:
-                            gs.logger.info("Applying offset to base link's pose with user provided value in morph.")
-                            pos = np.asarray(l_info.get("pos", (0.0, 0.0, 0.0)))
-                            quat = np.asarray(l_info.get("quat", (1.0, 0.0, 0.0, 0.0)))
-                            if morph.pos is None:
-                                pos_offset = np.zeros((3,))
-                            else:
-                                pos_offset = np.asarray(morph.pos)
-                            if morph.quat is None:
-                                quat_offset = np.array((1.0, 0.0, 0.0, 0.0))
-                            else:
-                                quat_offset = np.asarray(morph.quat)
-                            l_info["pos"], l_info["quat"] = gu.transform_pos_quat_by_trans_quat(
-                                pos, quat, pos_offset, quat_offset
-                            )
                     if j_info["type"] == gs.JOINT_TYPE.FREE:
                         # in this case, l_info['pos'] and l_info['quat'] are actually not used in solver,
                         # but this initial value will be reflected

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -348,6 +348,29 @@ def test_robot_kinematics(gs_sim, mj_sim, atol):
         check_mujoco_data_consistency(gs_sim, mj_sim, atol=atol)
 
 
+def test_mjcf_world_offset(show_viewer, atol):
+    scene = gs.Scene(
+        show_viewer=show_viewer,
+        show_FPS=False,
+    )
+    robot = scene.add_entity(
+        gs.morphs.MJCF(
+            file="xml/franka_emika_panda/panda.xml",
+            pos=(0.0, 0.4, 0.1),
+            euler=(0, 0, 90),
+        ),
+    )
+    scene.build()
+
+    np.testing.assert_allclose(robot.get_pos(), (0.0, 0.4, 0.1), atol=atol)
+    np.testing.assert_allclose(
+        gs.utils.geom.quat_to_xyz(robot.get_quat(), rpy=True, degrees=True), (0, 0, 90), atol=atol
+    )
+
+    if show_viewer:
+        scene.viewer.stop()
+
+
 @pytest.mark.dof_damping(True)
 @pytest.mark.parametrize("xml_path", ["xml/humanoid.xml"])
 @pytest.mark.parametrize("gs_solver", [gs.constraint_solver.Newton])


### PR DESCRIPTION
## Description

This PR fixes base robot pose overwrite for MJCF morph files.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/987

## How Has This Been / Can This Be Tested?

Adding a new unit tests making sure it works fine.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

