### PR TITLE
[BUG FIX] Expose decimate aggressiveness option.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -591,6 +591,7 @@ class RigidEntity(Entity):
                 cg_infos,
                 morph.decimate,
                 morph.decimate_face_num,
+                morph.decimate_aggressiveness,
                 morph.convexify,
                 morph.decompose_error_threshold,
                 morph.coacd_options,

--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -96,6 +96,14 @@ class RigidGeom(RBC):
             self._sdf_verts = np.array(self._init_verts)
             self._sdf_faces = np.array(self._init_faces)
 
+        if len(self._sdf_faces) > 50000:
+            mesh_descr = f"({mesh.metadata['mesh_path']})" if "mesh_path" in mesh.metadata else ""
+            gs.logging.warning(
+                "Beware that SDF pre-processing of mesh {mesh_descr} having more than 50000 vertices may take a very "
+                "long time (>10min) and require large RAM allocation (>20Gb). Please either enable convexify or "
+                "decimation. (see FileMorph options)"
+            )
+
         # collision mesh uses default color
         self._preprocess()
 

--- a/genesis/engine/mesh.py
+++ b/genesis/engine/mesh.py
@@ -33,6 +33,10 @@ class Mesh(RBC):
         Whether to decimate the mesh.
     decimate_face_num : int
         The target number of faces after decimation.
+    decimate_aggressiveness : int
+        How hard the decimation process will try to match the target number of faces, as a integer ranging from 0 to 8.
+        0 is losseless. 2 preserves all features of the original geometry. 5 may significantly alters
+        the original geometry if necessary. does what needs to be done at all costs.
     metadata : dict
         The metadata of the mesh.
     """
@@ -45,6 +49,7 @@ class Mesh(RBC):
         convexify=False,
         decimate=False,
         decimate_face_num=500,
+        decimate_aggressiveness=0,
         metadata=dict(),
     ):
         self._uid = gs.UID()
@@ -68,7 +73,7 @@ class Mesh(RBC):
             self.convexify()
 
         if decimate:
-            self.decimate(decimate_face_num, convexify)
+            self.decimate(decimate_face_num, decimate_aggressiveness, convexify)
 
     def convexify(self):
         """
@@ -78,7 +83,7 @@ class Mesh(RBC):
             self._mesh = trimesh.convex.convex_hull(self._mesh)
         self.clear_visuals()
 
-    def decimate(self, decimate_face_num, convexify):
+    def decimate(self, decimate_face_num, decimate_aggressiveness, convexify):
         """
         Decimate the mesh.
         """
@@ -88,7 +93,8 @@ class Mesh(RBC):
                     self._mesh.vertices,
                     self._mesh.faces,
                     target_count=decimate_face_num,
-                    agg=2,
+                    agg=decimate_aggressiveness,
+                    lossless=(decimate_aggressiveness == 0),
                 )
             )
 
@@ -204,7 +210,15 @@ class Mesh(RBC):
 
     @classmethod
     def from_trimesh(
-        cls, mesh, scale=None, convexify=False, decimate=False, decimate_face_num=500, metadata=dict(), surface=None
+        cls,
+        mesh,
+        scale=None,
+        convexify=False,
+        decimate=False,
+        decimate_face_num=500,
+        decimate_aggressiveness=2,
+        metadata=dict(),
+        surface=None,
     ):
         """
         Create a genesis.Mesh from a trimesh.Trimesh object.
@@ -292,6 +306,7 @@ class Mesh(RBC):
             convexify=convexify,
             decimate=decimate,
             decimate_face_num=decimate_face_num,
+            decimate_aggressiveness=decimate_aggressiveness,
             metadata=metadata,
         )
 

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -302,6 +302,11 @@ class FileMorph(Morph):
         Whether to decimate (simplify) the mesh. If not given, it defaults to `convexify`. **This is only used for RigidEntity.**
     decimate_face_num : int, optional
         The number of faces to decimate to. Defaults to 500. **This is only used for RigidEntity.**
+    decimate_aggressiveness : int
+        How hard the decimation process will try to match the target number of faces, as a integer ranging from 0 to 8.
+        0 is losseless. 2 preserves all features of the original geometry. 5 may significantly alters the original
+        geometry if necessary. 8 does what needs to be done at all costs. Defaults to 2.
+        **This is only used for RigidEntity.**
     convexify : bool, optional
         Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
         to a set of convex hulls. The mesh with be decomposed into multiple convex components if a single one is not
@@ -327,6 +332,7 @@ class FileMorph(Morph):
     scale: Union[float, tuple] = 1.0
     decimate: Optional[bool] = None
     decimate_face_num: int = 500
+    decimate_aggressiveness: int = 2
     convexify: Optional[bool] = None
     decompose_nonconvex: Optional[bool] = None
     decompose_error_threshold: float = 0.15
@@ -399,6 +405,11 @@ class Mesh(FileMorph):
         Whether to decimate (simplify) the mesh. Defaults to True. **This is only used for RigidEntity.**
     decimate_face_num : int, optional
         The number of faces to decimate to. Defaults to 500. **This is only used for RigidEntity.**
+    decimate_aggressiveness : int
+        How hard the decimation process will try to match the target number of faces, as a integer ranging from 0 to 8.
+        0 is losseless. 2 preserves all features of the original geometry. 5 may significantly alters the original
+        geometry if necessary. 8 does what needs to be done at all costs. Defaults to 2.
+        **This is only used for RigidEntity.**
     convexify : bool, optional
         Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
         to a set of convex hulls. The mesh with be decomposed into multiple convex components if a single one is not
@@ -498,6 +509,11 @@ class MJCF(FileMorph):
         Whether to decimate (simplify) the mesh. Defaults to True. **This is only used for RigidEntity.**
     decimate_face_num : int, optional
         The number of faces to decimate to. Defaults to 500. **This is only used for RigidEntity.**
+    decimate_aggressiveness : int
+        How hard the decimation process will try to match the target number of faces, as a integer ranging from 0 to 8.
+        0 is losseless. 2 preserves all features of the original geometry. 5 may significantly alters the original
+        geometry if necessary. 8 does what needs to be done at all costs. Defaults to 2.
+        **This is only used for RigidEntity.**
     convexify : bool, optional
         Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
         to a set of convex hulls. The mesh with be decomposed into multiple convex components if a single one is not
@@ -556,6 +572,11 @@ class URDF(FileMorph):
         Whether to decimate (simplify) the mesh. Defaults to True. **This is only used for RigidEntity.**
     decimate_face_num : int, optional
         The number of faces to decimate to. Defaults to 500. **This is only used for RigidEntity.**
+    decimate_aggressiveness : int
+        How hard the decimation process will try to match the target number of faces, as a integer ranging from 0 to 8.
+        0 is losseless. 2 preserves all features of the original geometry. 5 may significantly alters the original
+        geometry if necessary. 8 does what needs to be done at all costs. Defaults to 2.
+        **This is only used for RigidEntity.**
     convexify : bool, optional
         Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
         to a set of convex hulls. The mesh with be decomposed into multiple convex components if a single one is not
@@ -621,6 +642,11 @@ class Drone(FileMorph):
         Whether to decimate (simplify) the mesh. Defaults to True. **This is only used for RigidEntity.**
     decimate_face_num : int, optional
         The number of faces to decimate to. Defaults to 500. **This is only used for RigidEntity.**
+    decimate_aggressiveness : int
+        How hard the decimation process will try to match the target number of faces, as a integer ranging from 0 to 8.
+        0 is losseless. 2 preserves all features of the original geometry. 5 may significantly alters the original
+        geometry if necessary. 8 does what needs to be done at all costs. Defaults to 2.
+        **This is only used for RigidEntity.**
     convexify : bool, optional
         Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
         to a set of convex hulls. The mesh with be decomposed into multiple convex components if a single one is not

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -223,7 +223,7 @@ def convex_decompose(mesh, coacd_options):
 
 
 def postprocess_collision_geoms(
-    g_infos, decimate, decimate_face_num, convexify, decompose_error_threshold, coacd_options
+    g_infos, decimate, decimate_face_num, decimate_aggressiveness, convexify, decompose_error_threshold, coacd_options
 ):
     # Early return if there is no geometry to process
     if not g_infos:
@@ -344,6 +344,7 @@ def postprocess_collision_geoms(
             convexify=convexify,
             decimate=decimate,
             decimate_face_num=decimate_face_num,
+            decimate_aggressiveness=decimate_aggressiveness,
             surface=gs.surfaces.Collision(),
             metadata=mesh.metadata.copy(),
         )


### PR DESCRIPTION
## Description

This PR exposes 'decimate_aggressiveness' parameter and use it to enable decimation systematically. By default, aggressiveness is set to lossless if convexify is disabled, 2 otherwise.

## Related Issue

Related to Genesis-Embodied-AI/Genesis/issues/1015

## Motivation and Context

Enable decimation systematically would improve simulation speed and probably improve numerical stability and physical stability. If convexify is disabled, then decimation should be set to lossless mode instead of being completely disabled by default.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
