### PR TITLE
[BUG FIX] Fix dimension error while running apply external force/torque example

### DIFF
--- a/examples/rigid/apply_external_force_torque.py
+++ b/examples/rigid/apply_external_force_torque.py
@@ -27,6 +27,7 @@ def main():
             dt=0.01,
         ),
         show_viewer=args.vis,
+        show_FPS=False,
     )
 
     ########################## entities ##########################
@@ -40,12 +41,13 @@ def main():
         ),
     )
     ########################## build ##########################
-    scene.build()
+    scene.build(n_envs=1)
 
     for solver in scene.sim.solvers:
         if not isinstance(solver, RigidSolver):
             continue
         rigid_solver = solver
+        break
 
     link_idx = [
         1,
@@ -53,7 +55,7 @@ def main():
     rotation_direction = 1
     for i in range(1000):
         cube_pos = rigid_solver.get_links_pos(link_idx)
-        cube_pos[:, 2] -= 1
+        cube_pos[:, :, 2] -= 1
         force = -100 * cube_pos
         rigid_solver.apply_links_external_force(
             force=force,
@@ -61,7 +63,9 @@ def main():
         )
 
         torque = [
-            [0, 0, rotation_direction * 5],
+            [
+                [0, 0, rotation_direction * 5],
+            ],
         ]
         rigid_solver.apply_links_external_torque(
             torque=torque,

--- a/examples/rigid/apply_external_force_torque.py
+++ b/examples/rigid/apply_external_force_torque.py
@@ -47,14 +47,10 @@ def main():
         cube_pos = scene.sim.rigid_solver.get_links_pos(link_idx)
         cube_pos[:, :, 2] -= 1
         force = -100 * cube_pos
-        scene.sim.rigid_solver.apply_links_external_force(
-            force=force, links_idx=link_idx
-        )
+        scene.sim.rigid_solver.apply_links_external_force(force=force, links_idx=link_idx)
 
         torque = [[[0, 0, rotation_direction * 5]]]
-        scene.sim.rigid_solver.apply_links_external_torque(
-            torque=torque, links_idx=link_idx
-        )
+        scene.sim.rigid_solver.apply_links_external_torque(torque=torque, links_idx=link_idx)
 
         scene.step()
 

--- a/examples/rigid/apply_external_force_torque.py
+++ b/examples/rigid/apply_external_force_torque.py
@@ -14,15 +14,13 @@ def main():
     gs.init(backend=gs.gpu)
 
     ########################## create a scene ##########################
-    viewer_options = gs.options.ViewerOptions(
-        camera_pos=(0, -3.5, 2.5),
-        camera_lookat=(0.0, 0.0, 1.0),
-        camera_fov=40,
-        max_FPS=60,
-    )
-
     scene = gs.Scene(
-        viewer_options=viewer_options,
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(0, -3.5, 2.5),
+            camera_lookat=(0.0, 0.0, 1.0),
+            camera_fov=40,
+            max_FPS=60,
+        ),
         sim_options=gs.options.SimOptions(
             dt=0.01,
         ),
@@ -43,33 +41,19 @@ def main():
     ########################## build ##########################
     scene.build(n_envs=1)
 
-    for solver in scene.sim.solvers:
-        if not isinstance(solver, RigidSolver):
-            continue
-        rigid_solver = solver
-        break
-
-    link_idx = [
-        1,
-    ]
+    link_idx = [1]
     rotation_direction = 1
     for i in range(1000):
-        cube_pos = rigid_solver.get_links_pos(link_idx)
+        cube_pos = scene.sim.rigid_solver.get_links_pos(link_idx)
         cube_pos[:, :, 2] -= 1
         force = -100 * cube_pos
-        rigid_solver.apply_links_external_force(
-            force=force,
-            links_idx=link_idx,
+        scene.sim.rigid_solver.apply_links_external_force(
+            force=force, links_idx=link_idx
         )
 
-        torque = [
-            [
-                [0, 0, rotation_direction * 5],
-            ],
-        ]
-        rigid_solver.apply_links_external_torque(
-            torque=torque,
-            links_idx=link_idx,
+        torque = [[[0, 0, rotation_direction * 5]]]
+        scene.sim.rigid_solver.apply_links_external_torque(
+            torque=torque, links_idx=link_idx
         )
 
         scene.step()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->


When running the apply external force/torque example, the script fails with following errors.

### RigidSolver selection

```
Traceback (most recent call last):
  File "/home/alexis/Documents/python/robotics/Genesis/examples/rigid/apply_external_force_torque.py", line 78, in <module>
    main()
  File "/home/alexis/Documents/python/robotics/Genesis/examples/rigid/apply_external_force_torque.py", line 55, in main
    cube_pos = rigid_solver.get_links_pos(link_idx)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alexis/Documents/python/robotics/Genesis/genesis/engine/solvers/rigid/rigid_solver_decomp.py", line 4359, in get_links_pos
    tensor = ti_field_to_torch(self.links_state.pos, envs_idx, links_idx, transpose=True, unsafe=unsafe)
                               ^^^^^^^^^^^^^^^^
  File "/home/alexis/Documents/python/robotics/Genesis/.venv/lib/python3.11/site-packages/taichi/lang/kernel_impl.py", line 1221, in _getattr
    x = super(cls, self).__getattribute__(item)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alexis/Documents/python/robotics/Genesis/.venv/lib/python3.11/site-packages/taichi/lang/kernel_impl.py", line 1221, in _getattr
    x = super(cls, self).__getattribute__(item)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'AvatarSolver' object has no attribute 'links_state'
```

The fix is to pick the first match while selecting instances of `RigidSolver`.

### Dimension mismatch

```
Traceback (most recent call last):
  File "/home/alexis/Documents/python/robotics/Genesis/examples/rigid/apply_external_force_torque.py", line 79, in <module>
    main()
  File "/home/alexis/Documents/python/robotics/Genesis/examples/rigid/apply_external_force_torque.py", line 59, in main
    rigid_solver.apply_links_external_force(
  File "/home/alexis/Documents/python/robotics/Genesis/genesis/engine/solvers/rigid/rigid_solver_decomp.py", line 2660, in apply_links_external_force
    self._kernel_apply_links_external_force(force, links_idx, envs_idx)
  File "/home/alexis/Documents/python/robotics/Genesis/.venv/lib/python3.11/site-packages/taichi/lang/kernel_impl.py", line 1178, in __call__
    raise type(e)("\n" + str(e)) from None
taichi.lang.exception.TaichiIndexError: 
File "/home/alexis/Documents/python/robotics/Genesis/genesis/engine/solvers/rigid/rigid_solver_decomp.py", line 2672, in _kernel_apply_links_external_force:
                self.links_state[links_idx[i_l_],
     ^^^^^^^^^^^^^^^^^^^^
File "/home/alexis/Documents/python/robotics/Genesis/genesis/engine/solvers/rigid/rigid_solver_decomp.py", line 2672, in _kernel_apply_links_external_force:
                self.links_state[links_idx[i_l_],
     ^^^^^^^^^^^^^^^^^^^^
Array with dim 2 accessed with indices of dim 3
```

The fix is to change number of envs to `1`.

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context

Examples should not fail.

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Run the example with and without visualization.
```
python examples/rigid/apply_external_force_torque.py

PYOPENGL_PLATFORM=glx python examples/rigid/apply_external_force_torque.py -v
```

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/967a9e6d-1a85-403d-b0be-f3a1e3255c04



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
