### PR TITLE
[FEATURE] Add a function to convert terrain mesh to height field

### DIFF
--- a/examples/rigid/terrain_from_mesh.py
+++ b/examples/rigid/terrain_from_mesh.py
@@ -24,7 +24,7 @@ def main():
 
     horizontal_scale = 2.0
     path_terrain = "./genesis/assets/meshes/terrain_45.obj"
-    hf_terrain, xs, ys = mesh_to_heightfield(path_terrain, spacing=horizontal_scale, oversample=3)
+    hf_terrain, xs, ys = mesh_to_heightfield(path_terrain, spacing=horizontal_scale, oversample=1)
     print("hf_terrain", hf_terrain.shape, np.max(hf_terrain))
 
     # default heightfield starts at 0, 0, 0

--- a/examples/rigid/terrain_from_mesh.py
+++ b/examples/rigid/terrain_from_mesh.py
@@ -1,7 +1,8 @@
-import genesis as gs
-import numpy as np
 import argparse
 import os
+
+import genesis as gs
+import numpy as np
 from genesis.utils.terrain import mesh_to_heightfield
 
 
@@ -16,11 +17,11 @@ def main():
 
     ########################## create a scene ##########################
     scene = gs.Scene(
-        show_viewer=args.vis,
         viewer_options=gs.options.ViewerOptions(
             camera_pos=(0, -50, 0),
             camera_lookat=(0, 0, 0),
         ),
+        show_viewer=args.vis,
     )
 
     horizontal_scale = 2.0
@@ -41,14 +42,6 @@ def main():
             pos=translation,
         ),
         vis_mode="collision",
-    )
-
-    terrain_ori = scene.add_entity(
-        morph=gs.morphs.Mesh(
-            file=path_terrain,
-            fixed=True,
-            convexify=False,
-        ),
     )
 
     ball = scene.add_entity(

--- a/examples/rigid/terrain_from_mesh.py
+++ b/examples/rigid/terrain_from_mesh.py
@@ -16,10 +16,7 @@ def main():
 
     ########################## create a scene ##########################
     scene = gs.Scene(
-        show_viewer=True,
-        sim_options=gs.options.SimOptions(
-            gravity=(2, 0, -2),
-        ),
+        show_viewer=args.vis,
         viewer_options=gs.options.ViewerOptions(
             camera_pos=(0, -50, 0),
             camera_lookat=(0, 0, 0),
@@ -29,9 +26,8 @@ def main():
     horizontal_scale = 2.0
     gs_root = os.path.dirname(os.path.abspath(gs.__file__))
     path_terrain = os.path.join(gs_root, "assets", "meshes", "terrain_45.obj")
-    print("path_terrain", path_terrain)
     hf_terrain, xs, ys = mesh_to_heightfield(path_terrain, spacing=horizontal_scale, oversample=1)
-    print("hf_terrain", hf_terrain.shape, np.max(hf_terrain))
+    print("hf_terrain", path_terrain, hf_terrain.shape, np.max(hf_terrain))
 
     # default heightfield starts at 0, 0, 0
     # translate to the center of the mesh
@@ -65,15 +61,8 @@ def main():
 
     scene.build()
 
-    from IPython import embed
-
-    embed()
     for i in range(2000):
         scene.step()
-
-        qvel = scene.sim.rigid_solver.dofs_state.vel.to_numpy()[:, 0]
-        qvel_norm = np.linalg.norm(qvel, axis=-1)
-        print("qvel_norm", i, qvel_norm)
 
 
 if __name__ == "__main__":

--- a/examples/rigid/terrain_from_mesh.py
+++ b/examples/rigid/terrain_from_mesh.py
@@ -1,6 +1,7 @@
 import genesis as gs
 import numpy as np
 import argparse
+import os
 from genesis.utils.terrain import mesh_to_heightfield
 
 
@@ -16,6 +17,9 @@ def main():
     ########################## create a scene ##########################
     scene = gs.Scene(
         show_viewer=True,
+        sim_options=gs.options.SimOptions(
+            gravity=(2, 0, -2),
+        ),
         viewer_options=gs.options.ViewerOptions(
             camera_pos=(0, -50, 0),
             camera_lookat=(0, 0, 0),
@@ -23,7 +27,9 @@ def main():
     )
 
     horizontal_scale = 2.0
-    path_terrain = "./genesis/assets/meshes/terrain_45.obj"
+    gs_root = os.path.dirname(os.path.abspath(gs.__file__))
+    path_terrain = os.path.join(gs_root, "assets", "meshes", "terrain_45.obj")
+    print("path_terrain", path_terrain)
     hf_terrain, xs, ys = mesh_to_heightfield(path_terrain, spacing=horizontal_scale, oversample=1)
     print("hf_terrain", hf_terrain.shape, np.max(hf_terrain))
 
@@ -51,16 +57,23 @@ def main():
 
     ball = scene.add_entity(
         gs.morphs.Sphere(
-            pos=(10, 15, 18),
-            radius=2,
+            pos=(10, 15, 10),
+            radius=1,
         ),
         vis_mode="collision",
     )
 
     scene.build()
 
+    from IPython import embed
+
+    embed()
     for i in range(2000):
         scene.step()
+
+        qvel = scene.sim.rigid_solver.dofs_state.vel.to_numpy()[:, 0]
+        qvel_norm = np.linalg.norm(qvel, axis=-1)
+        print("qvel_norm", i, qvel_norm)
 
 
 if __name__ == "__main__":

--- a/examples/rigid/terrain_from_mesh.py
+++ b/examples/rigid/terrain_from_mesh.py
@@ -1,0 +1,67 @@
+import genesis as gs
+import numpy as np
+import argparse
+from genesis.utils.terrain import mesh_to_heightfield
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--vis", action="store_true", default=False)
+    parser.add_argument("-c", "--cpu", action="store_true", default=False)
+    args = parser.parse_args()
+
+    ########################## init ##########################
+    gs.init(backend=gs.cpu if args.cpu else gs.gpu)
+
+    ########################## create a scene ##########################
+    scene = gs.Scene(
+        show_viewer=True,
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(0, -50, 0),
+            camera_lookat=(0, 0, 0),
+        ),
+    )
+
+    horizontal_scale = 2.0
+    path_terrain = "./genesis/assets/meshes/terrain_45.obj"
+    hf_terrain, xs, ys = mesh_to_heightfield(path_terrain, spacing=horizontal_scale, oversample=3)
+    print("hf_terrain", hf_terrain.shape, np.max(hf_terrain))
+
+    # default heightfield starts at 0, 0, 0
+    # translate to the center of the mesh
+    translation = np.array([np.nanmin(xs), np.nanmin(ys), 0])
+
+    terrain_heightfield = scene.add_entity(
+        morph=gs.morphs.Terrain(
+            horizontal_scale=horizontal_scale,
+            vertical_scale=1.0,
+            height_field=hf_terrain,
+            pos=translation,
+        ),
+        vis_mode="collision",
+    )
+
+    terrain_ori = scene.add_entity(
+        morph=gs.morphs.Mesh(
+            file=path_terrain,
+            fixed=True,
+            convexify=False,
+        ),
+    )
+
+    ball = scene.add_entity(
+        gs.morphs.Sphere(
+            pos=(10, 15, 18),
+            radius=2,
+        ),
+        vis_mode="collision",
+    )
+
+    scene.build()
+
+    for i in range(2000):
+        scene.step()
+
+
+if __name__ == "__main__":
+    main()

--- a/genesis/assets/meshes/terrain_45.obj
+++ b/genesis/assets/meshes/terrain_45.obj
@@ -1,0 +1,10 @@
+# Simple 45° slope quad
+# Vertices
+v 5.0 10.0 0.0
+v 15.0 10.0 10.0
+v 5.0 20.0 0.0
+v 15.0 20.0 10.0
+
+# Faces (two triangles)
+f 1 2 4
+f 1 4 3

--- a/genesis/utils/terrain.py
+++ b/genesis/utils/terrain.py
@@ -386,9 +386,11 @@ def mesh_to_heightfield(
 
     Notes
     -----
-    • Requires `pyembree` or `rtree` for fast ray‑tracing.
     • Memory cost grows as  oversample².
     """
+    if np.isscalar(spacing):
+        spacing = (spacing, spacing)
+
     mesh = trimesh.load(path, force="mesh")
 
     # -------------------------------- axis handling ---------------------------
@@ -400,7 +402,7 @@ def mesh_to_heightfield(
     (minx, miny, _), (maxx, maxy, maxz) = mesh.bounds
 
     # -------------------------------- coarse grid ----------------------------
-    dx, dy = (spacing, spacing) if isinstance(spacing, (int, float)) else spacing
+    dx, dy = spacing
     nx = math.ceil((maxx - minx) / dx) + 1
     ny = math.ceil((maxy - miny) / dy) + 1
 
@@ -414,7 +416,7 @@ def mesh_to_heightfield(
     fy_lin = np.linspace(miny, maxy, fy, dtype=np.float32)
     fxx, fyy = np.meshgrid(fx_lin, fy_lin, indexing="ij")
 
-    origins = np.c_[fxx.ravel(), fyy.ravel(), np.full(fxx.size, maxz + 1.0)]
+    origins = np.stack((fxx.ravel(), fyy.ravel(), np.full(fxx.size, maxz + 1.0)), axis=-1)
     directions = np.tile([0.0, 0.0, -1.0], (origins.shape[0], 1))
 
     # -------------------------------- ray cast -------------------------------

--- a/genesis/utils/terrain.py
+++ b/genesis/utils/terrain.py
@@ -357,7 +357,7 @@ def convert_heightfield_to_watertight_trimesh(height_field_raw, horizontal_scale
 def mesh_to_heightfield(
     path: str,
     spacing: float | tuple[float, float],
-    oversample: int = 3,
+    oversample: int = 1,
     *,
     up_axis: str = "z",
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:

--- a/genesis/utils/terrain.py
+++ b/genesis/utils/terrain.py
@@ -1,7 +1,8 @@
 import os
 import math
-import numpy as np
 import pickle
+
+import numpy as np
 import trimesh
 
 import genesis as gs
@@ -386,8 +387,7 @@ def mesh_to_heightfield(
     Notes
     -----
     • Requires `pyembree` or `rtree` for fast ray‑tracing.
-    • Memory cost grows as  oversample².  For very large terrains keep
-      `oversample` ≤ 4 unless you have ample RAM.
+    • Memory cost grows as  oversample².
     """
     mesh = trimesh.load(path, force="mesh")
 

--- a/genesis/utils/terrain.py
+++ b/genesis/utils/terrain.py
@@ -431,6 +431,7 @@ def mesh_to_heightfield(
     h_coarse = np.nanmax(h_fine.reshape(nx, oversample, ny, oversample).swapaxes(1, 2), axis=(2, 3))
 
     # change nan to min
-    h_coarse = np.where(np.isnan(h_coarse), np.nanmin(h_coarse), h_coarse)
+    minz = mesh.bounds[0][2]
+    h_coarse = np.where(np.isnan(h_coarse), minz, h_coarse)
 
     return h_coarse, xs, ys

--- a/genesis/utils/terrain.py
+++ b/genesis/utils/terrain.py
@@ -1,5 +1,5 @@
 import os
-
+import math
 import numpy as np
 import pickle
 import trimesh
@@ -352,3 +352,83 @@ def convert_heightfield_to_watertight_trimesh(height_field_raw, horizontal_scale
     )
 
     return mesh, sdf_mesh
+
+
+def mesh_to_heightfield(
+    path: str,
+    spacing: float | tuple[float, float],
+    oversample: int = 3,
+    *,
+    up_axis: str = "z",
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Parameters
+    ----------
+    path : str
+        .glb / .obj / … file containing the terrain mesh.
+    spacing : float  |  (float, float)
+        Desired grid spacing  Δx  (and  Δy).  Units must match the mesh.
+    oversample : int, default 3
+        Number of extra rays per coarse‑grid axis.  k = 1 reproduces the
+        simple single‑ray method; k ≥ 2 captures peaks inside a cell.
+    up_axis : {"z", "y"}, default "z"
+        Mesh’s up direction.  If "y" (common in glTF), the function
+        rotates the mesh so Z is up before sampling.
+
+    Returns
+    -------
+    heights : (nx, ny)  float32 ndarray
+        Highest elevation per coarse cell (NaN if no hit).
+    xs      : (nx,)     float32 ndarray
+    ys      : (ny,)     float32 ndarray
+        Coordinates of grid lines (cell centres).
+
+    Notes
+    -----
+    • Requires `pyembree` or `rtree` for fast ray‑tracing.
+    • Memory cost grows as  oversample².  For very large terrains keep
+      `oversample` ≤ 4 unless you have ample RAM.
+    """
+    mesh = trimesh.load(path, force="mesh")
+
+    # -------------------------------- axis handling ---------------------------
+    if up_axis.lower() == "y":
+        # rotate so Z becomes up (‑90° around X)
+        T = trimesh.transformations.rotation_matrix(np.deg2rad(-90), [1, 0, 0])
+        mesh.apply_transform(T)
+
+    (minx, miny, _), (maxx, maxy, maxz) = mesh.bounds
+
+    # -------------------------------- coarse grid ----------------------------
+    dx, dy = (spacing, spacing) if isinstance(spacing, (int, float)) else spacing
+    nx = math.ceil((maxx - minx) / dx) + 1
+    ny = math.ceil((maxy - miny) / dy) + 1
+
+    xs = np.linspace(minx, maxx, nx, dtype=np.float32)
+    ys = np.linspace(miny, maxy, ny, dtype=np.float32)
+
+    # -------------------------------- fine grid ------------------------------
+    fx = nx * oversample
+    fy = ny * oversample
+    fx_lin = np.linspace(minx, maxx, fx, dtype=np.float32)
+    fy_lin = np.linspace(miny, maxy, fy, dtype=np.float32)
+    fxx, fyy = np.meshgrid(fx_lin, fy_lin, indexing="ij")
+
+    origins = np.c_[fxx.ravel(), fyy.ravel(), np.full(fxx.size, maxz + 1.0)]
+    directions = np.tile([0.0, 0.0, -1.0], (origins.shape[0], 1))
+
+    # -------------------------------- ray cast -------------------------------
+    locs, hit_ids, _ = mesh.ray.intersects_location(ray_origins=origins, ray_directions=directions, multiple_hits=False)
+
+    h_fine = np.full(fxx.size, np.nan, dtype=np.float32)
+    h_fine[hit_ids] = locs[:, 2]
+    h_fine = h_fine.reshape((fx, fy))  # (fx, fy) = (nx*k, ny*k)
+
+    # -------------------------------- down‑sample ----------------------------
+    # reshape to (nx, k, ny, k) then take max over the 2 fine axes
+    h_coarse = np.nanmax(h_fine.reshape(nx, oversample, ny, oversample).swapaxes(1, 2), axis=(2, 3))
+
+    # change nan to min
+    h_coarse = np.where(np.isnan(h_coarse), np.nanmin(h_coarse), h_coarse)
+
+    return h_coarse, xs, ys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ dependencies = [
     "scikit-image",
     # Convex decomposition library
     "coacd",
+    # Ray casting used in mesh to height field conversion
+    "rtree",
     # Used for loading raytracing special texture images used by LuisaRender
     "OpenEXR",
     # Motion Planning library

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -1,8 +1,8 @@
 import sys
 import xml.etree.ElementTree as ET
 import os
-import pytest
 
+import pytest
 import trimesh
 import torch
 import numpy as np
@@ -1152,5 +1152,4 @@ def test_mesh_to_heightfield(show_viewer):
 
     # speed is around 0
     qvel = ball.get_dofs_velocity().cpu()
-    qvel_norm = np.linalg.norm(qvel, axis=-1)
-    np.testing.assert_allclose(qvel_norm, 0, atol=1e-2)
+    np.testing.assert_allclose(qvel, 0, atol=1e-2)

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -922,7 +922,7 @@ def test_data_accessor(n_envs, atol):
             gs_robot.set_dofs_position(qpos)
 
     # Simulate for a while, until they collide with something
-    for _ in range(40.100):
+    for _ in range(400):
         gs_sim.step()
         gs_n_contacts = gs_sim.rigid_solver.collider.n_contacts.to_torch(device="cpu")
         if (gs_n_contacts > 0).all():

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -1,10 +1,10 @@
 import sys
 import xml.etree.ElementTree as ET
-
+import os
 import pytest
+
 import trimesh
 import torch
-import os
 import numpy as np
 from huggingface_hub import snapshot_download
 
@@ -1105,7 +1105,6 @@ def test_equality_weld(gs_sim, mj_sim):
 
 @pytest.mark.parametrize("backend", [gs.cpu])
 def test_mesh_to_heightfield(show_viewer):
-    from genesis.utils.terrain import mesh_to_heightfield
 
     ########################## create a scene ##########################
     scene = gs.Scene(
@@ -1122,7 +1121,7 @@ def test_mesh_to_heightfield(show_viewer):
     horizontal_scale = 2.0
     gs_root = os.path.dirname(os.path.abspath(gs.__file__))
     path_terrain = os.path.join(gs_root, "assets", "meshes", "terrain_45.obj")
-    hf_terrain, xs, ys = mesh_to_heightfield(path_terrain, spacing=horizontal_scale, oversample=1)
+    hf_terrain, xs, ys = gs.utils.terrain.mesh_to_heightfield(path_terrain, spacing=horizontal_scale, oversample=1)
 
     # default heightfield starts at 0, 0, 0
     # translate to the center of the mesh
@@ -1152,6 +1151,6 @@ def test_mesh_to_heightfield(show_viewer):
         scene.step()
 
     # speed is around 0
-    qvel = scene.sim.rigid_solver.dofs_state.vel.to_numpy()[:, 0]
+    qvel = ball.get_dofs_velocity().cpu()
     qvel_norm = np.linalg.norm(qvel, axis=-1)
     np.testing.assert_allclose(qvel_norm, 0, atol=1e-2)


### PR DESCRIPTION
## Description

Sometimes user might want to import a non-convex terrain represented by a mesh. The best practice is to convert that mesh to a height field for more accurate collision detection. 
A function based on ray-casting is added for this purpose.
Try 
```bash
python examples/rigid/terrain_from_mesh.py -v
```

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/790 
Resolves Genesis-Embodied-AI/Genesis/issues/491 

Related to Genesis-Embodied-AI/Genesis/issues/690 
Related to Genesis-Embodied-AI/Genesis/issues/625 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?

<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
