### PR TITLE
[BUG FIX] More robust computation of perturbation axes for multi-point contact.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -131,20 +131,15 @@ class RigidGeom(RBC):
                 center = (upper + lower) / 2.0
 
                 # NOTE: sdf size is from the center of the lower voxel cell to the center of the upper voxel cell
-                # add padding
+                # add padding. Adjust the cell size to keep resolution within bounds.
                 padding_ratio = 0.2
                 grid_size = (upper - lower).max() * padding_ratio + (upper - lower)
-                sdf_res = np.ceil(grid_size / self._material.sdf_cell_size).astype(int) + 1
-
-                if sdf_res.max() > self._material.sdf_max_res:
-                    sdf_res = np.ceil(sdf_res * self._material.sdf_max_res / sdf_res.max()).astype(int)
-                    sdf_cell_size = grid_size.max() / (sdf_res.max() - 1)
-                elif sdf_res.max() < self._material.sdf_min_res:
-                    sdf_res = np.ceil(sdf_res * self._material.sdf_min_res / sdf_res.max()).astype(int)
-                    sdf_cell_size = grid_size.max() / (sdf_res.max() - 1)
-                else:
-                    sdf_cell_size = self._material.sdf_cell_size
-                sdf_res = np.clip(sdf_res, 3, None)
+                sdf_cell_size = gs.EPS + np.clip(
+                    self._material.sdf_cell_size,
+                    grid_size.max() / (self._material.sdf_max_res - 1),
+                    grid_size.min() / max(self._material.sdf_min_res - 1, 2),
+                )
+                sdf_res = np.ceil(grid_size / sdf_cell_size).astype(int) + 1
 
                 # round up to multiple of sdf_cell_size
                 grid_size = (sdf_res - 1) * sdf_cell_size

--- a/genesis/engine/solvers/rigid/collider_decomp.py
+++ b/genesis/engine/solvers/rigid/collider_decomp.py
@@ -1234,10 +1234,12 @@ class Collider:
         i_la = self._solver.geoms_info[i_ga].link_idx
         i_lb = self._solver.geoms_info[i_gb].link_idx
 
-        # Disable multi-contact for pairs of decomposed geoms, as it is redundant and would significantly slowdown simu
+        # Disabling multi-contact for pairs of decomposed geoms would speed up simulation but may cause physical
+        # instabilities in the few cases where multiple contact points are actually need. Increasing the tolerance
+        # criteria to get rid of redundant contact points seems to be a better option.
         multi_contact = (
             ti.static(self._solver._enable_multi_contact)
-            and not (self._solver.geoms_info[i_ga].is_decomposed and self._solver.geoms_info[i_gb].is_decomposed)
+            # and not (self._solver.geoms_info[i_ga].is_decomposed and self._solver.geoms_info[i_gb].is_decomposed)
             and self._solver.geoms_info[i_ga].type != gs.GEOM_TYPE.SPHERE
             and self._solver.geoms_info[i_ga].type != gs.GEOM_TYPE.ELLIPSOID
             and self._solver.geoms_info[i_gb].type != gs.GEOM_TYPE.SPHERE

--- a/genesis/engine/solvers/rigid/collider_decomp.py
+++ b/genesis/engine/solvers/rigid/collider_decomp.py
@@ -37,7 +37,7 @@ class Collider:
 
         # multi contact perturbation and tolerance
         self._mc_perturbation = 1e-3
-        self._mc_tolerance = 1e-3
+        self._mc_tolerance = 5e-2
         self._mpr_to_sdf_overlap_ratio = 0.5
 
     def _init_verts_connectivity(self):

--- a/genesis/engine/solvers/rigid/mpr_decomp.py
+++ b/genesis/engine/solvers/rigid/mpr_decomp.py
@@ -338,38 +338,31 @@ class MPR:
     def mpr_find_pos(self, i_ga, i_gb, i_b):
         b = ti.Vector([0.0, 0.0, 0.0, 0.0], dt=gs.ti_float)
 
-        direction = self.mpr_portal_dir(i_ga, i_gb, i_b)
-
-        for i in range(4):
-            i1, i2, i3 = (i + 1) % 4, (i + 2) % 4, (i + 3) % 4
-            vec = self.simplex_support[i_ga, i_gb, i1, i_b].v.cross(self.simplex_support[i_ga, i_gb, i2, i_b].v)
-            b[i] = vec.dot(self.simplex_support[i_ga, i_gb, i3, i_b].v) * (1 - i % 2 * 2)
+        # Only look into the direction of the portal for consistency with penetration depth computation
+        if ti.static(self._solver._enable_mpr_vanilla):
+            for i in range(4):
+                i1, i2, i3 = (i % 2) + 1, (i + 2) % 4, 3 * ((i + 1) % 2)
+                vec = self.simplex_support[i_ga, i_gb, i1, i_b].v.cross(self.simplex_support[i_ga, i_gb, i2, i_b].v)
+                b[i] = vec.dot(self.simplex_support[i_ga, i_gb, i3, i_b].v) * (1 - 2 * (((i + 1) // 2) % 2))
 
         sum_ = b.sum()
 
-        if sum_ <= 0:
+        if sum_ < self.CCD_EPS:
+            direction = self.mpr_portal_dir(i_ga, i_gb, i_b)
             b[0] = 0.0
             for i in range(1, 4):
                 i1, i2 = i % 3 + 1, (i + 1) % 3 + 1
                 vec = self.simplex_support[i_ga, i_gb, i1, i_b].v.cross(self.simplex_support[i_ga, i_gb, i2, i_b].v)
                 b[i] = vec.dot(direction)
-
-        sum_ = b.sum()
+            sum_ = b.sum()
 
         p1 = gs.ti_vec3([0.0, 0.0, 0.0])
         p2 = gs.ti_vec3([0.0, 0.0, 0.0])
         for i in range(4):
-            vec = self.simplex_support[i_ga, i_gb, i, i_b].v1 * b[i]
-            p1 += vec
-            vec = self.simplex_support[i_ga, i_gb, i, i_b].v2 * b[i]
-            p2 += vec
+            p1 += b[i] * self.simplex_support[i_ga, i_gb, i, i_b].v1
+            p2 += b[i] * self.simplex_support[i_ga, i_gb, i, i_b].v2
 
-        inv_ = 1 / sum_
-        p1 = p1 * inv_
-        p2 = p2 * inv_
-        pos = (p1 + p2) * 0.5
-
-        return pos
+        return (0.5 / sum_) * (p1 + p2)
 
     @ti.func
     def mpr_find_penetr_touch(self, i_ga, i_gb, i_b):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,19 @@ def initialize_genesis(request, backend):
 
 
 @pytest.fixture
+def mpr_vanilla(request):
+    mpr_vanilla = None
+    for mark in request.node.iter_markers("mpr_vanilla"):
+        if mark.args:
+            if mpr_vanilla is not None:
+                pytest.fail("'mpr_vanilla' can only be specified once.")
+            (mpr_vanilla,) = mark.args
+    if mpr_vanilla is None:
+        mpr_vanilla = True
+    return mpr_vanilla
+
+
+@pytest.fixture
 def adjacent_collision(request):
     adjacent_collision = None
     for mark in request.node.iter_markers("adjacent_collision"):
@@ -173,7 +186,9 @@ def mj_sim(xml_path, gs_solver, gs_integrator, multi_contact, adjacent_collision
 
 
 @pytest.fixture
-def gs_sim(xml_path, gs_solver, gs_integrator, multi_contact, adjacent_collision, dof_damping, show_viewer, mj_sim):
+def gs_sim(
+    xml_path, gs_solver, gs_integrator, multi_contact, mpr_vanilla, adjacent_collision, dof_damping, show_viewer, mj_sim
+):
     scene = gs.Scene(
         viewer_options=gs.options.ViewerOptions(
             camera_pos=(3, -1, 1.5),
@@ -190,7 +205,7 @@ def gs_sim(xml_path, gs_solver, gs_integrator, multi_contact, adjacent_collision
         rigid_options=gs.options.RigidOptions(
             integrator=gs_integrator,
             constraint_solver=gs_solver,
-            enable_mpr_vanilla=True,
+            enable_mpr_vanilla=mpr_vanilla,
             box_box_detection=True,
             enable_self_collision=True,
             enable_adjacent_collision=adjacent_collision,

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -78,6 +78,76 @@ def box_box():
     return mjcf
 
 
+@pytest.fixture
+def collision_edge_cases(asset_tmp_path, mode):
+    assets = {}
+    for i, box_size in enumerate(((0.8, 0.8, 0.04), (0.04, 0.04, 0.005))):
+        tmesh = trimesh.creation.box(extents=np.array(box_size) * 2)
+        mesh_path = str(asset_tmp_path / f"box{i}.obj")
+        tmesh.export(mesh_path, file_type="obj")
+        assets[f"box{i}"] = mesh_path
+
+    mjcf = ET.Element("mujoco", model="one_box")
+    ET.SubElement(mjcf, "option", timestep="0.005")
+    default = ET.SubElement(mjcf, "default")
+    ET.SubElement(default, "geom", contype="1", conaffinity="1", condim="3", friction="1. 0.5 0.5")
+
+    asset = ET.SubElement(mjcf, "asset")
+    for name, mesh_path in assets.items():
+        ET.SubElement(asset, "mesh", name=name, refpos="0 0 0", refquat="1 0 0 0", file=mesh_path)
+
+    worldbody = ET.SubElement(mjcf, "worldbody")
+
+    if mode == 0:
+        ET.SubElement(worldbody, "geom", type="box", size="0.8 0.8 0.04", pos="0. 0. 0.", rgba="0 1 0 0.4")
+        box1_body = ET.SubElement(worldbody, "body", name="box1", pos="0.0 0.0 0.7")
+        ET.SubElement(box1_body, "geom", type="box", size="0.04 0.04 0.005", pos="-0.758 -0.758 0.", rgba="0 0 1 0.4")
+    elif mode == 1:
+        ET.SubElement(worldbody, "geom", type="box", size="0.8 0.8 0.04", pos="0. 0. 0.", rgba="0 1 0 0.4")
+        box1_body = ET.SubElement(worldbody, "body", name="box1", pos="-0.758 -0.758 0.7")
+        ET.SubElement(box1_body, "geom", type="box", size="0.04 0.04 0.005", pos="0. 0. 0.", rgba="0 0 1 0.4")
+    elif mode == 2:
+        ET.SubElement(worldbody, "geom", type="box", size="0.8 0.8 0.04", pos="0. 0. 0.", rgba="0 1 0 0.4")
+        box1_body = ET.SubElement(worldbody, "body", name="box1", pos="-0.758 -0.758 1.1")
+        ET.SubElement(box1_body, "geom", type="box", size="0.04 0.04 0.005", pos="0. 0. 0.", rgba="0 0 1 0.4")
+    elif mode == 3:
+        ET.SubElement(worldbody, "geom", type="box", size="0.8 0.8 0.04", pos="0. 0. 0.", rgba="0 1 0 0.4")
+        box1_body = ET.SubElement(worldbody, "body", name="box1", pos="0.0 0.0 0.7")
+        ET.SubElement(box1_body, "geom", type="mesh", mesh="box1", pos="-0.758 -0.758 0.", rgba="0 0 1 0.4")
+    elif mode == 4:
+        ET.SubElement(worldbody, "geom", type="mesh", mesh="box0", pos="0. 0. 0.", rgba="0 1 0 0.4")
+        box1_body = ET.SubElement(worldbody, "body", name="box1", pos="0.0 0.0 0.7")
+        ET.SubElement(box1_body, "geom", type="mesh", mesh="box1", pos="-0.758 -0.758 0.", rgba="0 0 1 0.4")
+    elif mode == 5:
+        ET.SubElement(worldbody, "geom", type="mesh", mesh="box0", pos="0. 0. 0.", rgba="0 1 0 0.4")
+        box1_body = ET.SubElement(worldbody, "body", name="box1", pos="-0.758 -0.758 0.7")
+        ET.SubElement(box1_body, "geom", type="mesh", mesh="box1", pos="0. 0. 0.", rgba="0 0 1 0.4")
+    elif mode == 6:
+        ET.SubElement(worldbody, "geom", type="mesh", mesh="box0", pos="0. 0. 0.", rgba="0 1 0 0.4")
+        box1_body = ET.SubElement(worldbody, "body", name="box1", pos="-0.758 -0.758 1.1")
+        ET.SubElement(box1_body, "geom", type="mesh", mesh="box1", pos="0. 0. 0.", rgba="0 0 1 0.4")
+    elif mode == 7:
+        ET.SubElement(worldbody, "geom", type="mesh", mesh="box1", pos=" 0.758  0.758 0.", rgba="0 1 0 0.4")
+        ET.SubElement(worldbody, "geom", type="mesh", mesh="box1", pos="-0.758 -0.758 0.", rgba="0 1 0 0.4")
+        ET.SubElement(worldbody, "geom", type="mesh", mesh="box1", pos=" 0.758 -0.758 0.", rgba="0 1 0 0.4")
+        ET.SubElement(worldbody, "geom", type="mesh", mesh="box1", pos="-0.758  0.758 0.", rgba="0 1 0 0.4")
+        box1_body = ET.SubElement(worldbody, "body", name="box1", pos="0. 0. 0.7")
+        ET.SubElement(box1_body, "geom", type="mesh", mesh="box0", pos="0. 0. 0.", rgba="0 0 1 0.4")
+    elif mode == 8:
+        ET.SubElement(worldbody, "geom", type="mesh", mesh="box1", pos=" 0.762  0.762 0.", rgba="0 1 0 0.4")
+        ET.SubElement(worldbody, "geom", type="mesh", mesh="box1", pos="-0.762 -0.762 0.", rgba="0 1 0 0.4")
+        ET.SubElement(worldbody, "geom", type="mesh", mesh="box1", pos=" 0.762 -0.762 0.", rgba="0 1 0 0.4")
+        ET.SubElement(worldbody, "geom", type="mesh", mesh="box1", pos="-0.762  0.762 0.", rgba="0 1 0 0.4")
+        box1_body = ET.SubElement(worldbody, "body", name="box1", pos="0. 0. 0.7")
+        ET.SubElement(box1_body, "geom", type="mesh", mesh="box0", pos="0. 0. 0.", rgba="0 0 1 0.4")
+    else:
+        raise ValueError("Invalid mode")
+
+    ET.SubElement(box1_body, "joint", name="root", type="free")
+
+    return mjcf
+
+
 def _build_chain_capsule_hinge(asset_tmp_path, enable_mesh):
     if enable_mesh:
         mesh_path = str(asset_tmp_path / "capsule.obj")
@@ -686,6 +756,23 @@ def test_convexify(euler, show_viewer):
             qpos = obj.get_dofs_position().cpu()
             np.testing.assert_allclose(qpos[0], 0.0, atol=6e-3)
             np.testing.assert_allclose(qpos[1], 0.15 * (i - 1.5), atol=5e-3)
+
+
+@pytest.mark.mpr_vanilla(False)
+@pytest.mark.parametrize("mode", range(9))
+@pytest.mark.parametrize("model_name", ["collision_edge_cases"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
+def test_collision_edge_cases(gs_sim, mode):
+    qpos_0 = gs_sim.rigid_solver.get_dofs_position().cpu()
+    for _ in range(200):
+        gs_sim.scene.step()
+
+    qvel = gs_sim.rigid_solver.get_dofs_velocity().cpu()
+    np.testing.assert_allclose(qvel, 0, atol=1e-2)
+    qpos = gs_sim.rigid_solver.get_dofs_position().cpu()
+    np.testing.assert_allclose(qpos[[0, 1, 3, 4, 5]], qpos_0[[0, 1, 3, 4, 5]], atol=1e-4)
 
 
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -1,6 +1,7 @@
-import pytest
+import sys
 import xml.etree.ElementTree as ET
 
+import pytest
 import trimesh
 import torch
 import numpy as np
@@ -551,12 +552,14 @@ def move_cube(use_suction, show_viewer):
     np.testing.assert_allclose(qpos[2], 0.06, atol=2e-3)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="OMPL is not supported on Windows OS.")
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
 def test_inverse_kinematics(show_viewer):
     use_suction = False
     move_cube(use_suction, show_viewer)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="OMPL is not supported on Windows OS.")
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
 def test_suction_cup(show_viewer):
     use_suction = True


### PR DESCRIPTION
## Description

* Fix broken 'qf_passive' for non-zero damping.
* Add first-order perturbation compensation of contact normal.
* More robust computation of perturbation axes for multi-point contact.
* Do not disable multi-point contact for pairs of decomposed geometries.
* Increase multi-contact repeated point tolerance.
* Add unit test for collision edge cases.
* Tune unit tests for flakyness.

## How Has This Been / Can This Be Tested?

Running the unit tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.