### PR TITLE
[BUG FIX] Fix time integration for ball joint

### DIFF
--- a/genesis/assets/xml/one_ball_joint.xml
+++ b/genesis/assets/xml/one_ball_joint.xml
@@ -1,0 +1,28 @@
+<mujoco model="capsule_rope">
+  <compiler angle="degree"/>
+  <option gravity="0 0 -9.81"/>
+  <default>
+    <default class="/">
+      <joint damping="0.01"/>
+      <geom friction="1 0.005 0.0001" density="500"/>
+    </default>
+  </default>
+  <asset>
+    <texture builtin="gradient" height="100" rgb1="1 1 1" rgb2="0 0 0" type="skybox" width="100"/>
+    <texture builtin="flat" height="1278" mark="cross" markrgb="1 1 1" name="texgeom" random="0.01" rgb1="0.8 0.6 0.4" rgb2="0.8 0.6 0.4" type="cube" width="127"/>
+    <texture builtin="checker" height="100" name="texplane" rgb1="0 0 0" rgb2="0.8 0.8 0.8" type="2d" width="100"/>
+    <material name="MatPlane" reflectance="0.5" shininess="1" specular="1" texrepeat="60 60" texture="texplane"/>
+  </asset>
+  <worldbody>
+    <!-- <geom conaffinity="1" condim="3" material="MatPlane" name="floor" pos="0 0 0" rgba="0.8 0.9 0.8 1" size="40 40 40" type="plane"/> -->
+
+    <body name="seg0" pos="0 0 0.2" euler="45 45 45">
+      <!-- <joint name="root" class="/" type="free"/> -->
+      <geom name="seg0_geom" class="/" type="capsule" size="0.02 0.05" fromto="-0 0 0 0.1 0 0"/>
+      <body name="seg1" pos="0.1 0 0">
+        <joint name="ball1" class="/" type="ball" stiffness="0"/>
+        <geom name="seg1_geom" class="/" type="capsule" size="0.02 0.05" fromto="-0 0 0 0.1 0 0"/>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -3359,9 +3359,7 @@ class RigidSolver(Solver):
                     for j in ti.static(range(3)):
                         self.qpos[q_start + j, i_b] = pos[j]
                 if joint_type == gs.JOINT_TYPE.SPHERICAL or joint_type == gs.JOINT_TYPE.FREE:
-                    rot_offset = 3
-                    if joint_type == gs.JOINT_TYPE.SPHERICAL:
-                        rot_offset = 0
+                    rot_offset = 3 if joint_type == gs.JOINT_TYPE.FREE else 0
                     rot = ti.Vector(
                         [
                             self.qpos[q_start + rot_offset + 0, i_b],

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -3347,26 +3347,6 @@ class RigidSolver(Solver):
                 joint_type = self.joints_info[I_j].type
 
                 if joint_type == gs.JOINT_TYPE.FREE:
-                    rot = ti.Vector(
-                        [
-                            self.qpos[q_start + 3, i_b],
-                            self.qpos[q_start + 4, i_b],
-                            self.qpos[q_start + 5, i_b],
-                            self.qpos[q_start + 6, i_b],
-                        ]
-                    )
-                    ang = (
-                        ti.Vector(
-                            [
-                                self.dofs_state[dof_start + 3, i_b].vel,
-                                self.dofs_state[dof_start + 4, i_b].vel,
-                                self.dofs_state[dof_start + 5, i_b].vel,
-                            ]
-                        )
-                        * self._substep_dt
-                    )
-                    qrot = gu.ti_rotvec_to_quat(ang)
-                    rot = gu.ti_transform_quat_by_quat(qrot, rot)
                     pos = ti.Vector([self.qpos[q_start, i_b], self.qpos[q_start + 1, i_b], self.qpos[q_start + 2, i_b]])
                     vel = ti.Vector(
                         [
@@ -3378,8 +3358,32 @@ class RigidSolver(Solver):
                     pos = pos + vel * self._substep_dt
                     for j in ti.static(range(3)):
                         self.qpos[q_start + j, i_b] = pos[j]
-                    for j in ti.static(range(4)):
-                        self.qpos[q_start + j + 3, i_b] = rot[j]
+                if joint_type == gs.JOINT_TYPE.SPHERICAL or joint_type == gs.JOINT_TYPE.FREE:
+                    rot_offset = 3
+                    if joint_type == gs.JOINT_TYPE.SPHERICAL:
+                        rot_offset = 0
+                    rot = ti.Vector(
+                        [
+                            self.qpos[q_start + rot_offset + 0, i_b],
+                            self.qpos[q_start + rot_offset + 1, i_b],
+                            self.qpos[q_start + rot_offset + 2, i_b],
+                            self.qpos[q_start + rot_offset + 3, i_b],
+                        ]
+                    )
+                    ang = (
+                        ti.Vector(
+                            [
+                                self.dofs_state[dof_start + rot_offset + 0, i_b].vel,
+                                self.dofs_state[dof_start + rot_offset + 1, i_b].vel,
+                                self.dofs_state[dof_start + rot_offset + 2, i_b].vel,
+                            ]
+                        )
+                        * self._substep_dt
+                    )
+                    qrot = gu.ti_rotvec_to_quat(ang)
+                    rot = gu.ti_transform_quat_by_quat(qrot, rot)
+                    for j in range(4):
+                        self.qpos[q_start + j + rot_offset, i_b] = rot[j]
                 else:
                     for j in range(q_end - q_start):
                         self.qpos[q_start + j, i_b] = (

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -1442,3 +1442,30 @@ def test_equality_weld(gs_sim, mj_sim):
     qpos = gs_sim.rigid_solver.dofs_state.pos.to_numpy()[:, 0]
     qpos[0], qpos[1], qpos[2] = 0.1, 0.1, 0.1
     simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos, qvel, num_steps=300, atol=atol)
+
+
+@pytest.mark.parametrize("xml_path", ["xml/one_ball_joint.xml"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_one_ball_joint(gs_sim, mj_sim, atol):
+    # Disable all constraints and actuation
+    mj_sim.model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONSTRAINT
+    mj_sim.model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_ACTUATION
+    # gs_sim.rigid_solver.dofs_state.ctrl_mode.fill(gs.CTRL_MODE.FORCE)
+    gs_sim.rigid_solver._enable_collision = False
+    gs_sim.rigid_solver._enable_joint_limit = False
+    gs_sim.rigid_solver._disable_constraint = True
+
+    check_mujoco_model_consistency(gs_sim, mj_sim, atol=atol)
+
+    (gs_robot,) = gs_sim.entities
+    dof_bounds = gs_sim.rigid_solver.dofs_info.limit.to_numpy()
+    qpos = gs_sim.rigid_solver.qpos.to_numpy()[:, 0]
+    print("qpos", qpos.shape)
+    # init_simulators(gs_sim, mj_sim, qpos)
+    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, num_steps=300, atol=atol)
+    # for _ in range(100):
+    #     check_mujoco_data_consistency(gs_sim, mj_sim, atol=atol)
+    #     gs_sim.scene.step()
+    #     mj_sim.step()

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -1452,20 +1452,9 @@ def test_one_ball_joint(gs_sim, mj_sim, atol):
     # Disable all constraints and actuation
     mj_sim.model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONSTRAINT
     mj_sim.model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_ACTUATION
-    # gs_sim.rigid_solver.dofs_state.ctrl_mode.fill(gs.CTRL_MODE.FORCE)
     gs_sim.rigid_solver._enable_collision = False
     gs_sim.rigid_solver._enable_joint_limit = False
     gs_sim.rigid_solver._disable_constraint = True
 
     check_mujoco_model_consistency(gs_sim, mj_sim, atol=atol)
-
-    (gs_robot,) = gs_sim.entities
-    dof_bounds = gs_sim.rigid_solver.dofs_info.limit.to_numpy()
-    qpos = gs_sim.rigid_solver.qpos.to_numpy()[:, 0]
-    print("qpos", qpos.shape)
-    # init_simulators(gs_sim, mj_sim, qpos)
     simulate_and_check_mujoco_consistency(gs_sim, mj_sim, num_steps=300, atol=atol)
-    # for _ in range(100):
-    #     check_mujoco_data_consistency(gs_sim, mj_sim, atol=atol)
-    #     gs_sim.scene.step()
-    #     mj_sim.step()

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -1449,6 +1449,7 @@ def test_equality_weld(gs_sim, mj_sim):
     qpos[0], qpos[1], qpos[2] = 0.1, 0.1, 0.1
     simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos, qvel, num_steps=300, atol=atol)
 
+
 @pytest.mark.parametrize("xml_path", ["xml/one_ball_joint.xml"])
 @pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG])
 @pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
@@ -1461,9 +1462,9 @@ def test_one_ball_joint(gs_sim, mj_sim, atol):
     check_mujoco_model_consistency(gs_sim, mj_sim, atol=atol)
     simulate_and_check_mujoco_consistency(gs_sim, mj_sim, num_steps=300, atol=atol)
 
+
 @pytest.mark.parametrize("backend", [gs.cpu])
 def test_mesh_to_heightfield(show_viewer):
-
     ########################## create a scene ##########################
     scene = gs.Scene(
         show_viewer=show_viewer,

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -1451,9 +1451,6 @@ def test_equality_weld(gs_sim, mj_sim):
 def test_one_ball_joint(gs_sim, mj_sim, atol):
     # Disable all constraints and actuation
     mj_sim.model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONSTRAINT
-    mj_sim.model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_ACTUATION
-    gs_sim.rigid_solver._enable_collision = False
-    gs_sim.rigid_solver._enable_joint_limit = False
     gs_sim.rigid_solver._disable_constraint = True
 
     check_mujoco_model_consistency(gs_sim, mj_sim, atol=atol)


### PR DESCRIPTION
## Description

`qpos` for ball joint is represented by quaternion. Fix the time integration accordingly.

Try
```
pytest --pdb -v --vis tests/test_rigid_physics.py::test_one_ball_joint
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
