### PR TITLE
[MISC] Get rid of recently introduced nested joints data structure.

### DIFF
--- a/genesis/_main.py
+++ b/genesis/_main.py
@@ -2,7 +2,6 @@ import argparse
 import multiprocessing
 import os
 import threading
-from itertools import chain
 import tkinter as tk
 from tkinter import ttk
 
@@ -79,7 +78,7 @@ class JointControlGUI:
 def get_movable_dofs(robot):
     motor_dofs = []
     motor_dof_names = []
-    for joint in chain.from_iterable(robot.joints):
+    for joint in robot.joints:
         if joint.type == gs.JOINT_TYPE.FREE:
             continue
         elif joint.type == gs.JOINT_TYPE.FIXED:

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -432,7 +432,6 @@ class RigidEntity(Entity):
                 )
 
     def _build(self):
-        assert self.n_links == len(self.joints)
         for link in self._links:
             link._build()
 
@@ -457,7 +456,7 @@ class RigidEntity(Entity):
         # compute joint limit in q space
         q_limit_lower = []
         q_limit_upper = []
-        for joint in chain.from_iterable(self._joints):
+        for joint in self.joints:
             if joint.type == gs.JOINT_TYPE.FREE:
                 q_limit_lower.append(joint.dofs_limit[:3, 0])
                 q_limit_lower.append(-np.ones(4))  # quaternion lower bound
@@ -1635,13 +1634,13 @@ class RigidEntity(Entity):
         """
 
         if name is not None:
-            for joint in chain.from_iterable(self._joints):
+            for joint in self.joints:
                 if joint.name == name:
                     return joint
             gs.raise_exception(f"Joint not found for name: {name}.")
 
         elif uid is not None:
-            for joint in chain.from_iterable(self._joints):
+            for joint in self.joints:
                 if uid in str(joint.uid):
                     return joint
             gs.raise_exception(f"Joint not found for uid: {uid}.")
@@ -2671,14 +2670,14 @@ class RigidEntity(Entity):
     @property
     def init_qpos(self):
         """The initial qpos of the entity."""
-        return np.concatenate([joint.init_qpos for joint in chain.from_iterable(self._joints)])
+        return np.concatenate([joint.init_qpos for joint in self.joints])
 
     @property
     def n_qs(self):
         """The number of `q` (generalized coordinates) of the entity."""
         if self._is_built:
             return self._n_qs
-        return sum(joint.n_qs for joint in chain.from_iterable(self._joints))
+        return sum(joint.n_qs for joint in self.joints)
 
     @property
     def n_links(self):
@@ -2695,7 +2694,7 @@ class RigidEntity(Entity):
         """The number of degrees of freedom (DOFs) of the entity."""
         if self._is_built:
             return self._n_dofs
-        return sum(joint.n_dofs for joint in chain.from_iterable(self._joints))
+        return sum(joint.n_dofs for joint in self.joints)
 
     @property
     def n_geoms(self):
@@ -2862,6 +2861,11 @@ class RigidEntity(Entity):
     @property
     def joints(self):
         """The list of joints (`RigidJoint`) in the entity."""
+        return tuple(chain.from_iterable(self._joints))
+
+    @property
+    def joints_by_links(self):
+        """The list of joints (`RigidJoint`) in the entity grouped by parent links."""
         return self._joints
 
     @property

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -436,14 +436,14 @@ class RigidLink(RBC):
         """
         The sequence of joints that connects the link to its parent link.
         """
-        return self._solver.joints[self._idx]
+        return self._solver.joints[self.joint_start : self.joint_end]
 
     @property
     def n_joints(self):
         """
         Number of the joints that connects the link to its parent link.
         """
-        return len(self.joints)
+        return self._n_joints
 
     @property
     def joint_start(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-from itertools import chain
 from enum import Enum
 
 import psutil
@@ -235,7 +234,7 @@ def gs_sim(
 
     # Joint damping is not properly supported in Genesis for now
     if not dof_damping:
-        for joint in chain.from_iterable(gs_robot.joints):
+        for joint in gs_robot.joints:
             joint.dofs_damping[:] = 0.0
 
     scene.build()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,4 @@
 from typing import Literal
-from itertools import chain
 from dataclasses import dataclass
 
 import numpy as np
@@ -55,7 +54,7 @@ def _gs_search_by_joint_names(
             gs_q_idcs = dict()
             gs_dof_idcs = dict()
             valid_joint_names = []
-            for joint in chain.from_iterable(entity.joints):
+            for joint in entity.joints:
                 valid_joint_names.append(joint.name)
                 if joint.name in joint_names:
                     if to == "entity":
@@ -140,10 +139,7 @@ def _get_model_mappings(
 ):
     if joint_names is None:
         joint_names = [
-            joint.name
-            for entity in gs_sim.entities
-            for joint in chain.from_iterable(entity.joints)
-            if joint.type != gs.JOINT_TYPE.FIXED
+            joint.name for entity in gs_sim.entities for joint in entity.joints if joint.type != gs.JOINT_TYPE.FIXED
         ]
     body_names = [
         body.name for entity in gs_sim.entities for body in entity.links if not (body.is_fixed and body.parent_idx < 0)
@@ -304,18 +300,14 @@ def check_mujoco_model_consistency(
     mj_dof_invweight0 = mj_sim.model.dof_invweight0
     np.testing.assert_allclose(gs_dof_invweight0[gs_dof_idcs], mj_dof_invweight0[mj_dof_idcs], atol=atol)
 
-    gs_jnt_solparams = np.concatenate(
-        [joint.sol_params for entity in gs_sim.entities for joints in entity.joints for joint in joints]
-    )
+    gs_jnt_solparams = np.concatenate([joint.sol_params for entity in gs_sim.entities for joint in entity.joints])
     gs_jnt_solref = gs_jnt_solparams[:, :2]
     mj_jnt_solref = mj_sim.model.jnt_solref
     np.testing.assert_allclose(gs_jnt_solref[gs_jnt_idcs], mj_jnt_solref[mj_jnt_idcs], atol=atol)
     gs_jnt_solimp = gs_jnt_solparams[:, 2:]
     mj_jnt_solimp = mj_sim.model.jnt_solimp
     np.testing.assert_allclose(gs_jnt_solimp[gs_jnt_idcs], mj_jnt_solimp[mj_jnt_idcs], atol=atol)
-    gs_dof_solparams = np.concatenate(
-        [joint.dofs_sol_params for entity in gs_sim.entities for joints in entity.joints for joint in joints]
-    )
+    gs_dof_solparams = np.concatenate([joint.dofs_sol_params for entity in gs_sim.entities for joint in entity.joints])
     gs_dof_solref = gs_dof_solparams[:, :2]
     mj_dof_solref = mj_sim.model.dof_solref
     np.testing.assert_allclose(gs_dof_solref[gs_dof_idcs], mj_dof_solref[mj_dof_idcs], atol=atol)


### PR DESCRIPTION
## Description

Revert nested list data structure (list of direct child joints associated with each link) for storing joints introduced by compound joints PR https://github.com/Genesis-Embodied-AI/Genesis/pull/853 in favour of a flattened list of all the joints for a given entity. Adding getter `RigidEntity.joints_by_links` for users that would be interested in the nested hierarchy. 

## Motivation and Context

This newly introduced nested list data structure for storing joints (list of direct child joints associated with each link) that was introduced by compound joints PR https://github.com/Genesis-Embodied-AI/Genesis/pull/853 is breaking backward compatibility, and is confusing for some. It would be better to revert this change at user-API level, plus add another getter to access the hierarchical representation.

## How Has This Been / Can This Be Tested?

Running the unit tests successfully.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.