### PR TITLE
[BUG FIX] Improve support of partially 'broken' mesh.

### DIFF
--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -664,9 +664,9 @@ def test_nonconvex_collision(show_viewer):
     # Force numpy seed because this test is very sensitive to the initial condition
     np.random.seed(0)
     ball.set_dofs_velocity(np.random.rand(ball.n_dofs) * 0.8)
-    for i in range(1500):
+    for i in range(1800):
         scene.step()
-        if i > 1400:
+        if i > 1700:
             qvel = scene.sim.rigid_solver.dofs_state.vel.to_numpy()[:, 0]
             np.testing.assert_allclose(qvel, 0, atol=0.1)
 
@@ -738,7 +738,7 @@ def test_convexify(euler, show_viewer):
     assert all(geom.metadata["decomposed"] for geom in box.geoms) and 5 <= len(box.geoms) <= 20
 
     # Check resting conditions repeateadly rather not just once, for numerical robustness
-    num_steps = 1200 if euler == (90, 0, 90) else 600
+    num_steps = 1500 if euler == (90, 0, 90) else 600
     for i in range(num_steps):
         scene.step()
         if i > num_steps - 100:


### PR DESCRIPTION
## Description

This PR considers that the ratio between the original volume and its convex decomposition is infinity.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/1015

## Motivation and Context

Partially broken meshes with flipped faces are not considered watertight. Because of this, their volume is not properly computed and they are never composed. If convexify is enabled, their convex hull will be used for collision, while convex decomposition was eventually necessary in the first place. The only option left to the user is to completely disable convexify. However, SDF collision detection is fragile, and having flipped vertices is not going to help... I suggest to always apply convex decomposition to meshes that are not watertight, unless this option is completely disabled via `decompose_error_threshold'=float('inf')`.

## How Has This Been / Can This Be Tested?

Running this script for the asset provided in related issue:
```python
    import genesis as gs

    if not gs._initialized:
        gs.init(backend=gs.cpu, logging_level="debug")

    scene = gs.Scene(
        show_viewer=True,
        show_FPS=True,
    )
    block = scene.add_entity(
        morph=gs.morphs.URDF(
            file="urdf/block/block.urdf",
            pos=(0.0, 0.0, 0.0),
            euler=(0.0, 0.0, 0.0),
            fixed=True,
            coacd_options=gs.options.CoacdOptions(
                threshold=0.05,
            )
        ),
        vis_mode="collision",
    )

    scene.build()
```

## Screenshots (if appropriate):

<img width="488" alt="image" src="https://github.com/user-attachments/assets/a91f27af-c051-4293-8a85-e7a10e9fd76c" />

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
