### PR TITLE
[BUG FIX] Fix CI Out-Of-Memory issues.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,6 @@ jobs:
             source \"\$HOME/.bash_profile\" && \
             cp -r /workspace /app && cd /app && \
             bash ./.github/workflows/setup_env.sh && \
-            curl -sS 'https://api.github.com/repos/ompl/ompl/releases/tags/prerelease' \
-            | jq -r '.assets[].browser_download_url' \
-            | while IFS= read -r URL; do wget -q -c \"\$URL\"; done && \
-            pyenv shell "${{ matrix.python-version }}" && \
-            python -m pip install --no-index --find-links . ompl && \
             pip install -e ".[dev]" && \
             pytest -v tests && \
             pytest -v -m 'benchmarks' tests"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,12 +92,6 @@ RUN git clone https://github.com/Genesis-Embodied-AI/Genesis.git && \
     pip install . && \
     pip install --no-cache-dir PyOpenGL==3.1.5
 
-# ------------------------ Motion planning -----------------------
-RUN PYTHON_MAJOR_MINOR=$(echo ${PYTHON_VERSION} | tr -d '.') && \
-    wget https://github.com/ompl/ompl/releases/download/prerelease/ompl-1.6.0-cp${PYTHON_MAJOR_MINOR}-cp${PYTHON_MAJOR_MINOR}-manylinux_2_28_x86_64.whl && \
-    pip install ompl-1.6.0-cp${PYTHON_MAJOR_MINOR}-cp${PYTHON_MAJOR_MINOR}-manylinux_2_28_x86_64.whl && \
-    rm ompl-1.6.0-cp${PYTHON_MAJOR_MINOR}-cp${PYTHON_MAJOR_MINOR}-manylinux_2_28_x86_64.whl
-
 # -------------------- Surface Reconstruction --------------------
 # Set the LD_LIBRARY_PATH directly in the environment
 COPY --from=builder /workspace/Genesis/genesis/ext/ParticleMesher/ParticleMesherPy /opt/conda/lib/python3.1/site-packages/genesis/ext/ParticleMesher/ParticleMesherPy

--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -40,52 +40,6 @@ exit_callbacks = []
 global_scene_list = set()
 
 
-############ fix python DLL search dir for OMPL ############
-try:
-    import ompl
-
-    _is_ompl_available = True
-except ImportError:
-    _is_ompl_available = False
-
-
-def dll_loader(lib, path):
-    # First, try the user-specified path
-    sys = system()
-    if sys == "Windows":
-        ext = ".dll"
-    elif sys == "Darwin":
-        ext = ".dylib"
-    else:  # Linux, other UNIX systems
-        ext = ".so"
-    fname = f"lib{lib}{ext}"
-    fpath = os.path.join(path, fname)
-
-    # Fallback to site-packages
-    if not os.path.isfile(fpath):
-        for sitepackagedir in site.getsitepackages():
-            if not os.path.exists(sitepackagedir):
-                continue
-            for _fname in os.listdir(sitepackagedir):
-                _fpath = os.path.join(sitepackagedir, _fname)
-                if os.path.isfile(_fpath):
-                    if _fname.startswith(fname):
-                        fpath = _fpath
-                        break
-
-    # Fallback to system loading and pray
-    if not os.path.isfile(fpath):
-        fpath = find_library(lib)
-
-    cdll = ctypes.CDLL(fpath, ctypes.RTLD_GLOBAL)
-    if cdll is None:
-        gs.raise_exception(f"Failed to load dynamic library '{lib}' (search path '{path}').")
-
-
-if _is_ompl_available:
-    ompl.dll_loader = dll_loader
-
-
 ########################## init ##########################
 def init(
     seed=None,

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1834,7 +1834,7 @@ class RigidEntity(Entity):
     @gs.assert_built
     def set_pos(self, pos, envs_idx=None, *, zero_velocity=True, unsafe=False):
         """
-        Set position of the entity's base free-floating link.
+        Set position of the entity's base link.
 
         Parameters
         ----------
@@ -1855,7 +1855,7 @@ class RigidEntity(Entity):
     @gs.assert_built
     def set_quat(self, quat, envs_idx=None, *, zero_velocity=True, unsafe=False):
         """
-        Set quaternion of the entity's base free-floating link.
+        Set quaternion of the entity's base link.
 
         Parameters
         ----------

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1464,14 +1464,11 @@ class RigidEntity(Entity):
             from ompl import base as ob
             from ompl import geometric as og
             from ompl import util as ou
-
-            ou.setLogLevel(ou.LOG_ERROR)
         except ImportError as e:
-            gs.raise_exception_from(
-                "Failed to import OMPL. Did you install? (For installation instructions, see "
-                "https://genesis-world.readthedocs.io/en/latest/user_guide/overview/installation.html#optional-motion-planning)",
-                e,
-            )
+            if gs.platform == "Windows":
+                gs.raise_exception_from("No pre-compiled binaries of OMPL are not distributed on Windows OS.", e)
+            else:
+                raise
 
         if self._solver.n_envs > 0:
             gs.raise_exception("Motion planning is not supported for batched envs (yet).")
@@ -1510,6 +1507,7 @@ class RigidEntity(Entity):
             q_limit_upper = np.maximum(q_limit_upper, qpos_goal)
 
         ######### setup OMPL ##########
+        ou.setLogLevel(ou.LOG_ERROR)
         space = ob.RealVectorStateSpace(self.n_qs)
         bounds = ob.RealVectorBounds(self.n_qs)
 

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -163,6 +163,9 @@ class RigidSolver(Solver):
         self._equalities = self.equalities
 
         base_links_idx = []
+        for link in self.links:
+            if link.parent_idx == -1 and link.is_fixed:
+                base_links_idx.append(link.idx)
         for joint in chain.from_iterable(self.joints):
             if joint.type == gs.JOINT_TYPE.FREE:
                 base_links_idx.append(joint.link.idx)
@@ -236,7 +239,7 @@ class RigidSolver(Solver):
                 offset = offsets[i_link]
 
                 this_link = i_link
-                while this_link >= 0:
+                while this_link != -1:
                     for i_d_ in range(dof_end[this_link] - dof_start[this_link]):
                         i_d = dof_end[this_link] - i_d_ - 1
                         jacr[i_d] = cdof_ang[i_d]
@@ -306,7 +309,7 @@ class RigidSolver(Solver):
 
         for i in range(self.n_links):
             j = i
-            while j >= 0:
+            while j != -1:
                 for i_d in range(self.links[i].dof_start, self.links[i].dof_end):
                     for j_d in range(self.links[j].dof_start, self.links[j].dof_end):
                         mass_parent_mask[i_d, j_d] = 1.0
@@ -2309,7 +2312,7 @@ class RigidSolver(Solver):
 
             pos = l_info.pos
             quat = l_info.quat
-            if l_info.parent_idx >= 0:
+            if l_info.parent_idx != -1:
                 parent_pos = self.links_state[l_info.parent_idx, i_b].pos
                 parent_quat = self.links_state[l_info.parent_idx, i_b].quat
                 pos = parent_pos + gu.ti_transform_by_quat(pos, parent_quat)
@@ -2388,8 +2391,10 @@ class RigidSolver(Solver):
                 else:
                     print("unrecognized joint type", joint_type)
 
-            self.links_state[i_l, i_b].pos = pos
-            self.links_state[i_l, i_b].quat = quat
+            # Skip link pose update for fixed root links to allow the user for manually overwriting them
+            if not (l_info.is_fixed and l_info.parent_idx == -1):
+                self.links_state[i_l, i_b].pos = pos
+                self.links_state[i_l, i_b].quat = quat
 
     @ti.func
     def _func_forward_velocity_entity(self, i_e, i_b):
@@ -2399,7 +2404,7 @@ class RigidSolver(Solver):
 
             cvel_vel = ti.Vector.zero(gs.ti_float, 3)
             cvel_ang = ti.Vector.zero(gs.ti_float, 3)
-            if l_info.parent_idx >= 0:
+            if l_info.parent_idx != -1:
                 cvel_vel = self.links_state[l_info.parent_idx, i_b].cd_vel
                 cvel_ang = self.links_state[l_info.parent_idx, i_b].cd_ang
 
@@ -3683,9 +3688,10 @@ class RigidSolver(Solver):
             gs.logger.debug(ALLOCATE_TENSOR_WARNING)
         if _inputs_idx.ndim != 1:
             gs.raise_exception(f"Expecting 1D tensor for `{idx_name}`.")
-        inputs_start, inputs_end = min(inputs_idx), max(inputs_idx)
-        if inputs_start < 0 or input_max <= inputs_end:
-            gs.raise_exception("`{idx_name}` is out-of-range.")
+        if len(inputs_idx):
+            inputs_start, inputs_end = min(inputs_idx), max(inputs_idx)
+            if inputs_start < 0 or input_max <= inputs_end:
+                gs.raise_exception("`{idx_name}` is out-of-range.")
 
         if is_preallocated:
             _tensor = torch.as_tensor(tensor, dtype=gs.tc_float, device=gs.device).contiguous()
@@ -3817,7 +3823,7 @@ class RigidSolver(Solver):
         if self.n_envs == 0:
             pos = pos.unsqueeze(0)
         if not unsafe and not torch.isin(links_idx, self._base_links_idx).all():
-            gs.raise_exception("`links_idx` contains at least one link that is not a free-floating base link.")
+            gs.raise_exception("`links_idx` contains at least one link that is not a base link.")
         self._kernel_set_links_pos(pos, links_idx, envs_idx)
         if not skip_forward:
             self._kernel_forward_kinematics_links_geoms(envs_idx)
@@ -3835,12 +3841,13 @@ class RigidSolver(Solver):
             I_l = [i_l, i_b_] if ti.static(self._options.batch_links_info) else i_l
             for i in ti.static(range(3)):
                 self.links_state[i_l, envs_idx[i_b_]].pos[i] = pos[i_b_, i_l_, i]
-            q_start = self.links_info[I_l].q_start
-            for i in ti.static(range(3)):
-                self.qpos[q_start + i, envs_idx[i_b_]] = pos[i_b_, i_l_, i]
+            if not (self.links_info[I_l].parent_idx == -1 and self.links_info[I_l].is_fixed):
+                q_start = self.links_info[I_l].q_start
+                for i in ti.static(range(3)):
+                    self.qpos[q_start + i, envs_idx[i_b_]] = pos[i_b_, i_l_, i]
 
     def set_links_quat(self, quat, links_idx=None, envs_idx=None, *, unsafe=False, skip_forward=False):
-        raise DeprecationError("This method has been removed. Please use 'set_base_links_pos' instead.")
+        raise DeprecationError("This method has been removed. Please use 'set_base_links_quat' instead.")
 
     def set_base_links_quat(self, quat, links_idx=None, envs_idx=None, *, unsafe=False, skip_forward=False):
         if links_idx is None:
@@ -3851,7 +3858,7 @@ class RigidSolver(Solver):
         if self.n_envs == 0:
             quat = quat.unsqueeze(0)
         if not unsafe and not torch.isin(links_idx, self._base_links_idx).all():
-            gs.raise_exception("`links_idx` contains at least one link that is not a free-floating base link.")
+            gs.raise_exception("`links_idx` contains at least one link that is not a base link.")
         self._kernel_set_links_quat(quat, links_idx, envs_idx)
         if skip_forward:
             self._kernel_forward_kinematics_links_geoms(envs_idx)
@@ -3869,9 +3876,10 @@ class RigidSolver(Solver):
             I_l = [i_l, i_b_] if ti.static(self._options.batch_links_info) else i_l
             for i in ti.static(range(4)):
                 self.links_state[i_l, envs_idx[i_b_]].quat[i] = quat[i_b_, i_l_, i]
-            q_start = self.links_info[I_l].q_start
-            for i in ti.static(range(4)):
-                self.qpos[q_start + i + 3, envs_idx[i_b_]] = quat[i_b_, i_l_, i]
+            if not (self.links_info[I_l].parent_idx == -1 and self.links_info[I_l].is_fixed):
+                q_start = self.links_info[I_l].q_start
+                for i in ti.static(range(4)):
+                    self.qpos[q_start + i + 3, envs_idx[i_b_]] = quat[i_b_, i_l_, i]
 
     def set_links_mass_shift(self, mass, links_idx=None, envs_idx=None, *, unsafe=False):
         mass, links_idx, envs_idx = self._sanitize_1D_io_variables(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ addopts = [
     "--dist=loadgroup",
     "--random-order-bucket=global",
     "--random-order-seed=0",
+    "--max-worker-restart=0",
     "--durations=0",
     "--durations-min=40.0",
     "-m not benchmarks",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ dependencies = [
     "coacd",
     # Used for loading raytracing special texture images used by LuisaRender
     "OpenEXR",
+    # Motion Planning library
+    # * 1.7.0: First version distributed on PyPI (no pre-compiled binaries for Windows OS).
+    #          Fix OMPL DLL search directory.
+    "ompl>=1.7.0; platform_system != 'Windows'"
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,23 +25,26 @@ def pytest_make_parametrize_id(config, val, argname):
     return f"{val}"
 
 
-def pytest_xdist_auto_num_workers(config):
-    # Determine whether 'benchmarks' marker is selected
+@pytest.hookimpl(tryfirst=True)
+def pytest_cmdline_main(config: pytest.Config) -> None:
+    # Force disabling distributed framework if benchmarks are selected
     expr = Expression.compile(config.option.markexpr)
     is_benchmarks = expr.evaluate(MarkMatcher.from_markers((pytest.mark.benchmarks,)))
+    if is_benchmarks:
+        config.option.numprocesses = 0
+
+    # Force disabling distributed framework if interactive viewer is enabled
     show_viewer = config.getoption("--vis")
+    if show_viewer:
+        config.option.numprocesses = 0
 
-    # Disable multi-processing for benchmarks
-    if is_benchmarks or show_viewer:
-        return 0
 
+def pytest_xdist_auto_num_workers(config):
     # Compute the default number of workers based on available RAM, VRAM, and number of physical cores
     physical_core_count = psutil.cpu_count(logical=False)
     _, _, ram_memory, _ = gs.utils.get_device(gs.cpu)
     _, _, vram_memory, _ = gs.utils.get_device(gs.gpu)
     return min(int(ram_memory / 4.0), int(vram_memory / 1.0), physical_core_count)
-
-    return config.option.numprocesses
 
 
 def pytest_addoption(parser):

--- a/tests/test_rigid_benchmarks.py
+++ b/tests/test_rigid_benchmarks.py
@@ -90,6 +90,8 @@ def batched_franka(solver, n_envs, show_viewer):
         rigid_options=gs.options.RigidOptions(
             dt=0.01,
             constraint_solver=solver,
+            # FIXME: Must disable self collision to avoid CUDA OOM error
+            enable_self_collision=False,
         ),
         show_viewer=show_viewer,
     )

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -371,14 +371,19 @@ def test_set_root_pose(show_viewer, atol):
     )
     scene.build()
 
-    np.testing.assert_allclose(robot.get_pos(), (0.0, 0.4, 0.1), atol=atol)
-    np.testing.assert_allclose(
-        gs.utils.geom.quat_to_xyz(robot.get_quat(), rpy=True, degrees=True), (0, 0, 90), atol=atol
-    )
-    np.testing.assert_allclose(cube.get_pos(), (0.65, 0.0, 0.02), atol=atol)
+    for _ in range(2):
+        scene.reset()
 
-    cube.set_pos(torch.tensor((0.0, 0.5, 0.2)))
-    np.testing.assert_allclose(cube.get_pos(), (0.0, 0.5, 0.2), atol=atol)
+        np.testing.assert_allclose(robot.get_pos(), (0.0, 0.4, 0.1), atol=atol)
+        np.testing.assert_allclose(
+            gs.utils.geom.quat_to_xyz(robot.get_quat(), rpy=True, degrees=True), (0, 0, 90), atol=atol
+        )
+        robot.set_pos(torch.tensor((-0.1, -0.2, 0.2)))
+        np.testing.assert_allclose(robot.get_pos(), (-0.1, -0.2, 0.2), atol=atol)
+
+        np.testing.assert_allclose(cube.get_pos(), (0.65, 0.0, 0.02), atol=atol)
+        cube.set_pos(torch.tensor((0.0, 0.5, 0.2)))
+        np.testing.assert_allclose(cube.get_pos(), (0.0, 0.5, 0.2), atol=atol)
 
 
 @pytest.mark.dof_damping(True)


### PR DESCRIPTION
## Description

* Disable self collision on Franka for large-scale benchmarks as it causes CUDA OOM issues
* Make it possible again to set the pose of a robot having a fixed base link
* Install pre-compiled binary wheels of OMPL available on PyPI

* ~~orce running unit tests in isolated subprocesses. I tried to reduce the amount of RAM being reserved for each worker from 4GB to 3GB but takes up to 95% of the available RAM. Reverting to avoid instability since the CI is a shared machine.~~ (It turnout it is not possible to do this systematically because forking cannot be used due GPU devices limitations (and is not even available on Windows OS) and spawn cannot be used because of pytest fixture limitations...)

## Motivation and Context

As the number of unit tests increasing, addressing the memory leak issue of Genesis (see https://github.com/Genesis-Embodied-AI/Genesis/issues/949) is becoming more pressing. Since memory is not released between each test, the amount of allocated RAM and VRAM memory keeps increasing, until it triggers Out-Of-Memory. Fixing the root cause of the issue may be quite tricky. As a quick fix, running each test in a isolated subprocess should be sufficient for running the unit tests without issue.

## How Has This Been / Can This Be Tested?

The CI is passing without issue.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.