### PR TITLE
[MISC] Fix naming convention inconsistencies.

### DIFF
--- a/examples/locomotion/go2_backflip.py
+++ b/examples/locomotion/go2_backflip.py
@@ -26,7 +26,7 @@ def get_cfgs():
             "RL_calf_joint": -1.5,
             "RR_calf_joint": -1.5,
         },
-        "dof_names": [
+        "joint_names": [
             "FR_hip_joint",
             "FR_thigh_joint",
             "FR_calf_joint",

--- a/examples/locomotion/go2_train.py
+++ b/examples/locomotion/go2_train.py
@@ -84,7 +84,7 @@ def get_cfgs():
             "RL_calf_joint": -1.5,
             "RR_calf_joint": -1.5,
         },
-        "dof_names": [
+        "joint_names": [
             "FR_hip_joint",
             "FR_thigh_joint",
             "FR_calf_joint",

--- a/examples/rigid/accelerometer_duck.py
+++ b/examples/rigid/accelerometer_duck.py
@@ -45,7 +45,7 @@ def main():
     )
     ########################## build ##########################
     scene.build()
-    dofs_idx = duck.base_joint.dof_idx
+    dofs_idx = duck.base_joint.dofs_idx
 
     duck.set_dofs_kv(
         np.array([1, 1, 1, 1, 1, 1]) * 50.0,

--- a/examples/rigid/accelerometer_franka.py
+++ b/examples/rigid/accelerometer_franka.py
@@ -39,7 +39,7 @@ def main():
     ########################## build ##########################
     scene.build()
 
-    jnt_names = [
+    joints_name = (
         "joint1",
         "joint2",
         "joint3",
@@ -49,22 +49,22 @@ def main():
         "joint7",
         "finger_joint1",
         "finger_joint2",
-    ]
-    dofs_idx = [franka.get_joint(name).dof_idx_local for name in jnt_names]
+    )
+    motors_dof_idx = tuple(i for name in joints_name for i in franka.get_joint(name).motors_dof_idx_local)
 
     # Optional: set control gains
     # franka.set_dofs_kp(
     #     np.array([4500, 4500, 3500, 3500, 2000, 2000, 2000, 100, 100]),
-    #     dofs_idx,
+    #     motors_dof_idx,
     # )
     # franka.set_dofs_kv(
     #     np.array([450, 450, 350, 350, 200, 200, 200, 10, 10]),
-    #     dofs_idx,
+    #     motors_dof_idx,
     # )
     # franka.set_dofs_force_range(
     #     np.array([-87, -87, -87, -87, -12, -12, -12, -100, -100]),
     #     np.array([87, 87, 87, 87, 12, 12, 12, 100, 100]),
-    #     dofs_idx,
+    #     motors_dof_idx,
     # )
 
     last_link_vel = None
@@ -73,36 +73,36 @@ def main():
         # if i == 0:
         #     franka.control_dofs_position(
         #         np.array([1, 1, 0, 0, 0, 0, 0, 0.04, 0.04]),
-        #         dofs_idx,
+        #         motors_dof_idx,
         #     )
         # elif i == 250:
         #     franka.control_dofs_position(
         #         np.array([-1, 0.8, 1, -2, 1, 0.5, -0.5, 0.04, 0.04]),
-        #         dofs_idx,
+        #         motors_dof_idx,
         #     )
         # elif i == 500:
         #     franka.control_dofs_position(
         #         np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        #         dofs_idx,
+        #         motors_dof_idx,
         #     )
         # elif i == 750:
         #     # control first dof with velocity, and the rest with position
         #     franka.control_dofs_position(
         #         np.array([0, 0, 0, 0, 0, 0, 0, 0, 0])[1:],
-        #         dofs_idx[1:],
+        #         motors_dof_idx[1:],
         #     )
         #     franka.control_dofs_velocity(
         #         np.array([1.0, 0, 0, 0, 0, 0, 0, 0, 0])[:1],
-        #         dofs_idx[:1],
+        #         motors_dof_idx[:1],
         #     )
         # elif i == 1000:
         #     franka.control_dofs_force(
         #         np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        #         dofs_idx,
+        #         motors_dof_idx,
         #     )
         # This is the internal control force computed based on the given control command
         # If using force control, it's the same as the given control command
-        # print("control force:", franka.get_dofs_control_force(dofs_idx))
+        # print("control force:", franka.get_dofs_control_force(motors_dof_idx))
 
         scene.step()
 

--- a/examples/rigid/control_franka.py
+++ b/examples/rigid/control_franka.py
@@ -39,7 +39,7 @@ def main():
     ########################## build ##########################
     scene.build()
 
-    jnt_names = [
+    joints_name = (
         "joint1",
         "joint2",
         "joint3",
@@ -49,31 +49,31 @@ def main():
         "joint7",
         "finger_joint1",
         "finger_joint2",
-    ]
-    dofs_idx = [franka.get_joint(name).dof_idx_local for name in jnt_names]
+    )
+    motors_dof_idx = [franka.get_joint(name).dof_start for name in joints_name]
 
     # Optional: set control gains
     franka.set_dofs_kp(
         np.array([4500, 4500, 3500, 3500, 2000, 2000, 2000, 100, 100]),
-        dofs_idx,
+        motors_dof_idx,
     )
     franka.set_dofs_kv(
         np.array([450, 450, 350, 350, 200, 200, 200, 10, 10]),
-        dofs_idx,
+        motors_dof_idx,
     )
     franka.set_dofs_force_range(
         np.array([-87, -87, -87, -87, -12, -12, -12, -100, -100]),
         np.array([87, 87, 87, 87, 12, 12, 12, 100, 100]),
-        dofs_idx,
+        motors_dof_idx,
     )
     # Hard reset
     for i in range(150):
         if i < 50:
-            franka.set_dofs_position(np.array([1, 1, 0, 0, 0, 0, 0, 0.04, 0.04]), dofs_idx)
+            franka.set_dofs_position(np.array([1, 1, 0, 0, 0, 0, 0, 0.04, 0.04]), motors_dof_idx)
         elif i < 100:
-            franka.set_dofs_position(np.array([-1, 0.8, 1, -2, 1, 0.5, -0.5, 0.04, 0.04]), dofs_idx)
+            franka.set_dofs_position(np.array([-1, 0.8, 1, -2, 1, 0.5, -0.5, 0.04, 0.04]), motors_dof_idx)
         else:
-            franka.set_dofs_position(np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]), dofs_idx)
+            franka.set_dofs_position(np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]), motors_dof_idx)
 
         scene.step()
 
@@ -82,36 +82,36 @@ def main():
         if i == 0:
             franka.control_dofs_position(
                 np.array([1, 1, 0, 0, 0, 0, 0, 0.04, 0.04]),
-                dofs_idx,
+                motors_dof_idx,
             )
         elif i == 250:
             franka.control_dofs_position(
                 np.array([-1, 0.8, 1, -2, 1, 0.5, -0.5, 0.04, 0.04]),
-                dofs_idx,
+                motors_dof_idx,
             )
         elif i == 500:
             franka.control_dofs_position(
                 np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]),
-                dofs_idx,
+                motors_dof_idx,
             )
         elif i == 750:
             # control first dof with velocity, and the rest with position
             franka.control_dofs_position(
                 np.array([0, 0, 0, 0, 0, 0, 0, 0, 0])[1:],
-                dofs_idx[1:],
+                motors_dof_idx[1:],
             )
             franka.control_dofs_velocity(
                 np.array([1.0, 0, 0, 0, 0, 0, 0, 0, 0])[:1],
-                dofs_idx[:1],
+                motors_dof_idx[:1],
             )
         elif i == 1000:
             franka.control_dofs_force(
                 np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]),
-                dofs_idx,
+                motors_dof_idx,
             )
         # This is the internal control force computed based on the given control command
         # If using force control, it's the same as the given control command
-        print("control force:", franka.get_dofs_control_force(dofs_idx))
+        print("control force:", franka.get_dofs_control_force(motors_dof_idx))
 
         scene.step()
 

--- a/examples/rigid/control_mesh.py
+++ b/examples/rigid/control_mesh.py
@@ -43,7 +43,7 @@ def main():
     ########################## build ##########################
     scene.build()
 
-    dofs_idx = duck.base_joint.dof_idx
+    dofs_idx = duck.base_joint.dofs_idx
 
     duck.set_dofs_kv(
         np.array([1, 1, 1, 1, 1, 1]) * 50.0,

--- a/examples/rigid/domain_randomization.py
+++ b/examples/rigid/domain_randomization.py
@@ -70,7 +70,7 @@ def main():
         ls_idx_local=np.arange(0, robot.n_links),
     )
 
-    joint_names = [
+    joints_name = (
         "FR_hip_joint",
         "FR_thigh_joint",
         "FR_calf_joint",
@@ -83,11 +83,11 @@ def main():
         "RL_hip_joint",
         "RL_thigh_joint",
         "RL_calf_joint",
-    ]
-    motor_dofs = [robot.get_joint(name).dof_idx_local for name in joint_names]
+    )
+    motors_dof_idx = [robot.get_joint(name).dof_start for name in joints_name]
 
-    robot.set_dofs_kp(np.full(12, 20), motor_dofs)
-    robot.set_dofs_kv(np.full(12, 1), motor_dofs)
+    robot.set_dofs_kp(np.full(12, 20), motors_dof_idx)
+    robot.set_dofs_kv(np.full(12, 1), motors_dof_idx)
     default_dof_pos = np.array(
         [
             0.0,
@@ -104,7 +104,7 @@ def main():
             -1.5,
         ]
     )
-    robot.control_dofs_position(default_dof_pos, motor_dofs)
+    robot.control_dofs_position(default_dof_pos, motors_dof_idx)
 
     for i in range(1000):
         scene.step()

--- a/examples/rigid/ik_custom_chain.py
+++ b/examples/rigid/ik_custom_chain.py
@@ -53,25 +53,20 @@ def main():
     index_finger_distal = robot.get_link("index_finger_distal")
 
     dofs_idx_local = []
-    for v in robot.joints:
-        if v.name in [
+    for joint in robot.joints:
+        if joint.name in (
             "wrist_joint",
             "index_finger_joint1",
-            "index_finger_join2",
+            "index_finger_joint2",
             "index_finger_joint3",
-        ]:
-            dof_idx_local_v = v.dof_idx_local
-            if isinstance(dof_idx_local_v, list):
-                dofs_idx_local.extend(dof_idx_local_v)
-            else:
-                assert isinstance(dof_idx_local_v, int)
-                dofs_idx_local.append(dof_idx_local_v)
+        ):
+            dofs_idx_local += joint.dofs_idx_local
 
     center = np.array([0.033, -0.01, 0.42])
     r1 = 0.05
 
     for i in range(2000):
-        index_finger_pos = center + np.array([0, np.cos(i / 90 * np.pi) - 1.0, np.sin(i / 90 * np.pi) - 1.0]) * r1
+        index_finger_pos = center + np.array([0.0, np.cos(i / 90 * np.pi) - 1.0, np.sin(i / 90 * np.pi) - 1.0]) * r1
 
         target_1.set_qpos(np.concatenate([index_finger_pos, target_quat]))
 

--- a/examples/rigid/merge_entities.py
+++ b/examples/rigid/merge_entities.py
@@ -71,7 +71,7 @@ def main():
     ########################## build ##########################
     scene.build()
 
-    arm_jnt_names = [
+    arm_joints_name = (
         "joint1",
         "joint2",
         "joint3",
@@ -79,8 +79,8 @@ def main():
         "joint5",
         "joint6",
         "joint7",
-    ]
-    arm_dofs_idx = [franka.get_joint(name).dof_idx_local for name in arm_jnt_names]
+    )
+    arm_dofs_idx = [franka.get_joint(name).dof_start for name in arm_joints_name]
 
     # Optional: set control gains
     franka.set_dofs_kp(
@@ -97,11 +97,11 @@ def main():
         arm_dofs_idx,
     )
 
-    gripper_jnt_names = [
+    gripper_joints_name = (
         "finger_joint1",
         "finger_joint2",
-    ]
-    gripper_dofs_idx = [hand.get_joint(name).dof_idx_local for name in gripper_jnt_names]
+    )
+    gripper_dofs_idx = [franka.get_joint(name).dof_start for name in gripper_joints_name]
 
     # Optional: set control gains
     hand.set_dofs_kp(

--- a/examples/rigid/set_phys_attr.py
+++ b/examples/rigid/set_phys_attr.py
@@ -46,7 +46,7 @@ def main():
     ########################## build ##########################
     scene.build(n_envs=2)  # test with 2 different environments
 
-    jnt_names = [
+    joints_name = (
         "joint1",
         "joint2",
         "joint3",
@@ -56,10 +56,10 @@ def main():
         "joint7",
         "finger_joint1",
         "finger_joint2",
-    ]
-    dofs_idx = [franka.get_joint(name).dof_idx_local for name in jnt_names]
+    )
+    motors_dof_idx = [franka.get_joint(name).dof_start for name in joints_name]
 
-    lnk_names = [
+    links_name = (
         "link0",
         "link1",
         "link2",
@@ -71,8 +71,8 @@ def main():
         "hand",
         "left_finger",
         "right_finger",
-    ]
-    links_idx = [franka.get_link(name).idx_local for name in lnk_names]
+    )
+    links_idx = [franka.get_link(name).idx_local for name in links_name]
 
     # Optional: set control gains
     franka.set_dofs_kp(
@@ -82,7 +82,7 @@ def main():
                 [100, 100, 2000, 2000, 2000, 3500, 3500, 4500, 4500],
             ]
         ),
-        dofs_idx,
+        motors_dof_idx,
     )
     print("=== kp ===\n", franka.get_dofs_kp())
     franka.set_dofs_kv(
@@ -92,7 +92,7 @@ def main():
                 [10, 10, 200, 200, 200, 350, 350, 450, 450],
             ]
         ),
-        dofs_idx,
+        motors_dof_idx,
     )
     print("=== kv ===\n", franka.get_dofs_kv())
     franka.set_dofs_force_range(
@@ -108,27 +108,27 @@ def main():
                 [100, 100, 12, 12, 12, 87, 87, 87, 87],
             ]
         ),
-        dofs_idx,
+        motors_dof_idx,
     )
     print("=== force range ===\n", franka.get_dofs_force_range())
     franka.set_dofs_armature(
         np.array(
             [
-                [0.1] * len(dofs_idx),
-                [0.2] * len(dofs_idx),
+                [0.1] * len(motors_dof_idx),
+                [0.2] * len(motors_dof_idx),
             ]
         ),
-        dofs_idx,
+        motors_dof_idx,
     )
     print("=== armature ===\n", franka.get_dofs_armature())
     franka.set_dofs_stiffness(
         np.array(
             [
-                [0.0] * len(dofs_idx),
-                [0.1] * len(dofs_idx),
+                [0.0] * len(motors_dof_idx),
+                [0.1] * len(motors_dof_idx),
             ]
         ),
-        dofs_idx,
+        motors_dof_idx,
     )
     print("=== stiffness ===\n", franka.get_dofs_stiffness())
     franka.set_dofs_invweight(
@@ -138,17 +138,17 @@ def main():
                 [8.6984, 8.6984, 9.4213, 6.6139, 7.8085, 3.9007, 6.8053, 0.9693, 5.5882],
             ]
         ),
-        dofs_idx,
+        motors_dof_idx,
     )
     print("=== invweight ===\n", franka.get_dofs_invweight())
     franka.set_dofs_damping(
         np.array(
             [
-                [1.0] * len(dofs_idx),
-                [2.0] * len(dofs_idx),
+                [1.0] * len(motors_dof_idx),
+                [2.0] * len(motors_dof_idx),
             ]
         ),
-        dofs_idx,
+        motors_dof_idx,
     )
     print("=== damping ===\n", franka.get_dofs_damping())
     franka.set_links_inertial_mass(
@@ -176,14 +176,16 @@ def main():
     for i in range(150):
         if i < 50:
             franka.set_dofs_position(
-                np.array([1, 1, 0, 0, 0, 0, 0, 0.04, 0.04])[None, :].repeat(scene.n_envs, 0), dofs_idx
+                np.array([1, 1, 0, 0, 0, 0, 0, 0.04, 0.04])[None, :].repeat(scene.n_envs, 0), motors_dof_idx
             )
         elif i < 100:
             franka.set_dofs_position(
-                np.array([-1, 0.8, 1, -2, 1, 0.5, -0.5, 0.04, 0.04])[None, :].repeat(scene.n_envs, 0), dofs_idx
+                np.array([-1, 0.8, 1, -2, 1, 0.5, -0.5, 0.04, 0.04])[None, :].repeat(scene.n_envs, 0), motors_dof_idx
             )
         else:
-            franka.set_dofs_position(np.array([0, 0, 0, 0, 0, 0, 0, 0, 0])[None, :].repeat(scene.n_envs, 0), dofs_idx)
+            franka.set_dofs_position(
+                np.array([0, 0, 0, 0, 0, 0, 0, 0, 0])[None, :].repeat(scene.n_envs, 0), motors_dof_idx
+            )
 
         scene.step()
 
@@ -192,36 +194,36 @@ def main():
         if i == 0:
             franka.control_dofs_position(
                 np.array([1, 1, 0, 0, 0, 0, 0, 0.04, 0.04])[None, :].repeat(scene.n_envs, 0),
-                dofs_idx,
+                motors_dof_idx,
             )
         elif i == 250:
             franka.control_dofs_position(
                 np.array([-1, 0.8, 1, -2, 1, 0.5, -0.5, 0.04, 0.04])[None, :].repeat(scene.n_envs, 0),
-                dofs_idx,
+                motors_dof_idx,
             )
         elif i == 500:
             franka.control_dofs_position(
                 np.array([0, 0, 0, 0, 0, 0, 0, 0, 0])[None, :].repeat(scene.n_envs, 0),
-                dofs_idx,
+                motors_dof_idx,
             )
         elif i == 750:
             # control first dof with velocity, and the rest with position
             franka.control_dofs_position(
                 np.array([0, 0, 0, 0, 0, 0, 0, 0, 0])[1:][None, :].repeat(scene.n_envs, 0),
-                dofs_idx[1:],
+                motors_dof_idx[1:],
             )
             franka.control_dofs_velocity(
                 np.array([1.0, 0, 0, 0, 0, 0, 0, 0, 0])[:1][None, :].repeat(scene.n_envs, 0),
-                dofs_idx[:1],
+                motors_dof_idx[:1],
             )
         elif i == 1000:
             franka.control_dofs_force(
                 np.array([0, 0, 0, 0, 0, 0, 0, 0, 0])[None, :].repeat(scene.n_envs, 0),
-                dofs_idx,
+                motors_dof_idx,
             )
         # This is the internal control force computed based on the given control command
         # If using force control, it's the same as the given control command
-        print("control force:", franka.get_dofs_control_force(dofs_idx))
+        print("control force:", franka.get_dofs_control_force(motors_dof_idx))
 
         scene.step()
 

--- a/examples/speed_benchmark/anymal_c.py
+++ b/examples/speed_benchmark/anymal_c.py
@@ -29,7 +29,7 @@ robot = scene.add_entity(
 n_envs = 30000
 scene.build(n_envs=n_envs)
 
-joint_names = [
+joints_name = (
     "RH_HAA",
     "LH_HAA",
     "RF_HAA",
@@ -42,11 +42,11 @@ joint_names = [
     "LH_KFE",
     "RF_KFE",
     "LF_KFE",
-]
-motor_dofs = [robot.get_joint(name).dof_idx_local for name in joint_names]
+)
+motors_dof_idx = [robot.get_joint(name).dof_start for name in joints_name]
 
-robot.set_dofs_kp(np.full(12, 1000), motor_dofs)
-robot.control_dofs_position(np.zeros((n_envs, 12)), motor_dofs)
+robot.set_dofs_kp(np.full(12, 1000), motors_dof_idx)
+robot.control_dofs_position(np.zeros((n_envs, 12)), motors_dof_idx)
 
 # Speed: 14.4M FPS
 for i in range(1000):

--- a/examples/tutorials/control_your_robot.py
+++ b/examples/tutorials/control_your_robot.py
@@ -31,7 +31,7 @@ franka = scene.add_entity(
 ########################## build ##########################
 scene.build()
 
-jnt_names = [
+joints_name = (
     "joint1",
     "joint2",
     "joint3",
@@ -41,34 +41,34 @@ jnt_names = [
     "joint7",
     "finger_joint1",
     "finger_joint2",
-]
-dofs_idx = [franka.get_joint(name).dof_idx_local for name in jnt_names]
+)
+motors_dof_idx = [franka.get_joint(name).dof_start for name in joints_name]
 
 ############ Optional: set control gains ############
 # set positional gains
 franka.set_dofs_kp(
     kp=np.array([4500, 4500, 3500, 3500, 2000, 2000, 2000, 100, 100]),
-    dofs_idx_local=dofs_idx,
+    dofs_idx_local=motors_dof_idx,
 )
 # set velocity gains
 franka.set_dofs_kv(
     kv=np.array([450, 450, 350, 350, 200, 200, 200, 10, 10]),
-    dofs_idx_local=dofs_idx,
+    dofs_idx_local=motors_dof_idx,
 )
 # set force range for safety
 franka.set_dofs_force_range(
     lower=np.array([-87, -87, -87, -87, -12, -12, -12, -100, -100]),
     upper=np.array([87, 87, 87, 87, 12, 12, 12, 100, 100]),
-    dofs_idx_local=dofs_idx,
+    dofs_idx_local=motors_dof_idx,
 )
 # Hard reset
 for i in range(150):
     if i < 50:
-        franka.set_dofs_position(np.array([1, 1, 0, 0, 0, 0, 0, 0.04, 0.04]), dofs_idx)
+        franka.set_dofs_position(np.array([1, 1, 0, 0, 0, 0, 0, 0.04, 0.04]), motors_dof_idx)
     elif i < 100:
-        franka.set_dofs_position(np.array([-1, 0.8, 1, -2, 1, 0.5, -0.5, 0.04, 0.04]), dofs_idx)
+        franka.set_dofs_position(np.array([-1, 0.8, 1, -2, 1, 0.5, -0.5, 0.04, 0.04]), motors_dof_idx)
     else:
-        franka.set_dofs_position(np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]), dofs_idx)
+        franka.set_dofs_position(np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]), motors_dof_idx)
 
     scene.step()
 
@@ -77,38 +77,38 @@ for i in range(1250):
     if i == 0:
         franka.control_dofs_position(
             np.array([1, 1, 0, 0, 0, 0, 0, 0.04, 0.04]),
-            dofs_idx,
+            motors_dof_idx,
         )
     elif i == 250:
         franka.control_dofs_position(
             np.array([-1, 0.8, 1, -2, 1, 0.5, -0.5, 0.04, 0.04]),
-            dofs_idx,
+            motors_dof_idx,
         )
     elif i == 500:
         franka.control_dofs_position(
             np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]),
-            dofs_idx,
+            motors_dof_idx,
         )
     elif i == 750:
         # control first dof with velocity, and the rest with position
         franka.control_dofs_position(
             np.array([0, 0, 0, 0, 0, 0, 0, 0, 0])[1:],
-            dofs_idx[1:],
+            motors_dof_idx[1:],
         )
         franka.control_dofs_velocity(
             np.array([1.0, 0, 0, 0, 0, 0, 0, 0, 0])[:1],
-            dofs_idx[:1],
+            motors_dof_idx[:1],
         )
     elif i == 1000:
         franka.control_dofs_force(
             np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]),
-            dofs_idx,
+            motors_dof_idx,
         )
     # This is the control force computed based on the given control command
     # If using force control, it's the same as the given control command
-    print("control force:", franka.get_dofs_control_force(dofs_idx))
+    print("control force:", franka.get_dofs_control_force(motors_dof_idx))
 
     # This is the actual force experienced by the dof
-    print("internal force:", franka.get_dofs_force(dofs_idx))
+    print("internal force:", franka.get_dofs_force(motors_dof_idx))
 
     scene.step()

--- a/genesis/_main.py
+++ b/genesis/_main.py
@@ -2,6 +2,8 @@ import argparse
 import multiprocessing
 import os
 import threading
+from functools import partial
+
 import tkinter as tk
 from tkinter import ttk
 
@@ -13,27 +15,28 @@ from taichi.lang import impl
 import genesis as gs
 
 
+FPS = 60
+
+
 class JointControlGUI:
-    def __init__(self, master, motor_names, dof_pos_limits, gui_joint_positions):
+    def __init__(self, master, motors_name, motors_position_limit, motors_position):
         self.master = master
         self.master.title("Joint Controller")  # Set the window title
-        self.motor_names = motor_names
-        self.dof_pos_limits = dof_pos_limits
-        self.gui_joint_positions = gui_joint_positions
-        self.default_joint_positions = np.clip(np.zeros(len(motor_names)), dof_pos_limits[:, 0], dof_pos_limits[:, 1])
+        self.motors_name = motors_name
+        self.motors_position_limit = motors_position_limit
+        self.motors_position = motors_position
+        self.motors_default_position = np.clip(
+            np.zeros(len(motors_name)), motors_position_limit[:, 0], motors_position_limit[:, 1]
+        )
         self.sliders = []
-        self.value_labels = []
+        self.values_label = []
         self.create_widgets()
-        self.reset_joint_position()
+        self.reset_motors_position()
 
     def create_widgets(self):
-        for i, name in enumerate(self.motor_names):
-            self.update_joint_position(i, self.default_joint_positions[i])
-            min_limit, max_limit = self.dof_pos_limits[i]
-            if min_limit == torch.tensor(-np.inf):
-                min_limit = -np.pi
-            if max_limit == torch.tensor(np.inf):
-                max_limit = np.pi
+        for i_m, name in enumerate(self.motors_name):
+            self.update_joint_position(i_m, self.motors_default_position[i_m])
+            min_limit, max_limit = map(float, self.motors_position_limit[i_m])
             frame = tk.Frame(self.master)
             frame.pack(pady=5, padx=10, fill=tk.X)
 
@@ -41,18 +44,18 @@ class JointControlGUI:
 
             slider = ttk.Scale(
                 frame,
-                from_=float(min_limit),
-                to=float(max_limit),
+                from_=min_limit,
+                to=max_limit,
                 orient=tk.HORIZONTAL,
                 length=300,
-                command=lambda val, idx=i: self.update_joint_position(idx, val),
+                command=partial(self.update_joint_position, i_m),
             )
             slider.pack(side=tk.LEFT, padx=5)
             self.sliders.append(slider)
 
             value_label = tk.Label(frame, text=f"{slider.get():.2f}", font=("Arial", 12))
             value_label.pack(side=tk.LEFT, padx=5)
-            self.value_labels.append(value_label)
+            self.values_label.append(value_label)
 
             # Update label dynamically
             def update_label(s=slider, l=value_label):
@@ -63,29 +66,35 @@ class JointControlGUI:
 
             slider.bind("<Motion>", update_label())
 
-        tk.Button(self.master, text="Reset", font=("Arial", 12), command=self.reset_joint_position).pack(pady=20)
+        tk.Button(self.master, text="Reset", font=("Arial", 12), command=self.reset_motors_position).pack(pady=20)
 
     def update_joint_position(self, idx, val):
-        self.gui_joint_positions[idx] = float(val)
+        self.motors_position[idx] = float(val)
 
-    def reset_joint_position(self):
-        for i, slider in enumerate(self.sliders):
-            slider.set(self.default_joint_positions[i])
-            self.value_labels[i].config(text=f"{self.default_joint_positions[i]:.2f}")
-            self.gui_joint_positions[i] = self.default_joint_positions[i]
+    def reset_motors_position(self):
+        for i_m, slider in enumerate(self.sliders):
+            slider.set(self.motors_default_position[i_m])
+            self.values_label[i_m].config(text=f"{self.motors_default_position[i_m]:.2f}")
+            self.motors_position[i_m] = self.motors_default_position[i_m]
 
 
-def get_movable_dofs(robot):
-    motor_dofs = []
-    motor_dof_names = []
+def get_motors_info(robot):
+    motors_dof_idx = []
+    motors_dof_name = []
     for joint in robot.joints:
         if joint.type == gs.JOINT_TYPE.FREE:
             continue
         elif joint.type == gs.JOINT_TYPE.FIXED:
             continue
-        motor_dofs.append(robot.get_joint(joint.name).dof_idx_local)
-        motor_dof_names.append(joint.name)
-    return motor_dofs, motor_dof_names
+        dofs_idx_local = robot.get_joint(joint.name).dofs_idx_local
+        if dofs_idx_local:
+            if len(dofs_idx_local) == 1:
+                dofs_name = [joint.name]
+            else:
+                dofs_name = [f"{joint.name}_{i_d}" for i_d in range(dofs_idx_local)]
+            motors_dof_idx += dofs_idx_local
+            motors_dof_name += dofs_name
+    return motors_dof_idx, motors_dof_name
 
 
 def clean():
@@ -94,7 +103,7 @@ def clean():
     print("Cleaned up all genesis and taichi cache files.")
 
 
-def _start_gui_mac(motor_names, dof_pos_limits, gui_joint_positions, stop_event):
+def _start_gui(motors_name, motors_position_limit, motors_position, stop_event):
     def on_close():
         nonlocal after_id
         if after_id is not None:
@@ -105,7 +114,7 @@ def _start_gui_mac(motor_names, dof_pos_limits, gui_joint_positions, stop_event)
         root.quit()
 
     root = tk.Tk()
-    app = JointControlGUI(root, motor_names, dof_pos_limits, gui_joint_positions)
+    app = JointControlGUI(root, motors_name, motors_position_limit, motors_position)
     root.protocol("WM_DELETE_WINDOW", on_close)
 
     def check_event():
@@ -121,9 +130,11 @@ def _start_gui_mac(motor_names, dof_pos_limits, gui_joint_positions, stop_event)
 
 def view(filename, collision, rotate, scale=1.0, show_link_frame=False):
     gs.init(backend=gs.cpu)
-    FPS = 60
-    dt = 1 / FPS
+
     scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            gravity=(0.0, 0.0, 0.0),
+        ),
         viewer_options=gs.options.ViewerOptions(
             camera_pos=(3.5, 0.0, 2.5),
             camera_lookat=(0.0, 0.0, 0.5),
@@ -133,48 +144,50 @@ def view(filename, collision, rotate, scale=1.0, show_link_frame=False):
         vis_options=gs.options.VisOptions(
             show_link_frame=show_link_frame,
         ),
-        sim_options=gs.options.SimOptions(
-            gravity=(0, 0, 0),
-        ),
     )
 
     if filename.endswith(".urdf"):
-        morph = gs.morphs.URDF(file=filename, collision=collision, scale=scale)
+        morph_cls = gs.morphs.URDF
     elif filename.endswith(".xml"):
-        morph = gs.morphs.MJCF(file=filename, collision=collision, scale=scale)
+        morph_cls = gs.morphs.MJCF
     else:
-        morph = gs.morphs.Mesh(file=filename, collision=collision, scale=scale)
-
+        morph_cls = gs.morphs.Mesh
     entity = scene.add_entity(
-        morph,
+        morph_cls(file=filename, collision=collision, scale=scale),
         surface=gs.surfaces.Default(
             vis_mode="visual" if not collision else "collision",
         ),
     )
     scene.build(compile_kernels=False)
 
-    motor_dofs, motor_names = get_movable_dofs(entity)
-    dof_pos_limits = torch.stack(entity.get_dofs_limit(motor_dofs), dim=1).numpy()
+    # Get motor info
+    motors_dof_idx, motors_name = get_motors_info(entity)
 
-    manager = multiprocessing.Manager()
-    gui_joint_positions = manager.list([0.0] * len(motor_dofs))
-    stop_event = multiprocessing.Event()
+    # Get motor position limits.
+    # Makes sure that all joints are bounded, included revolute joints.
+    motors_position_limit = torch.stack(entity.get_dofs_limit(motors_dof_idx), dim=1).numpy()
+    motors_position_limit[motors_position_limit == -np.inf] = -np.pi
+    motors_position_limit[motors_position_limit == +np.inf] = +np.pi
+
     # Start the GUI process
+    manager = multiprocessing.Manager()
+    motors_position = manager.list([0.0 for _ in motors_dof_idx])
+    stop_event = multiprocessing.Event()
     gui_process = multiprocessing.Process(
-        target=_start_gui_mac, args=(motor_names, dof_pos_limits, gui_joint_positions, stop_event), daemon=True
+        target=_start_gui, args=(motors_name, motors_position_limit, motors_position, stop_event), daemon=True
     )
     gui_process.start()
 
     t = 0
     while scene.viewer.is_alive() and not stop_event.is_set():
-        # rotate entity
-        t += dt
+        # Rotate entity if requested
         if rotate:
+            t += 1 / FPS
             entity.set_quat(gs.utils.geom.xyz_to_quat(np.array([0, 0, t * 50]), rpy=True, degrees=True))
 
         entity.set_dofs_position(
-            position=torch.tensor(gui_joint_positions),
-            dofs_idx_local=motor_dofs,
+            position=torch.tensor(motors_position),
+            dofs_idx_local=motors_dof_idx,
             zero_velocity=True,
         )
         scene.visualizer.update(force=True)

--- a/genesis/assets/urdf/shadow_hand/shadow_hand.urdf
+++ b/genesis/assets/urdf/shadow_hand/shadow_hand.urdf
@@ -210,7 +210,7 @@
         <limit effort="4.0" lower="-0.349065850399" upper="0.349065850399" velocity="2.0"/>
     </joint>
 
-    <joint name="index_finger_join2" type="revolute">
+    <joint name="index_finger_joint2" type="revolute">
         <parent link="index_finger_knuckle"/>
         <child link="index_finger_proximal"/>
         <axis xyz="1 0 0"/>

--- a/genesis/engine/entities/drone_entity.py
+++ b/genesis/engine/entities/drone_entity.py
@@ -20,16 +20,16 @@ class DroneEntity(RigidEntity):
         self._KF = float(properties["kf"])
         self._KM = float(properties["km"])
 
-        self._n_propellers = len(morph.propellers_link_names)
+        self._n_propellers = len(morph.propellers_link_name)
         self._COM_link_idx = self.get_link(morph.COM_link_name).idx
 
-        propellers_links = gs.List([self.get_link(name) for name in morph.propellers_link_names])
+        propellers_link = gs.List([self.get_link(name) for name in morph.propellers_link_name])
         self._propellers_link_idxs = torch.tensor(
-            [link.idx for link in propellers_links], dtype=gs.tc_int, device=gs.device
+            [link.idx for link in propellers_link], dtype=gs.tc_int, device=gs.device
         )
         try:
             self._propellers_vgeom_idxs = torch.tensor(
-                [link.vgeoms[0].idx for link in propellers_links], dtype=gs.tc_int, device=gs.device
+                [link.vgeoms[0].idx for link in propellers_link], dtype=gs.tc_int, device=gs.device
             )
             self._animate_propellers = True
         except Exception:

--- a/genesis/engine/entities/rigid_entity/rigid_joint.py
+++ b/genesis/engine/entities/rigid_entity/rigid_joint.py
@@ -274,50 +274,97 @@ class RigidJoint(RBC):
     @property
     def dof_idx(self):
         """
-        Returns all the dof indices of the joint in the rigid solver.
+        Returns all the Degrees' of Freedom (DoF) indices of the joint in the rigid solver.
+
+        This property either returns a list, an integer, or None depending on whether the joint has multiple DoFs, a
+        single one, or none, respectively.
         """
+        gs.logger.warning(
+            "This property is deprecated and will be removed in future release. Please use 'dofs_idx' instead."
+        )
         if self.n_dofs == 1:
             return self.dof_start
-        elif self.n_dofs == 0:
+        if self.n_dofs == 0:
             return None
-        else:
-            return list(range(self.dof_start, self.dof_end))
+        return self.dofs_idx
+
+    @property
+    def dofs_idx(self):
+        """
+        Returns all the Degrees' of Freedom (DoF) indices of the joint in the rigid solver as a sequence.
+        """
+        return list(range(self.dof_start, self.dof_end))
 
     @property
     def dof_idx_local(self):
         """
         Returns the local dof index of the joint in the entity.
+
+        This property either returns a list, an integer, or None depending on whether the joint has multiple DoFs, a
+        single one, or none, respectively.
         """
+        gs.logger.warning(
+            "This property is deprecated and will be removed in future release. Please use 'dof_idx_local' instead."
+        )
         if self.n_dofs == 1:
-            return self.dof_idx - self._entity._dof_start
-        elif self.n_dofs == 0:
+            return self.dofs_idx[0] - self._entity._dof_start
+        if self.n_dofs == 0:
             return None
-        else:
-            return [dof_idx - self._entity._dof_start for dof_idx in self.dof_idx]
+        return self.dofs_idx_local
+
+    @property
+    def dofs_idx_local(self):
+        """
+        Returns the local Degrees of Freedom indices of the joint in the entity.
+        """
+        return [dof_idx - self._entity._dof_start for dof_idx in self.dofs_idx]
 
     @property
     def q_idx(self):
         """
-        Returns all the `q` indices of the joint in the rigid solver.
+        Returns all the position indices of the joint in the rigid solver.
+
+        This property either returns a list, an integer, or None depending on whether the joint has multiple position
+        indices, a single one, or none, respectively.
         """
+        gs.logger.warning(
+            "This property is deprecated and will be removed in future release. Please use 'qs_idx' instead."
+        )
         if self.n_qs == 1:
             return self.q_start
         elif self.n_qs == 0:
             return None
         else:
-            return list(range(self.q_start, self.q_end))
+            return self.qs_idx
+
+    @property
+    def qs_idx(self):
+        """
+        Returns all the position indices of the joint in the rigid solver.
+        """
+        return list(range(self.q_start, self.q_end))
 
     @property
     def q_idx_local(self):
         """
         Returns all the local `q` indices of the joint in the entity.
         """
+        gs.logger.warning(
+            "This property is deprecated and will be removed in future release. Please use 'qs_idx_local' instead."
+        )
         if self.n_qs == 1:
             return self.q_start - self._entity._q_start
         elif self.n_qs == 0:
             return None
         else:
-            return [q_idx - self._entity._q_start for q_idx in self.q_idx]
+            return self.qs_idx_local
+
+    @property
+    def qs_idx_local(self):
+        """
+        Returns all the local `q` indices of the joint in the entity.
+        """
+        return [q_idx - self._entity._q_start for q_idx in self.qs_idx]
 
     @property
     def dofs_motion_ang(self):

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -81,7 +81,10 @@ class RigidSolver(Solver):
 
         if options.contact_resolve_time is not None:
             self._sol_contact_resolve_time = options.contact_resolve_time
-            gs.logger.warning("contact_resolve_time is deprecated. Please use constraint_resolve_time instead.")
+            gs.logger.warning(
+                "Rigid option 'contact_resolve_time' is deprecated and will be remove in future release. Please use "
+                "'constraint_resolve_time' instead."
+            )
 
         self._options = options
 
@@ -601,9 +604,9 @@ class RigidSolver(Solver):
             init_qpos = self._batch_array(self.init_qpos.astype(gs.np_float))
             for joint in joints:
                 if joint.type in (gs.JOINT_TYPE.REVOLUTE, gs.JOINT_TYPE.PRISMATIC):
-                    is_init_qpos_out_of_bounds |= (joint.dofs_limit[0, 0] > init_qpos[joint.q_idx]).any()
-                    is_init_qpos_out_of_bounds |= (init_qpos[joint.q_idx] > joint.dofs_limit[0, 1]).any()
-                    # init_qpos[joint.q_idx] = np.clip(init_qpos[joint.q_idx], *joint.dofs_limit[0])
+                    is_init_qpos_out_of_bounds |= (joint.dofs_limit[0, 0] > init_qpos[joint.q_start]).any()
+                    is_init_qpos_out_of_bounds |= (init_qpos[joint.q_start] > joint.dofs_limit[0, 1]).any()
+                    # init_qpos[joint.q_start] = np.clip(init_qpos[joint.q_start], *joint.dofs_limit[0])
             self.qpos.from_numpy(init_qpos)
         if is_init_qpos_out_of_bounds:
             gs.logger.warning(

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Sequence, Union
 
 import numpy as np
 
@@ -358,8 +358,8 @@ class FileMorph(Morph):
                 self.decompose_object_error_threshold = float("inf")
                 self.decompose_robot_error_threshold = float("inf")
             gs.logger.warning(
-                "`decompose_nonconvex` is deprecated. Please use 'convexify' and "
-                "'decompose_(robot|object)_error_threshold' instead."
+                "FileMorph option 'decompose_nonconvex' is deprecated and will be removed in future release. Please use "
+                "'convexify' and 'decompose_(robot|object)_error_threshold' instead."
             )
 
         # Make sure that this threshold is positive to avoid decomposition of convex and primitive shapes
@@ -708,9 +708,11 @@ class Drone(FileMorph):
         The model of the drone. Defaults to 'CF2X'. Supported models are 'CF2X', 'CF2P', and 'RACE'.
     COM_link_name : str, optional
         The name of the link that represents the center of mass. Defaults to 'center_of_mass_link'.
-    propellers_link_names : list of str, optional
+    propellers_link_names : sequence of str, optional
+        This option is deprecated and will be removed in the future. Please use 'propellers_link_name' instead.
+    propellers_link_name : sequence of str, optional
         The names of the links that represent the propellers. Defaults to ['prop0_link', 'prop1_link', 'prop2_link', 'prop3_link'].
-    propellers_spin : list of int, optional
+    propellers_spin : sequence of int, optional
         The spin direction of the propellers. 1: CCW, -1: CW. Defaults to [-1, 1, -1, 1].
     """
 
@@ -718,11 +720,20 @@ class Drone(FileMorph):
     fixed: bool = False
     prioritize_urdf_material: bool = False
     COM_link_name: str = "center_of_mass_link"
-    propellers_link_names: List[str] = ["prop0_link", "prop1_link", "prop2_link", "prop3_link"]
-    propellers_spin: List[int] = [-1, 1, -1, 1]  # 1: CCW, -1: CW
+    propellers_link_names: Optional[Sequence[str]] = None
+    propellers_link_name: Sequence[str] = ("prop0_link", "prop1_link", "prop2_link", "prop3_link")
+    propellers_spin: Sequence[int] = (-1, 1, -1, 1)  # 1: CCW, -1: CW
 
     def __init__(self, **data):
         super().__init__(**data)
+
+        if self.propellers_link_names is not None:
+            gs.logger.warning(
+                "Drone option 'propellers_link_names' is deprecated and will be remove in future release. Please use "
+                "'propellers_link_name' instead."
+            )
+            self.propellers_link_name = self.propellers_link_names
+
         if isinstance(self.file, str) and not self.file.endswith(".urdf"):
             gs.raise_exception(f"Drone only supports `.urdf` extension: {self.file}")
 

--- a/genesis/options/solvers.py
+++ b/genesis/options/solvers.py
@@ -165,7 +165,7 @@ class RigidOptions(Options):
     sparse_solve : bool, optional
         Whether to exploit sparsity in the constraint system. Defaults to False.
     contact_resolve_time : float, optional
-        Please note that this argument will be deprecated in a future version. Use constraint_resolve_time instead.
+        Please note that this option will be deprecated in a future version. Use 'constraint_resolve_time' instead.
     constraint_resolve_time : float, optional
         Time to resolve a constraint. The smaller the value, the more stiff the constraint. Defaults to 0.02. (called timeconst in https://mujoco.readthedocs.io/en/latest/modeling.html#solver-parameters)
     use_contact_island : bool, optional

--- a/genesis/options/vis.py
+++ b/genesis/options/vis.py
@@ -132,6 +132,9 @@ class VisOptions(Options):
             )
 
         if not self.n_rendered_envs is None:
-            gs.logger.warning("n_rendered_envs is deprecated. Please use rendered_envs_idx instead.")
+            gs.logger.warning(
+                "Viewer option 'n_rendered_envs' is deprecated and will be removed in future release. Please use "
+                "'rendered_envs_idx' instead."
+            )
             assert self.rendered_envs_idx is None
             self.rendered_envs_idx = list(range(self.n_rendered_envs))

--- a/tests/test_rigid_benchmarks.py
+++ b/tests/test_rigid_benchmarks.py
@@ -49,7 +49,7 @@ def anymal_c(solver, n_envs, show_viewer):
     scene.build(n_envs=n_envs)
 
     ######################## simulate #########################
-    joint_names = [
+    joints_name = (
         "RH_HAA",
         "LH_HAA",
         "RF_HAA",
@@ -62,14 +62,14 @@ def anymal_c(solver, n_envs, show_viewer):
         "LH_KFE",
         "RF_KFE",
         "LF_KFE",
-    ]
-    motor_dofs = [robot.get_joint(name).dof_idx_local for name in joint_names]
+    )
+    motors_dof_idx = [robot.get_joint(name).dof_start for name in joints_name]
 
-    robot.set_dofs_kp(np.full(12, 1000), motor_dofs)
+    robot.set_dofs_kp(np.full(12, 1000), motors_dof_idx)
     if n_envs > 0:
-        robot.control_dofs_position(np.zeros((n_envs, 12)), motor_dofs)
+        robot.control_dofs_position(np.zeros((n_envs, 12)), motors_dof_idx)
     else:
-        robot.control_dofs_position(np.zeros(12), motor_dofs)
+        robot.control_dofs_position(np.zeros(12), motors_dof_idx)
 
     vec_fps = []
     for i in range(1000):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,9 @@
-from typing import Literal
 from dataclasses import dataclass
+from itertools import chain
+from typing import Literal, Sequence
 
 import numpy as np
+
 import mujoco
 import genesis as gs
 import genesis.utils.geom as gu
@@ -15,7 +17,7 @@ class MjSim:
 
 def init_simulators(gs_sim, mj_sim=None, qpos=None, qvel=None):
     if mj_sim is not None:
-        _, (_, _, mj_q_idcs, mj_dof_idcs, _) = _get_model_mappings(gs_sim, mj_sim)
+        _, (_, _, mj_qs_idx, mj_dofs_idx, _) = _get_model_mappings(gs_sim, mj_sim)
 
     (gs_robot,) = gs_sim.entities
 
@@ -33,182 +35,171 @@ def init_simulators(gs_sim, mj_sim=None, qpos=None, qvel=None):
 
     if mj_sim is not None:
         mujoco.mj_resetData(mj_sim.model, mj_sim.data)
-        mj_sim.data.qpos[mj_q_idcs] = gs_sim.rigid_solver.qpos.to_numpy()[:, 0]
-        mj_sim.data.qvel[mj_dof_idcs] = gs_sim.rigid_solver.dofs_state.vel.to_numpy()[:, 0]
+        mj_sim.data.qpos[mj_qs_idx] = gs_sim.rigid_solver.qpos.to_numpy()[:, 0]
+        mj_sim.data.qvel[mj_dofs_idx] = gs_sim.rigid_solver.dofs_state.vel.to_numpy()[:, 0]
         mujoco.mj_forward(mj_sim.model, mj_sim.data)
 
 
-def _gs_search_by_joint_names(
+def _gs_search_by_joints_name(
     scene,
-    joint_names: str | list[str],
+    joints_name: str | list[str],
     to: Literal["entity", "index"] = "index",
     is_local: bool = False,
     flatten: bool = True,
 ):
-    if isinstance(joint_names, str):
-        joint_names = [joint_names]
+    if isinstance(joints_name, str):
+        joints_name = [joints_name]
 
     for entity in scene.entities:
         try:
-            gs_jnt_idcs = dict()
-            gs_q_idcs = dict()
-            gs_dof_idcs = dict()
-            valid_joint_names = []
+            gs_joints_idx = dict()
+            gs_joints_qs_idx = dict()
+            gs_joints_dofs_idx = dict()
+            valid_joints_name = []
             for joint in entity.joints:
-                valid_joint_names.append(joint.name)
-                if joint.name in joint_names:
+                valid_joints_name.append(joint.name)
+                if joint.name in joints_name:
                     if to == "entity":
-                        gs_jnt_idcs[joint.name] = joint
-                        gs_q_idcs[joint.name] = joint
-                        gs_dof_idcs[joint.name] = joint
+                        gs_joints_idx[joint.name] = joint
+                        gs_joints_qs_idx[joint.name] = joint
+                        gs_joints_dofs_idx[joint.name] = joint
                     elif to == "index":
-                        gs_jnt_idcs[joint.name] = joint.idx_local if is_local else joint.idx
-                        gs_q_idcs[joint.name] = joint.q_idx_local if is_local else joint.q_idx
-                        gs_dof_idcs[joint.name] = joint.d_idx_local if is_local else joint.dof_idx
+                        gs_joints_idx[joint.name] = joint.idx_local if is_local else joint.idx
+                        gs_joints_qs_idx[joint.name] = joint.qs_idx_local if is_local else joint.qs_idx
+                        gs_joints_dofs_idx[joint.name] = joint.dofs_idx_local if is_local else joint.dofs_idx
                     else:
                         raise ValueError(f"Cannot recognize what ({to}) to extract for the search")
 
-            missing_joint_names = set(joint_names) - gs_jnt_idcs.keys()
-            if len(missing_joint_names) > 0:
+            missing_joints_name = set(joints_name) - gs_joints_idx.keys()
+            if len(missing_joints_name) > 0:
                 raise ValueError(
-                    f"Cannot find joints `{missing_joint_names}`. Valid joints names are {valid_joint_names}"
+                    f"Cannot find joints `{missing_joints_name}`. Valid joints names are {valid_joints_name}"
                 )
 
             if flatten:
-                gs_q_idcs_flat = []
-                gs_dof_idcs_flat = []
-                for k in joint_names:
-                    if isinstance(gs_q_idcs[k], list):
-                        gs_q_idcs_flat.extend(gs_q_idcs[k])
-                        gs_dof_idcs_flat.extend(gs_dof_idcs[k])
-                    else:
-                        gs_q_idcs_flat.append(gs_q_idcs[k])
-                        gs_dof_idcs_flat.append(gs_dof_idcs[k])
-                return (list(gs_jnt_idcs.values()), gs_q_idcs_flat, gs_dof_idcs_flat)
-
-            return (gs_jnt_idcs, gs_q_idcs, gs_dof_idcs)
+                return (
+                    list(gs_joints_idx.values()),
+                    list(chain.from_iterable(gs_joints_qs_idx.values())),
+                    list(chain.from_iterable(gs_joints_dofs_idx.values())),
+                )
+            return (gs_joints_idx, gs_joints_qs_idx, gs_joints_dofs_idx)
         except ValueError:
             pass
     else:
-        raise ValueError(f"Fail to find joint indices for {joint_names}")
+        raise ValueError(f"Fail to find joint indices for {joints_name}")
 
 
-def _gs_search_by_link_names(
+def _gs_search_by_links_name(
     scene,
-    link_names: str | list[str],
+    links_name: str | Sequence[str],
     to: Literal["entity", "index"] = "index",
     is_local: bool = False,
     flatten: bool = True,
 ):
-    if isinstance(link_names, str):
-        link_names = [link_names]
+    if isinstance(links_name, str):
+        links_name = (links_name,)
 
     for entity in scene.entities:
         try:
-            gs_link_idcs = dict()
-            valid_link_names = []
-            for v in entity.links:
-                valid_link_names.append(v.name)
-                if v.name in link_names:
+            gs_links_idx = dict()
+            valid_links_name = []
+            for link in entity.links:
+                valid_links_name.append(link.name)
+                if link.name in links_name:
                     if to == "entity":
-                        gs_link_idcs[v.name] = v
+                        gs_links_idx[link.name] = link
                     elif to == "index":
-                        gs_link_idcs[v.name] = v.idx_local if is_local else v.idx
+                        gs_links_idx[link.name] = link.idx_local if is_local else link.idx
                     else:
                         raise ValueError(f"Cannot recognize what ({to}) to extract for the search")
 
-            missing_link_names = set(link_names) - gs_link_idcs.keys()
-            if len(missing_link_names) > 0:
-                raise ValueError(f"Cannot find links `{missing_link_names}`. Valid link names are {valid_link_names}")
+            missing_links_name = set(links_name) - gs_links_idx.keys()
+            if missing_links_name:
+                raise ValueError(f"Cannot find links `{missing_links_name}`. Valid link names are {valid_links_name}")
 
             if flatten:
-                return [gs_link_idcs[k] for k in link_names]
-
-            return gs_link_idcs
+                return list(gs_links_idx.values())
+            return gs_links_idx
         except ValueError:
             pass
     else:
-        raise ValueError(f"Fail to find link indices for {link_names}")
+        raise ValueError(f"Fail to find link indices for {links_name}")
 
 
 def _get_model_mappings(
     gs_sim,
     mj_sim,
-    joint_names: list[str] | None = None,
+    joints_name: list[str] | None = None,
     body_names: list[str] | None = None,
 ):
-    if joint_names is None:
-        joint_names = [
+    if joints_name is None:
+        joints_name = [
             joint.name for entity in gs_sim.entities for joint in entity.joints if joint.type != gs.JOINT_TYPE.FIXED
         ]
     body_names = [
         body.name for entity in gs_sim.entities for body in entity.links if not (body.is_fixed and body.parent_idx < 0)
     ]
 
-    act_names: list[str] = []
-    mj_jnt_idcs: list[int] = []
-    mj_q_idcs: list[int] = []
-    mj_dof_idcs: list[int] = []
-    mj_act_idcs: list[int] = []
-    for joint_name in joint_names:
+    motors_name: list[str] = []
+    mj_joints_idx: list[int] = []
+    mj_qs_idx: list[int] = []
+    mj_dofs_idx: list[int] = []
+    mj_motors_idx: list[int] = []
+    for joint_name in joints_name:
         if joint_name:
-            mj_joint_j = mj_sim.model.joint(joint_name)
+            mj_joint = mj_sim.model.joint(joint_name)
         else:
             # Must rely on exhaustive search if the joint has empty name
-            for j in range(mj_sim.model.njnt):
-                mj_joint_j = mj_sim.model.joint(j)
-                if mj_joint_j.name == "":
+            for j in range(mj_sim.model.njoint):
+                mj_joint = mj_sim.model.joint(j)
+                if mj_joint.name == "":
                     break
             else:
-                raise ValueError("Invalid joint name ''.")
-        mj_jnt_idcs.append(mj_joint_j.id)
-        mj_type_j = mj_sim.model.jnt_type[mj_joint_j.id]
-        if mj_type_j == mujoco.mjtJoint.mjJNT_HINGE:
-            n_dofs_j = 1
-            n_q_j = 1
-        elif mj_type_j == mujoco.mjtJoint.mjJNT_SLIDE:
-            n_dofs_j = 1
-            n_q_j = 1
-        elif mj_type_j == mujoco.mjtJoint.mjJNT_BALL:
-            n_dofs_j = 3
-            n_q_j = 4
-        elif mj_type_j == mujoco.mjtJoint.mjJNT_FREE:
-            n_dofs_j = 6
-            n_q_j = 7
+                raise ValueError(f"Invalid joint name '{joint_name}'.")
+        mj_joints_idx.append(mj_joint.id)
+        mj_type = mj_sim.model.jnt_type[mj_joint.id]
+        if mj_type == mujoco.mjtJoint.mjJNT_HINGE:
+            n_dofs, n_qs = 1, 1
+        elif mj_type == mujoco.mjtJoint.mjJNT_SLIDE:
+            n_dofs, n_qs = 1, 1
+        elif mj_type == mujoco.mjtJoint.mjJNT_BALL:
+            n_dofs, n_qs = 3, 4
+        elif mj_type == mujoco.mjtJoint.mjJNT_FREE:
+            n_dofs, n_qs = 6, 7
         else:
-            assert False
-        mj_dof_start_j = mj_sim.model.jnt_dofadr[mj_joint_j.id]
-        mj_dof_idcs += range(mj_dof_start_j, mj_dof_start_j + n_dofs_j)
+            raise ValueError(f"Invalid joint type '{mj_type}'.")
+        mj_dof_start_j = mj_sim.model.jnt_dofadr[mj_joint.id]
+        mj_dofs_idx += range(mj_dof_start_j, mj_dof_start_j + n_dofs)
 
-        mj_q_start_j = mj_sim.model.jnt_qposadr[mj_joint_j.id]
-        mj_q_idcs += range(mj_q_start_j, mj_q_start_j + n_q_j)
-        if (mj_joint_j.id == mj_sim.model.actuator_trnid[:, 0]).any():
-            act_names.append(joint_name)
-            (act_ids,) = np.nonzero(mj_joint_j.id == mj_sim.model.actuator_trnid[:, 0])
+        mj_q_start_j = mj_sim.model.jnt_qposadr[mj_joint.id]
+        mj_qs_idx += range(mj_q_start_j, mj_q_start_j + n_qs)
+        if (mj_joint.id == mj_sim.model.actuator_trnid[:, 0]).any():
+            motors_name.append(joint_name)
+            (motors_idx,) = np.nonzero(mj_joint.id == mj_sim.model.actuator_trnid[:, 0])
             # FIXME: only supporting 1DoF per actuator
-            mj_act_idcs.append(act_ids[0])
-    mj_body_idcs = [mj_sim.model.body(body_name).id for body_name in body_names]
-    (gs_jnt_idcs, gs_q_idcs, gs_dof_idcs) = _gs_search_by_joint_names(gs_sim.scene, joint_names)
-    (_, _, gs_act_idcs) = _gs_search_by_joint_names(gs_sim.scene, act_names)
-    gs_body_idcs = _gs_search_by_link_names(gs_sim.scene, body_names)
+            mj_motors_idx.append(motors_idx[0])
+    mj_bodies_idx = [mj_sim.model.body(body_name).id for body_name in body_names]
+    (gs_joints_idx, gs_q_idx, gs_dofs_idx) = _gs_search_by_joints_name(gs_sim.scene, joints_name)
+    (_, _, gs_motors_idx) = _gs_search_by_joints_name(gs_sim.scene, motors_name)
+    gs_bodies_idx = _gs_search_by_links_name(gs_sim.scene, body_names)
 
-    gs_maps = (gs_body_idcs, gs_jnt_idcs, gs_q_idcs, gs_dof_idcs, gs_act_idcs)
-    mj_maps = (mj_body_idcs, mj_jnt_idcs, mj_q_idcs, mj_dof_idcs, mj_act_idcs)
+    gs_maps = (gs_bodies_idx, gs_joints_idx, gs_q_idx, gs_dofs_idx, gs_motors_idx)
+    mj_maps = (mj_bodies_idx, mj_joints_idx, mj_qs_idx, mj_dofs_idx, mj_motors_idx)
     return gs_maps, mj_maps
 
 
 def check_mujoco_model_consistency(
     gs_sim,
     mj_sim,
-    joint_names: list[str] | None = None,
+    joints_name: list[str] | None = None,
     body_names: list[str] | None = None,
     *,
     atol: float,
 ):
     # Get mapping between Mujoco and Genesis
-    gs_maps, mj_maps = _get_model_mappings(gs_sim, mj_sim, joint_names, body_names)
-    (gs_body_idcs, gs_jnt_idcs, gs_q_idcs, gs_dof_idcs, gs_act_idcs) = gs_maps
-    (mj_body_idcs, mj_jnt_idcs, mj_q_idcs, mj_dof_idcs, mj_act_idcs) = mj_maps
+    gs_maps, mj_maps = _get_model_mappings(gs_sim, mj_sim, joints_name, body_names)
+    (gs_bodies_idx, gs_joints_idx, gs_q_idx, gs_dofs_idx, gs_motors_idx) = gs_maps
+    (mj_bodies_idx, mj_joints_idx, mj_qs_idx, mj_dofs_idx, mj_motors_idx) = mj_maps
 
     # solver
     gs_gravity = gs_sim.rigid_solver.scene.gravity
@@ -256,7 +247,7 @@ def check_mujoco_model_consistency(
         assert False
 
     # body
-    for gs_i, mj_i in zip(gs_body_idcs, mj_body_idcs):
+    for gs_i, mj_i in zip(gs_bodies_idx, mj_bodies_idx):
         gs_invweight_i = gs_sim.rigid_solver.links_info.invweight.to_numpy()[gs_i]
         mj_invweight_i = mj_sim.model.body(mj_i).invweight0[0]
         np.testing.assert_allclose(gs_invweight_i, mj_invweight_i, atol=atol)
@@ -282,51 +273,51 @@ def check_mujoco_model_consistency(
     # dof / joints
     gs_dof_damping = gs_sim.rigid_solver.dofs_info.damping.to_numpy()
     mj_dof_damping = mj_sim.model.dof_damping
-    np.testing.assert_allclose(gs_dof_damping[gs_dof_idcs], mj_dof_damping[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_dof_damping[gs_dofs_idx], mj_dof_damping[mj_dofs_idx], atol=atol)
 
     # FIXME: DoF damping implementation in Genesis is not consistent with Mujoco (for efficiency)
     # np.testing.assert_allclose(mj_sim.model.dof_damping, 0.0)
 
     gs_dof_armature = gs_sim.rigid_solver.dofs_info.armature.to_numpy()
     mj_dof_armature = mj_sim.model.dof_armature
-    np.testing.assert_allclose(gs_dof_armature[gs_dof_idcs], mj_dof_armature[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_dof_armature[gs_dofs_idx], mj_dof_armature[mj_dofs_idx], atol=atol)
 
     # FIXME: 1 stiffness per joint in Mujoco, 1 stiffness per DoF in Genesis
     gs_dof_stiffness = gs_sim.rigid_solver.dofs_info.stiffness.to_numpy()
     mj_dof_stiffness = mj_sim.model.jnt_stiffness
-    # np.testing.assert_allclose(gs_dof_stiffness[gs_dof_idcs], mj_dof_stiffness[mj_jnt_idcs], atol=atol)
+    # np.testing.assert_allclose(gs_dof_stiffness[gs_dofs_idx], mj_dof_stiffness[mj_joints_idx], atol=atol)
 
     gs_dof_invweight0 = gs_sim.rigid_solver.dofs_info.invweight.to_numpy()
     mj_dof_invweight0 = mj_sim.model.dof_invweight0
-    np.testing.assert_allclose(gs_dof_invweight0[gs_dof_idcs], mj_dof_invweight0[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_dof_invweight0[gs_dofs_idx], mj_dof_invweight0[mj_dofs_idx], atol=atol)
 
-    gs_jnt_solparams = np.concatenate([joint.sol_params for entity in gs_sim.entities for joint in entity.joints])
-    gs_jnt_solref = gs_jnt_solparams[:, :2]
-    mj_jnt_solref = mj_sim.model.jnt_solref
-    np.testing.assert_allclose(gs_jnt_solref[gs_jnt_idcs], mj_jnt_solref[mj_jnt_idcs], atol=atol)
-    gs_jnt_solimp = gs_jnt_solparams[:, 2:]
-    mj_jnt_solimp = mj_sim.model.jnt_solimp
-    np.testing.assert_allclose(gs_jnt_solimp[gs_jnt_idcs], mj_jnt_solimp[mj_jnt_idcs], atol=atol)
+    gs_joint_solparams = np.concatenate([joint.sol_params for entity in gs_sim.entities for joint in entity.joints])
+    gs_joint_solref = gs_joint_solparams[:, :2]
+    mj_joint_solref = mj_sim.model.jnt_solref
+    np.testing.assert_allclose(gs_joint_solref[gs_joints_idx], mj_joint_solref[mj_joints_idx], atol=atol)
+    gs_joint_solimp = gs_joint_solparams[:, 2:]
+    mj_joint_solimp = mj_sim.model.jnt_solimp
+    np.testing.assert_allclose(gs_joint_solimp[gs_joints_idx], mj_joint_solimp[mj_joints_idx], atol=atol)
     gs_dof_solparams = np.concatenate([joint.dofs_sol_params for entity in gs_sim.entities for joint in entity.joints])
     gs_dof_solref = gs_dof_solparams[:, :2]
     mj_dof_solref = mj_sim.model.dof_solref
-    np.testing.assert_allclose(gs_dof_solref[gs_dof_idcs], mj_dof_solref[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_dof_solref[gs_dofs_idx], mj_dof_solref[mj_dofs_idx], atol=atol)
     gs_dof_solimp = gs_dof_solparams[:, 2:]
     mj_dof_solimp = mj_sim.model.dof_solimp
-    np.testing.assert_allclose(gs_dof_solimp[gs_dof_idcs], mj_dof_solimp[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_dof_solimp[gs_dofs_idx], mj_dof_solimp[mj_dofs_idx], atol=atol)
 
     np.testing.assert_allclose(mj_sim.model.jnt_margin, 0, atol=atol)
-    gs_jnt_range = np.stack(
+    gs_joint_range = np.stack(
         [
             gs_sim.rigid_solver.dofs_info[gs_sim.rigid_solver.joints_info[i].dof_start].limit.to_numpy()
-            for i in gs_jnt_idcs
+            for i in gs_joints_idx
         ],
         axis=0,
     )
-    mj_jnt_range = mj_sim.model.jnt_range
-    mj_jnt_range[mj_sim.model.jnt_limited == 0, 0] = float("-inf")
-    mj_jnt_range[mj_sim.model.jnt_limited == 0, 1] = float("+inf")
-    np.testing.assert_allclose(gs_jnt_range, mj_jnt_range[mj_jnt_idcs], atol=atol)
+    mj_joint_range = mj_sim.model.jnt_range
+    mj_joint_range[mj_sim.model.jnt_limited == 0, 0] = float("-inf")
+    mj_joint_range[mj_sim.model.jnt_limited == 0, 1] = float("+inf")
+    np.testing.assert_allclose(gs_joint_range, mj_joint_range[mj_joints_idx], atol=atol)
 
     # actuator (position control)
     for v in mj_sim.model.actuator_dyntype:
@@ -339,43 +330,43 @@ def check_mujoco_model_consistency(
     gs_kv = gs_sim.rigid_solver.dofs_info.kv.to_numpy()
     mj_kp = -mj_sim.model.actuator_biasprm[:, 1]
     mj_kv = -mj_sim.model.actuator_biasprm[:, 2]
-    np.testing.assert_allclose(gs_kp[gs_act_idcs], mj_kp[mj_act_idcs], atol=atol)
-    np.testing.assert_allclose(gs_kv[gs_act_idcs], mj_kv[mj_act_idcs], atol=atol)
+    np.testing.assert_allclose(gs_kp[gs_motors_idx], mj_kp[mj_motors_idx], atol=atol)
+    np.testing.assert_allclose(gs_kv[gs_motors_idx], mj_kv[mj_motors_idx], atol=atol)
 
 
 def check_mujoco_data_consistency(
     gs_sim,
     mj_sim,
-    joint_names: list[str] | None = None,
+    joints_name: list[str] | None = None,
     body_names: list[str] | None = None,
     *,
     qvel_prev: np.ndarray | None = None,
     atol: float,
 ):
     # Get mapping between Mujoco and Genesis
-    gs_maps, mj_maps = _get_model_mappings(gs_sim, mj_sim, joint_names, body_names)
-    (gs_body_idcs, gs_jnt_idcs, gs_q_idcs, gs_dof_idcs, gs_act_idcs) = gs_maps
-    (mj_body_idcs, mj_jnt_idcs, mj_q_idcs, mj_dof_idcs, mj_act_idcs) = mj_maps
+    gs_maps, mj_maps = _get_model_mappings(gs_sim, mj_sim, joints_name, body_names)
+    (gs_bodies_idx, gs_joints_idx, gs_q_idx, gs_dofs_idx, gs_motors_idx) = gs_maps
+    (mj_bodies_idx, mj_joints_idx, mj_qs_idx, mj_dofs_idx, mj_motors_idx) = mj_maps
 
     # crb
     gs_crb_inertial = gs_sim.rigid_solver.links_state.crb_inertial.to_numpy()[:, 0].reshape([-1, 9])[
         :, [0, 4, 8, 1, 2, 5]
     ]
     mj_crb_inertial = mj_sim.data.crb[:, :6]  # upper-triangular part
-    np.testing.assert_allclose(gs_crb_inertial[gs_body_idcs], mj_crb_inertial[mj_body_idcs], atol=atol)
+    np.testing.assert_allclose(gs_crb_inertial[gs_bodies_idx], mj_crb_inertial[mj_bodies_idx], atol=atol)
     gs_crb_pos = gs_sim.rigid_solver.links_state.crb_pos.to_numpy()[:, 0]
     mj_crb_pos = mj_sim.data.crb[:, 6:9]
-    np.testing.assert_allclose(gs_crb_pos[gs_body_idcs], mj_crb_pos[mj_body_idcs], atol=atol)
+    np.testing.assert_allclose(gs_crb_pos[gs_bodies_idx], mj_crb_pos[mj_bodies_idx], atol=atol)
     gs_crb_mass = gs_sim.rigid_solver.links_state.crb_mass.to_numpy()[:, 0]
     mj_crb_mass = mj_sim.data.crb[:, 9]
-    np.testing.assert_allclose(gs_crb_mass[gs_body_idcs], mj_crb_mass[mj_body_idcs], atol=atol)
+    np.testing.assert_allclose(gs_crb_mass[gs_bodies_idx], mj_crb_mass[mj_bodies_idx], atol=atol)
 
     gs_mass_mat_damped = gs_sim.rigid_solver.mass_mat.to_numpy()[:, :, 0]
     mj_mass_mat_damped = np.zeros((mj_sim.model.nv, mj_sim.model.nv))
     mujoco.mj_fullM(mj_sim.model, mj_mass_mat_damped, mj_sim.data.qM)
     mj_mass_mat_damped[np.diag_indices(mj_sim.model.nv)] += mj_sim.model.dof_damping * mj_sim.model.opt.timestep
     np.testing.assert_allclose(
-        gs_mass_mat_damped[gs_dof_idcs][:, gs_dof_idcs], mj_mass_mat_damped[mj_dof_idcs][:, mj_dof_idcs], atol=atol
+        gs_mass_mat_damped[gs_dofs_idx][:, gs_dofs_idx], mj_mass_mat_damped[mj_dofs_idx][:, mj_dofs_idx], atol=atol
     )
 
     gs_meaninertia = gs_sim.rigid_solver.meaninertia.to_numpy()[0]
@@ -384,13 +375,13 @@ def check_mujoco_data_consistency(
 
     gs_qfrc_bias = gs_sim.rigid_solver.dofs_state.qf_bias.to_numpy()[:, 0]
     mj_qfrc_bias = mj_sim.data.qfrc_bias
-    np.testing.assert_allclose(gs_qfrc_bias, mj_qfrc_bias[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_qfrc_bias, mj_qfrc_bias[mj_dofs_idx], atol=atol)
     gs_qfrc_passive = gs_sim.rigid_solver.dofs_state.qf_passive.to_numpy()[:, 0]
     mj_qfrc_passive = mj_sim.data.qfrc_passive
-    np.testing.assert_allclose(gs_qfrc_passive, mj_qfrc_passive[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_qfrc_passive, mj_qfrc_passive[mj_dofs_idx], atol=atol)
     gs_qfrc_actuator = gs_sim.rigid_solver.dofs_state.qf_applied.to_numpy()[:, 0]
     mj_qfrc_actuator = mj_sim.data.qfrc_actuator
-    np.testing.assert_allclose(gs_qfrc_actuator, mj_qfrc_actuator[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_qfrc_actuator, mj_qfrc_actuator[mj_dofs_idx], atol=atol)
 
     gs_n_contacts = gs_sim.rigid_solver.collider.n_contacts.to_numpy()[0]
     mj_n_contacts = mj_sim.data.ncon
@@ -423,7 +414,7 @@ def check_mujoco_data_consistency(
             (np.argsort(gs_efc_aref), np.argsort(mj_efc_aref)),
         ):
             try:
-                np.testing.assert_allclose(gs_jac[gs_sidx][:, gs_dof_idcs], mj_jac[mj_sidx][:, mj_dof_idcs], atol=atol)
+                np.testing.assert_allclose(gs_jac[gs_sidx][:, gs_dofs_idx], mj_jac[mj_sidx][:, mj_dofs_idx], atol=atol)
                 np.testing.assert_allclose(gs_efc_D[gs_sidx], mj_efc_D[mj_sidx], atol=atol)
                 np.testing.assert_allclose(gs_efc_aref[gs_sidx], mj_efc_aref[mj_sidx], atol=atol)
                 break
@@ -448,7 +439,7 @@ def check_mujoco_data_consistency(
 
     gs_qfrc_constraint = gs_sim.rigid_solver.dofs_state.qf_constraint.to_numpy()[:, 0]
     mj_qfrc_constraint = mj_sim.data.qfrc_constraint
-    np.testing.assert_allclose(gs_qfrc_constraint[gs_dof_idcs], mj_qfrc_constraint[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_qfrc_constraint[gs_dofs_idx], mj_qfrc_constraint[mj_dofs_idx], atol=atol)
 
     if gs_n_constraints:
         gs_efc_force = gs_sim.rigid_solver.constraint_solver.efc_force.to_numpy()[:gs_n_constraints, 0]
@@ -465,16 +456,16 @@ def check_mujoco_data_consistency(
     mj_qfrc_all = mj_sim.data.qfrc_smooth + mj_sim.data.qfrc_constraint
     if gs_sim.rigid_solver._options.integrator != gs.integrator.Euler:
         # FIXME: External forces are not added up for Euler integrator
-        np.testing.assert_allclose(gs_qfrc_all[gs_dof_idcs], mj_qfrc_all[mj_dof_idcs], atol=atol)
+        np.testing.assert_allclose(gs_qfrc_all[gs_dofs_idx], mj_qfrc_all[mj_dofs_idx], atol=atol)
 
     # FIXME: Why this check is not passing???
     gs_qfrc_smooth = gs_sim.rigid_solver.dofs_state.qf_smooth.to_numpy()[:, 0]
     mj_qfrc_smooth = mj_sim.data.qfrc_smooth
-    # np.testing.assert_allclose(gs_qfrc_smooth[gs_dof_idcs], mj_qfrc_smooth[mj_dof_idcs], atol=atol)
+    # np.testing.assert_allclose(gs_qfrc_smooth[gs_dofs_idx], mj_qfrc_smooth[mj_dofs_idx], atol=atol)
 
     gs_qacc_smooth = gs_sim.rigid_solver.dofs_state.acc_smooth.to_numpy()[:, 0]
     mj_qacc_smooth = mj_sim.data.qacc_smooth
-    np.testing.assert_allclose(gs_qacc_smooth[gs_dof_idcs], mj_qacc_smooth[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_qacc_smooth[gs_dofs_idx], mj_qacc_smooth[mj_dofs_idx], atol=atol)
 
     # Acceleration pre- VS post-implicit damping
     # gs_qacc_post = gs_sim.rigid_solver.dofs_state.acc.to_numpy()[:, 0]
@@ -483,14 +474,14 @@ def check_mujoco_data_consistency(
     else:
         gs_qacc_pre = gs_qacc_smooth
     mj_qacc_pre = mj_sim.data.qacc
-    np.testing.assert_allclose(gs_qacc_pre[gs_dof_idcs], mj_qacc_pre[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_qacc_pre[gs_dofs_idx], mj_qacc_pre[mj_dofs_idx], atol=atol)
 
     gs_qpos = gs_sim.rigid_solver.qpos.to_numpy()[:, 0]
     mj_qpos = mj_sim.data.qpos
-    np.testing.assert_allclose(gs_qpos[gs_q_idcs], mj_qpos[mj_q_idcs], atol=atol)
+    np.testing.assert_allclose(gs_qpos[gs_q_idx], mj_qpos[mj_qs_idx], atol=atol)
     gs_qvel = gs_sim.rigid_solver.dofs_state.vel.to_numpy()[:, 0]
     mj_qvel = mj_sim.data.qvel
-    np.testing.assert_allclose(gs_qvel[gs_dof_idcs], mj_qvel[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_qvel[gs_dofs_idx], mj_qvel[mj_dofs_idx], atol=atol)
 
     # ------------------------------------------------------------------------
     mujoco.mj_fwdPosition(mj_sim.model, mj_sim.data)
@@ -503,58 +494,58 @@ def check_mujoco_data_consistency(
 
     gs_xipos = gs_sim.rigid_solver.links_state.i_pos.to_numpy()[:, 0]
     mj_xipos = mj_sim.data.xipos - mj_sim.data.subtree_com[0]
-    np.testing.assert_allclose(gs_xipos[gs_body_idcs], mj_xipos[mj_body_idcs], atol=atol)
+    np.testing.assert_allclose(gs_xipos[gs_bodies_idx], mj_xipos[mj_bodies_idx], atol=atol)
 
     gs_xpos = gs_sim.rigid_solver.links_state.pos.to_numpy()[:, 0]
     mj_xpos = mj_sim.data.xpos
-    np.testing.assert_allclose(gs_xpos[gs_body_idcs], mj_xpos[mj_body_idcs], atol=atol)
+    np.testing.assert_allclose(gs_xpos[gs_bodies_idx], mj_xpos[mj_bodies_idx], atol=atol)
 
     gs_xquat = gs_sim.rigid_solver.links_state.quat.to_numpy()[:, 0]
     gs_xmat = gu.quat_to_R(gs_xquat).reshape([-1, 9])
     mj_xmat = mj_sim.data.xmat
-    np.testing.assert_allclose(gs_xmat[gs_body_idcs], mj_xmat[mj_body_idcs], atol=atol)
+    np.testing.assert_allclose(gs_xmat[gs_bodies_idx], mj_xmat[mj_bodies_idx], atol=atol)
 
     gs_cd_vel = gs_sim.rigid_solver.links_state.cd_vel.to_numpy()[:, 0]
     gs_cd_vel_ = gs_sim.rigid_solver.links_state.vel.to_numpy()[:, 0]
     np.testing.assert_allclose(gs_cd_vel, gs_cd_vel_, atol=atol)
     mj_cd_vel = mj_sim.data.cvel[:, 3:]
-    np.testing.assert_allclose(gs_cd_vel[gs_body_idcs], mj_cd_vel[mj_body_idcs], atol=atol)
+    np.testing.assert_allclose(gs_cd_vel[gs_bodies_idx], mj_cd_vel[mj_bodies_idx], atol=atol)
     gs_cd_ang = gs_sim.rigid_solver.links_state.cd_ang.to_numpy()[:, 0]
     mj_cd_ang = mj_sim.data.cvel[:, :3]
-    np.testing.assert_allclose(gs_cd_ang[gs_body_idcs], mj_cd_ang[mj_body_idcs], atol=atol)
+    np.testing.assert_allclose(gs_cd_ang[gs_bodies_idx], mj_cd_ang[mj_bodies_idx], atol=atol)
 
     gs_cdof_vel = gs_sim.rigid_solver.dofs_state.cdof_vel.to_numpy()[:, 0]
     mj_cdof_vel = mj_sim.data.cdof[:, 3:]
-    np.testing.assert_allclose(gs_cdof_vel[gs_dof_idcs], mj_cdof_vel[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_cdof_vel[gs_dofs_idx], mj_cdof_vel[mj_dofs_idx], atol=atol)
     gs_cdof_ang = gs_sim.rigid_solver.dofs_state.cdof_ang.to_numpy()[:, 0]
     mj_cdof_ang = mj_sim.data.cdof[:, :3]
-    np.testing.assert_allclose(gs_cdof_ang[gs_dof_idcs], mj_cdof_ang[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_cdof_ang[gs_dofs_idx], mj_cdof_ang[mj_dofs_idx], atol=atol)
 
     mj_cdof_dot_ang = mj_sim.data.cdof_dot[:, :3]
     gs_cdof_dot_ang = gs_sim.rigid_solver.dofs_state.cdofd_ang.to_numpy()[:, 0]
-    np.testing.assert_allclose(gs_cdof_dot_ang[gs_dof_idcs], mj_cdof_dot_ang[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_cdof_dot_ang[gs_dofs_idx], mj_cdof_dot_ang[mj_dofs_idx], atol=atol)
 
     mj_cdof_dot_vel = mj_sim.data.cdof_dot[:, 3:]
     gs_cdof_dot_vel = gs_sim.rigid_solver.dofs_state.cdofd_vel.to_numpy()[:, 0]
-    np.testing.assert_allclose(gs_cdof_dot_vel[gs_dof_idcs], mj_cdof_dot_vel[mj_dof_idcs], atol=atol)
+    np.testing.assert_allclose(gs_cdof_dot_vel[gs_dofs_idx], mj_cdof_dot_vel[mj_dofs_idx], atol=atol)
 
     # cinr
     gs_cinr_inertial = gs_sim.rigid_solver.links_state.cinr_inertial.to_numpy()[:, 0].reshape([-1, 9])[
         :, [0, 4, 8, 1, 2, 5]
     ]
     mj_cinr_inertial = mj_sim.data.cinert[:, :6]  # upper-triangular part
-    np.testing.assert_allclose(gs_cinr_inertial[gs_body_idcs], mj_cinr_inertial[mj_body_idcs], atol=atol)
+    np.testing.assert_allclose(gs_cinr_inertial[gs_bodies_idx], mj_cinr_inertial[mj_bodies_idx], atol=atol)
     gs_cinr_pos = gs_sim.rigid_solver.links_state.cinr_pos.to_numpy()[:, 0]
     mj_cinr_pos = mj_sim.data.cinert[:, 6:9]
-    np.testing.assert_allclose(gs_cinr_pos[gs_body_idcs], mj_cinr_pos[mj_body_idcs], atol=atol)
+    np.testing.assert_allclose(gs_cinr_pos[gs_bodies_idx], mj_cinr_pos[mj_bodies_idx], atol=atol)
     gs_cinr_mass = gs_sim.rigid_solver.links_state.cinr_mass.to_numpy()[:, 0]
     mj_cinr_mass = mj_sim.data.cinert[:, 9]
-    np.testing.assert_allclose(gs_cinr_mass[gs_body_idcs], mj_cinr_mass[mj_body_idcs], atol=atol)
+    np.testing.assert_allclose(gs_cinr_mass[gs_bodies_idx], mj_cinr_mass[mj_bodies_idx], atol=atol)
 
 
 def simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos=None, qvel=None, *, atol, num_steps):
     # Get mapping between Mujoco and Genesis
-    _, (_, _, mj_q_idcs, mj_dof_idcs, _) = _get_model_mappings(gs_sim, mj_sim)
+    _, (_, _, mj_qs_idx, mj_dofs_idx, _) = _get_model_mappings(gs_sim, mj_sim)
 
     # Make sure that "static" model information are matching
     check_mujoco_model_consistency(gs_sim, mj_sim, atol=atol)
@@ -570,8 +561,8 @@ def simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos=None, qvel=None, 
         check_mujoco_data_consistency(gs_sim, mj_sim, qvel_prev=qvel_prev, atol=atol)
 
         # Keep Mujoco and Genesis simulation in sync to avoid drift over time
-        mj_sim.data.qpos[mj_q_idcs] = gs_sim.rigid_solver.qpos.to_numpy()[:, 0]
-        mj_sim.data.qvel[mj_dof_idcs] = gs_sim.rigid_solver.dofs_state.vel.to_numpy()[:, 0]
+        mj_sim.data.qpos[mj_qs_idx] = gs_sim.rigid_solver.qpos.to_numpy()[:, 0]
+        mj_sim.data.qvel[mj_dofs_idx] = gs_sim.rigid_solver.dofs_state.vel.to_numpy()[:, 0]
         qvel_prev = mj_sim.data.qvel.copy()
 
         # Do a single simulation step (eventually with substeps for Genesis)


### PR DESCRIPTION
## Description

This PR fixes a few naming conventions issue: 

I tried to infer a good naming convention from the actual codebase and I ended up with the following **rules for variable names**.

For individual instances:
* Snake case: `link_idx` vs `LinkIdx`
* No abbreviation: prefer `joint_` vs `jnt_` / `link_` vs `ln_` 
  * Notable exception (for now): `idx` vs `index`, `n` vs `num`

For containers holding multiple instances: 
* First word is the parent type, followed by the child attribute: `links_dof_start` vs `dof_start_links`
* `s` suffix on the first word only (even if grammatically wrong): `links_name` vs `link_names`
OR 
* type of container as last word: `_pair`, `_set`, `_map`, `_list`

For nested containers:
* Order word from highest to lowest hierarchical level
* As many `s` suffixes or container types as maximum depth, i.e. `geoms_vertices_idx`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I read the **CONTRIBUTING** document.
- [ ] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [ ] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
