### PR TITLE
[BUG FIX] Fix rendering bugs (non-deterministic, segmentation map glitches).

### DIFF
--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -308,8 +308,11 @@ def _custom_excepthook(exctype, value, tb):
     print("".join(traceback.format_exception(exctype, value, tb)))
 
     # Logger the exception right before exit if possible
-    if gs.logger is not None:
+    try:
         gs.logger.error(f"{exctype.__name__}: {value}")
+    except AttributeError:
+        # Logger may not be configured at this point
+        pass
 
 
 # Set the custom excepthook to handle GenesisException

--- a/genesis/ext/pyrender/offscreen.py
+++ b/genesis/ext/pyrender/offscreen.py
@@ -5,9 +5,14 @@ Author: Matthew Matl
 
 import os
 
+from OpenGL.GL import *
+
 from .constants import RenderFlags
 from .renderer import Renderer
 from .shader_program import ShaderProgram, ShaderProgramCache
+
+
+MODULE_DIR = os.path.dirname(__file__)
 
 
 class OffscreenRenderer(object):
@@ -138,17 +143,15 @@ class OffscreenRenderer(object):
                 retval = color, depth
 
         if normal:
-
             class CustomShaderCache:
                 def __init__(self):
                     self.program = None
 
                 def get_program(self, vertex_shader, fragment_shader, geometry_shader=None, defines=None):
                     if self.program is None:
-                        absolute_path = os.path.abspath(__file__)
                         self.program = ShaderProgram(
-                            os.path.join(absolute_path.replace("offscreen.py", ""), "shaders/mesh_normal.vert"),
-                            os.path.join(absolute_path.replace("offscreen.py", ""), "shaders/mesh_normal.frag"),
+                            os.path.join(MODULE_DIR, "shaders/mesh_normal.vert"),
+                            os.path.join(MODULE_DIR, "shaders/mesh_normal.frag"),
                             defines=defines,
                         )
                     return self.program
@@ -159,8 +162,10 @@ class OffscreenRenderer(object):
             flags = RenderFlags.FLAT | RenderFlags.OFFSCREEN
             if env_separate_rigid:
                 flags |= RenderFlags.ENV_SEPARATE
-            normal_arr, _ = renderer.render(scene, flags)
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
+            normal_arr, _ = renderer.render(scene, flags, is_first_pass=False)
             retval = retval + (normal_arr,)
+
             renderer._program_cache = old_cache
 
         # Make the platform not current

--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -11,6 +11,7 @@ from threading import Event, RLock, Semaphore, Thread
 import imageio
 import numpy as np
 import OpenGL
+from OpenGL.GL import *
 
 import genesis as gs
 
@@ -62,6 +63,9 @@ from .shader_program import ShaderProgram, ShaderProgramCache
 from .trackball import Trackball
 
 pyglet.options["shadow_window"] = False
+
+
+MODULE_DIR = os.path.dirname(__file__)
 
 
 class Viewer(pyglet.window.Window):
@@ -1075,66 +1079,65 @@ class Viewer(pyglet.window.Window):
         elif self.scene.has_node(self._direct_light):
             self.scene.remove_node(self._direct_light)
 
-        if normal:
+        flags = RenderFlags.NONE
+        if self.render_flags["flip_wireframe"]:
+            flags |= RenderFlags.FLIP_WIREFRAME
+        elif self.render_flags["all_wireframe"]:
+            flags |= RenderFlags.ALL_WIREFRAME
+        elif self.render_flags["all_solid"]:
+            flags |= RenderFlags.ALL_SOLID
 
+        if self.render_flags["shadows"]:
+            flags |= RenderFlags.SHADOWS_ALL
+        if self.render_flags["plane_reflection"]:
+            flags |= RenderFlags.REFLECTIVE_FLOOR
+        if self.render_flags["env_separate_rigid"]:
+            flags |= RenderFlags.ENV_SEPARATE
+        if self.render_flags["vertex_normals"]:
+            flags |= RenderFlags.VERTEX_NORMALS
+        if self.render_flags["face_normals"]:
+            flags |= RenderFlags.FACE_NORMALS
+        if not self.render_flags["cull_faces"]:
+            flags |= RenderFlags.SKIP_CULL_FACES
+
+        if self.render_flags["offscreen"]:
+            flags |= RenderFlags.OFFSCREEN
+
+        seg_node_map = None
+        if self.render_flags["seg"]:
+            flags |= RenderFlags.SEG
+            seg_node_map = self._seg_node_map
+
+        if self.render_flags["depth"]:
+            flags |= RenderFlags.RET_DEPTH
+
+        retval = renderer.render(self.scene, flags, seg_node_map=seg_node_map)
+
+        if normal:
             class CustomShaderCache:
                 def __init__(self):
                     self.program = None
 
                 def get_program(self, vertex_shader, fragment_shader, geometry_shader=None, defines=None):
                     if self.program is None:
-                        absolute_path = os.path.abspath(__file__)
-                        print(absolute_path)
                         self.program = ShaderProgram(
-                            os.path.join(absolute_path.replace("viewer.py", ""), "shaders/mesh_normal.vert"),
-                            os.path.join(absolute_path.replace("viewer.py", ""), "shaders/mesh_normal.frag"),
+                            os.path.join(MODULE_DIR, "shaders/mesh_normal.vert"),
+                            os.path.join(MODULE_DIR, "shaders/mesh_normal.frag"),
                             defines=defines,
                         )
                     return self.program
 
+            old_cache = renderer._program_cache
             renderer._program_cache = CustomShaderCache()
 
             flags = RenderFlags.FLAT | RenderFlags.OFFSCREEN
             if self.render_flags["env_separate_rigid"]:
                 flags |= RenderFlags.ENV_SEPARATE
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
+            normal_arr, _ = renderer.render(scene, flags, is_first_pass=True)
+            retval = retval + (normal_arr,)
 
-            retval = renderer.render(scene, flags)
-            renderer._program_cache = ShaderProgramCache()
-
-        else:
-            flags = RenderFlags.NONE
-            if self.render_flags["flip_wireframe"]:
-                flags |= RenderFlags.FLIP_WIREFRAME
-            elif self.render_flags["all_wireframe"]:
-                flags |= RenderFlags.ALL_WIREFRAME
-            elif self.render_flags["all_solid"]:
-                flags |= RenderFlags.ALL_SOLID
-
-            if self.render_flags["shadows"]:
-                flags |= RenderFlags.SHADOWS_ALL
-            if self.render_flags["plane_reflection"]:
-                flags |= RenderFlags.REFLECTIVE_FLOOR
-            if self.render_flags["env_separate_rigid"]:
-                flags |= RenderFlags.ENV_SEPARATE
-            if self.render_flags["vertex_normals"]:
-                flags |= RenderFlags.VERTEX_NORMALS
-            if self.render_flags["face_normals"]:
-                flags |= RenderFlags.FACE_NORMALS
-            if not self.render_flags["cull_faces"]:
-                flags |= RenderFlags.SKIP_CULL_FACES
-
-            if self.render_flags["offscreen"]:
-                flags |= RenderFlags.OFFSCREEN
-
-            seg_node_map = None
-            if self.render_flags["seg"]:
-                flags |= RenderFlags.SEG
-                seg_node_map = self._seg_node_map
-
-            if self.render_flags["depth"]:
-                flags |= RenderFlags.RET_DEPTH
-
-            retval = renderer.render(self.scene, flags, seg_node_map=seg_node_map)
+            renderer._program_cache = old_cache
 
         if camera_node is not None:
             self.scene.main_camera_node = saved_camera_node

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -481,7 +481,6 @@ def test_info_batching():
     np.testing.assert_allclose(qposs[0], qposs[1])
 
 
-@pytest.mark.xfail(reason="Offscreen rendering is actually not deterministic on Nvidia GPU.")
 def test_batched_offscreen_rendering(show_viewer):
     scene = gs.Scene(
         vis_options=gs.options.VisOptions(


### PR DESCRIPTION
## Description

* Enforce clearing of OpenGL frame buffer between (RGB + Depth Map) vs Normal Map
* Gather (RGB + Depth Map) rendering pass with Normal Map
  * Unify logics between onscreen and offscreen rendering

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/546

## Motivation and Context

Currently, the viewer is facing 2 different issues. First, it is non-deterministic: A given scene may produce different RGB arrays despite being in the exact same physical state. The difference is only +/- 1 (on 0 to 255 uint8 scale). This is messing up with unit tests checking reproducibility of the simulation as a whole. Second, the segmentation map has graphical glitches when normal map is also enabled. This is more problematic has it means it cannot be used reliably practical user applications (training agents or anything else).

## How Has This Been / Can This Be Tested?

Running the unit tests successfully, along with `examples/tutorials/visualization.py` tweaked to check both hybrid offscreen rendering and fully onscreen rendering, which corresponds to very different codepath.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] All new and existing tests passed.
