### PR TITLE
[FEATURE] DroneEnv compatible with rsl-rl-lib==2.2.4

### DIFF
--- a/examples/drone/README.md
+++ b/examples/drone/README.md
@@ -44,7 +44,7 @@ At this stage, we have defined the environments. Now, we use the PPO implementat
 
 ```bash
 pip install --upgrade pip
-pip install "tensorboard" "git+https://github.com/leggedrobotics/rsl_rl.git@v1.0.2"
+pip install "tensorboard" "git+https://github.com/leggedrobotics/rsl_rl.git@v2.2.4"
 ```
 
 #### 3.1 Training
@@ -54,13 +54,13 @@ Train the drone hovering policy using the `HoverEnv` environment.
 Run with:
 
 ```bash
-python hover_train.py -e drone-hovering -B 8192 --max_iterations 300
+python hover_train.py -e drone-hovering -B 8192 --max_iterations 301
 ```
 
 Train with visualization:
 
 ```bash
-python hover_train.py -e drone-hovering -B 8192 --max_iterations 300 -v
+python hover_train.py -e drone-hovering -B 8192 --max_iterations 301 -v
 ```
 
 #### 3.2 Evaluation

--- a/examples/drone/hover_env.py
+++ b/examples/drone/hover_env.py
@@ -16,6 +16,7 @@ class HoverEnv:
         self.num_privileged_obs = None
         self.num_actions = env_cfg["num_actions"]
         self.num_commands = command_cfg["num_commands"]
+        self.device = gs.device
 
         self.simulate_action_latency = env_cfg["simulate_action_latency"]
         self.dt = 0.01  # run in 100hz
@@ -112,6 +113,7 @@ class HoverEnv:
         self.last_base_pos = torch.zeros_like(self.base_pos)
 
         self.extras = dict()  # extra information for logging
+        self.extras["observations"] = dict()
 
     def _resample_commands(self, envs_idx):
         self.commands[envs_idx, 0] = gs_rand_float(*self.command_cfg["pos_x_range"], (len(envs_idx),), gs.device)
@@ -192,11 +194,13 @@ class HoverEnv:
         )
 
         self.last_actions[:] = self.actions[:]
+        self.extras["observations"]["critic"] = self.obs_buf
 
-        return self.obs_buf, None, self.rew_buf, self.reset_buf, self.extras
+        return self.obs_buf, self.rew_buf, self.reset_buf, self.extras
 
     def get_observations(self):
-        return self.obs_buf
+        self.extras["observations"]["critic"] = self.obs_buf
+        return self.obs_buf, self.extras
 
     def get_privileged_observations(self):
         return None

--- a/examples/drone/hover_eval.py
+++ b/examples/drone/hover_eval.py
@@ -7,13 +7,13 @@ import torch
 
 try:
     try:
-        if metadata.version("rsl-rl-lib"):
+        if metadata.version("rsl-rl"):
             raise ImportError
     except metadata.PackageNotFoundError:
-        if metadata.version("rsl-rl") != "1.0.2":
+        if metadata.version("rsl-rl-lib") != "2.2.4":
             raise ImportError
 except (metadata.PackageNotFoundError, ImportError) as e:
-    raise ImportError("Please uninstall 'rsl-rl-lib' and install 'rsl_rl==1.0.2'.") from e
+    raise ImportError("Please uninstall 'rsl_rl' and install 'rsl-rl-lib==2.2.4'.") from e
 from rsl_rl.runners import OnPolicyRunner
 
 import genesis as gs
@@ -63,13 +63,13 @@ def main():
             env.cam.start_recording()
             for _ in range(max_sim_step):
                 actions = policy(obs)
-                obs, _, rews, dones, infos = env.step(actions)
+                obs, rews, dones, infos = env.step(actions)
                 env.cam.render()
             env.cam.stop_recording(save_to_filename="video.mp4", fps=env_cfg["max_visualize_FPS"])
         else:
             for _ in range(max_sim_step):
                 actions = policy(obs)
-                obs, _, rews, dones, infos = env.step(actions)
+                obs, rews, dones, infos = env.step(actions)
 
 
 if __name__ == "__main__":

--- a/examples/drone/hover_train.py
+++ b/examples/drone/hover_train.py
@@ -6,13 +6,13 @@ from importlib import metadata
 
 try:
     try:
-        if metadata.version("rsl-rl-lib"):
+        if metadata.version("rsl-rl"):
             raise ImportError
     except metadata.PackageNotFoundError:
-        if metadata.version("rsl-rl") != "1.0.2":
+        if metadata.version("rsl-rl-lib") != "2.2.4":
             raise ImportError
 except (metadata.PackageNotFoundError, ImportError) as e:
-    raise ImportError("Please uninstall 'rsl-rl-lib' and install 'rsl_rl==1.0.2'.") from e
+    raise ImportError("Please uninstall 'rsl_rl' and install 'rsl-rl-lib==2.2.4'.") from e
 from rsl_rl.runners import OnPolicyRunner
 
 import genesis as gs
@@ -23,6 +23,7 @@ from hover_env import HoverEnv
 def get_train_cfg(exp_name, max_iterations):
     train_cfg_dict = {
         "algorithm": {
+            "class_name": "PPO",
             "clip_param": 0.2,
             "desired_kl": 0.01,
             "entropy_coef": 0.004,
@@ -42,24 +43,23 @@ def get_train_cfg(exp_name, max_iterations):
             "actor_hidden_dims": [128, 128],
             "critic_hidden_dims": [128, 128],
             "init_noise_std": 1.0,
+            "class_name": "ActorCritic",
         },
         "runner": {
-            "algorithm_class_name": "PPO",
             "checkpoint": -1,
             "experiment_name": exp_name,
             "load_run": -1,
             "log_interval": 1,
             "max_iterations": max_iterations,
-            "num_steps_per_env": 100,
-            "policy_class_name": "ActorCritic",
             "record_interval": -1,
             "resume": False,
             "resume_path": None,
             "run_name": "",
-            "runner_class_name": "runner_class_name",
-            "save_interval": 100,
         },
         "runner_class_name": "OnPolicyRunner",
+        "num_steps_per_env": 100,
+        "save_interval": 100,
+        "empirical_normalization": None,
         "seed": 1,
     }
 
@@ -122,7 +122,7 @@ def main():
     parser.add_argument("-e", "--exp_name", type=str, default="drone-hovering")
     parser.add_argument("-v", "--vis", action="store_true", default=False)
     parser.add_argument("-B", "--num_envs", type=int, default=8192)
-    parser.add_argument("--max_iterations", type=int, default=300)
+    parser.add_argument("--max_iterations", type=int, default=301)
     args = parser.parse_args()
 
     gs.init(logging_level="warning")
@@ -138,6 +138,11 @@ def main():
     if args.vis:
         env_cfg["visualize_target"] = True
 
+    pickle.dump(
+        [env_cfg, obs_cfg, reward_cfg, command_cfg, train_cfg],
+        open(f"{log_dir}/cfgs.pkl", "wb"),
+    )
+
     env = HoverEnv(
         num_envs=args.num_envs,
         env_cfg=env_cfg,
@@ -148,11 +153,6 @@ def main():
     )
 
     runner = OnPolicyRunner(env, train_cfg, log_dir, device=gs.device)
-
-    pickle.dump(
-        [env_cfg, obs_cfg, reward_cfg, command_cfg, train_cfg],
-        open(f"{log_dir}/cfgs.pkl", "wb"),
-    )
 
     runner.learn(num_learning_iterations=args.max_iterations, init_at_random_ep_len=True)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->
Same as issue #895, This PR updates drone examples to be compatible with the latest `rsl-rl-lib==2.2.4`.

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#1035

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
### Key Changes
- **Update version requirements** in [hover_eval.py](https://github.com/Genesis-Embodied-AI/Genesis/blob/main/examples/drone/hover_eval.py) and [hover_train.py](https://github.com/Genesis-Embodied-AI/Genesis/blob/main/examples/drone/hover_train.py) as described in #997 
- **Add** `self.extras` **in** `get_observations()` function in [hover_env.py](https://github.com/Genesis-Embodied-AI/Genesis/blob/main/examples/drone/hover_env.py) to support the latest API
- **Add compatibility parameters**
   - `empirical_normalization`
   - `num_steps_per_env`
- **Update default value** of `--max_iterations` to `101` in [hover_train.py](https://github.com/Genesis-Embodied-AI/Genesis/blob/main/examples/drone/hover_train.py) since training iterations begin at `0`.

### Improvements
- **Optimize critic observation handling** by setting it with `self.obs_buf` in `get_observations()` and `step()` functions. The latest `rsl-rl` library retrieves critic observations from extras in the `learn()` function.
- **Improve configuration management** by saving the config pickle (`cfgs.pkl`) file before `OnPolicyRunner()` initialization, as `train_cfg["policy"]["class_name"]` gets removed during initialization.

### Motivation

<!--  Motivation for adding / enhancing this feature, optimally describing a concrete use case in the form of a user story -->
Updates drone examples to be compatible with the latest `rsl-rl-lib==2.2.4`.

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
The command in [README.md](https://github.com/Genesis-Embodied-AI/Genesis/blob/main/examples/drone/README.md)

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
