### PR TITLE
[FEATURE][BREAKING] Add maxvolume support for TetGen-based tetrahedralization, unify TetGen config handling, and add tests

### DIFF
--- a/genesis/engine/entities/fem_entity.py
+++ b/genesis/engine/entities/fem_entity.py
@@ -5,6 +5,7 @@ import torch
 import genesis as gs
 import genesis.utils.element as eu
 import genesis.utils.geom as gu
+import genesis.utils.mesh as mu
 from genesis.engine.states.cache import QueriedStates
 from genesis.engine.states.entities import FEMEntityState
 from genesis.utils.misc import to_gs_tensor
@@ -496,13 +497,5 @@ class FEMEntity(Entity):
 
     @property
     def tet_cfg(self):
-        tet_cfg = dict(
-            order=getattr(self.morph, "order", 1),
-            mindihedral=getattr(self.morph, "mindihedral", 10),
-            minratio=getattr(self.morph, "minratio", 1.1),
-            nobisect=getattr(self.morph, "nobisect", True),
-            quality=getattr(self.morph, "quality", True),
-            maxvolume=getattr(self.morph, "maxvolume", -1.0),
-            verbose=getattr(self.morph, "verbose", 0),
-        )
+        tet_cfg = mu.generate_tetgen_config_from_morph(self.morph)
         return tet_cfg

--- a/genesis/engine/entities/fem_entity.py
+++ b/genesis/engine/entities/fem_entity.py
@@ -502,6 +502,7 @@ class FEMEntity(Entity):
             minratio=getattr(self.morph, "minratio", 1.1),
             nobisect=getattr(self.morph, "nobisect", True),
             quality=getattr(self.morph, "quality", True),
+            maxvolume=getattr(self.morph, "maxvolume", -1.0),
             verbose=getattr(self.morph, "verbose", 0),
         )
         return tet_cfg

--- a/genesis/engine/entities/pbd_entity.py
+++ b/genesis/engine/entities/pbd_entity.py
@@ -299,15 +299,7 @@ class PBD3DEntity(PBDTetEntity):
             gs.raise_exception("Input mesh has zero volume.")
         self._mass = self._vmesh.volume * self.material.rho
 
-        tet_cfg = dict(
-            order=getattr(self.morph, "order", 1),
-            mindihedral=getattr(self.morph, "mindihedral", 10),
-            minratio=getattr(self.morph, "minratio", 1.1),
-            nobisect=getattr(self.morph, "nobisect", True),
-            quality=getattr(self.morph, "quality", True),
-            maxvolume=getattr(self.morph, "maxvolume", -1.0),
-            verbose=getattr(self.morph, "verbose", 0),
-        )
+        tet_cfg = mu.generate_tetgen_config_from_morph(self.morph)
         self._particles, self._elems = self._mesh.tetrahedralize(tet_cfg)
         self._edges = np.array(
             list(

--- a/genesis/engine/entities/pbd_entity.py
+++ b/genesis/engine/entities/pbd_entity.py
@@ -299,14 +299,16 @@ class PBD3DEntity(PBDTetEntity):
             gs.raise_exception("Input mesh has zero volume.")
         self._mass = self._vmesh.volume * self.material.rho
 
-        self._particles, self._elems = self._mesh.tetrahedralize(
+        tet_cfg = dict(
             order=getattr(self.morph, "order", 1),
             mindihedral=getattr(self.morph, "mindihedral", 10),
             minratio=getattr(self.morph, "minratio", 1.1),
             nobisect=getattr(self.morph, "nobisect", True),
             quality=getattr(self.morph, "quality", True),
+            maxvolume=getattr(self.morph, "maxvolume", -1.0),
             verbose=getattr(self.morph, "verbose", 0),
         )
+        self._particles, self._elems = self._mesh.tetrahedralize(tet_cfg)
         self._edges = np.array(
             list(
                 set(

--- a/genesis/engine/mesh.py
+++ b/genesis/engine/mesh.py
@@ -144,7 +144,7 @@ class Mesh(RBC):
         )
         self.clear_visuals()
 
-    def tetrahedralize(self, order, mindihedral, minratio, nobisect, quality, verbose):
+    def tetrahedralize(self, tet_cfg):
         """
         Tetrahedralize the mesh.
         """
@@ -152,9 +152,8 @@ class Mesh(RBC):
             self.verts, np.concatenate([np.full((self.faces.shape[0], 1), self.faces.shape[1]), self.faces], axis=1)
         )
         tet = tetgen.TetGen(pv_obj)
-        verts, elems = tet.tetrahedralize(
-            order=order, mindihedral=mindihedral, minratio=minratio, nobisect=nobisect, quality=quality, verbose=verbose
-        )
+        switches = mu.make_tetgen_switches(tet_cfg)
+        verts, elems = tet.tetrahedralize(switches=switches)
         # visualize_tet(tet, pv_obj, show_surface=False, plot_cell_qual=False)
         return verts, elems
 

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -16,6 +16,21 @@ These are independent of backend solver type and are shared by different solvers
 """
 
 
+class TetGenMixin(Options):
+    # FEM specific
+    order: int = 1
+
+    # Volumetric mesh entity
+    mindihedral: int = 10
+    minratio: float = 1.1
+    nobisect: bool = True
+    quality: bool = True
+    maxvolume: float = -1.0
+    verbose: int = 0
+
+    force_retet: bool = False
+
+
 @gs.assert_initialized
 class Morph(Options):
     """
@@ -51,19 +66,6 @@ class Morph(Options):
     collision: bool = True
     requires_jac_and_IK: bool = False
     is_free: bool = True
-
-    # FEM specific
-    order: int = 1
-
-    # Volumetric mesh entity
-    mindihedral: int = 10
-    minratio: float = 1.1
-    nobisect: bool = True
-    quality: bool = True
-    maxvolume: float = -1.0
-    verbose: int = 0
-
-    force_retet: bool = False
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -139,7 +141,7 @@ class Primitive(Morph):
     fixed: bool = False
 
 
-class Box(Primitive):
+class Box(Primitive, TetGenMixin):
     """
     Morph defined by a box shape.
 
@@ -209,7 +211,7 @@ class Box(Primitive):
                 gs.raise_exception("Invalid lower and upper corner.")
 
 
-class Cylinder(Primitive):
+class Cylinder(Primitive, TetGenMixin):
     """
     Morph defined by a cylinder shape.
 
@@ -255,7 +257,7 @@ class Cylinder(Primitive):
     radius: float = 0.5
 
 
-class Sphere(Primitive):
+class Sphere(Primitive, TetGenMixin):
     """
     Morph defined by a sphere shape.
 
@@ -452,7 +454,7 @@ class FileMorph(Morph):
         return f"<gs.morphs.{self.__class__.__name__}(file='{self.file}')>"
 
 
-class Mesh(FileMorph):
+class Mesh(FileMorph, TetGenMixin):
     """
     Morph loaded from a mesh file.
 

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -17,6 +17,10 @@ These are independent of backend solver type and are shared by different solvers
 
 
 class TetGenMixin(Options):
+    """
+    A mixin to introduce TetGen-related options into morph classes that support tetrahedralization using TetGen.
+    """
+
     # FEM specific
     order: int = 1
 

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -462,6 +462,8 @@ class Mesh(FileMorph):
         Whether to disable bisection during tetraheralization. Defaults to True. **This is only used for Volumetric Entity that requires tetraheralization.**
     quality : bool, optional
         Whether to improve quality during tetraheralization. Defaults to True. **This is only used for Volumetric Entity that requires tetraheralization.**
+    maxvolume : float, optional
+        The maximum tetrahedron volume. Defaults to -1.0 (no limit). **This is only used for Volumetric Entity that requires tetraheralization.**
     verbose : int, optional
         The verbosity level during tetraheralization. Defaults to 0. **This is only used for Volumetric Entity that requires tetraheralization.**
     force_retet : bool, optional
@@ -484,6 +486,7 @@ class Mesh(FileMorph):
     minratio: float = 1.1
     nobisect: bool = True
     quality: bool = True
+    maxvolume: float = -1.0
     verbose: int = 0
 
     force_retet: bool = False

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -52,6 +52,19 @@ class Morph(Options):
     requires_jac_and_IK: bool = False
     is_free: bool = True
 
+    # FEM specific
+    order: int = 1
+
+    # Volumetric mesh entity
+    mindihedral: int = 10
+    minratio: float = 1.1
+    nobisect: bool = True
+    quality: bool = True
+    maxvolume: float = -1.0
+    verbose: int = 0
+
+    force_retet: bool = False
+
     def __init__(self, **data):
         super().__init__(**data)
         if self.pos is not None:
@@ -156,6 +169,22 @@ class Box(Primitive):
         Whether this morph, if created as `RigidEntity`, requires jacobian and inverse kinematics. Defaults to False. **This is only used for RigidEntity.**
     fixed : bool, optional
         Whether the baselink of the entity should be fixed. Defaults to False. **This is only used for RigidEntity.**
+    order : int, optional
+        The order of the FEM mesh. Defaults to 1. **This is only used for FEMEntity.**
+    mindihedral : int, optional
+        The minimum dihedral angle in degrees during tetraheralization. Defaults to 10. **This is only used for Volumetric Entity that requires tetraheralization.**
+    minratio : float, optional
+        The minimum tetrahedron quality ratio during tetraheralization. Defaults to 1.1. **This is only used for Volumetric Entity that requires tetraheralization.**
+    nobisect : bool, optional
+        Whether to disable bisection during tetraheralization. Defaults to True. **This is only used for Volumetric Entity that requires tetraheralization.**
+    quality : bool, optional
+        Whether to improve quality during tetraheralization. Defaults to True. **This is only used for Volumetric Entity that requires tetraheralization.**
+    maxvolume : float, optional
+        The maximum tetrahedron volume. Defaults to -1.0 (no limit). **This is only used for Volumetric Entity that requires tetraheralization.**
+    verbose : int, optional
+        The verbosity level during tetraheralization. Defaults to 0. **This is only used for Volumetric Entity that requires tetraheralization.**
+    force_retet : bool, optional
+        Whether to force re-tetraheralization. Defaults to False. **This is only used for Volumetric Entity that requires tetraheralization.**
     """
 
     lower: Optional[tuple] = None
@@ -204,6 +233,22 @@ class Cylinder(Primitive):
         Whether this morph, if created as `RigidEntity`, requires jacobian and inverse kinematics. Defaults to False. **This is only used for RigidEntity.**
     fixed : bool, optional
         Whether the baselink of the entity should be fixed. Defaults to False. **This is only used for RigidEntity.**
+    order : int, optional
+        The order of the FEM mesh. Defaults to 1. **This is only used for FEMEntity.**
+    mindihedral : int, optional
+        The minimum dihedral angle in degrees during tetraheralization. Defaults to 10. **This is only used for Volumetric Entity that requires tetraheralization.**
+    minratio : float, optional
+        The minimum tetrahedron quality ratio during tetraheralization. Defaults to 1.1. **This is only used for Volumetric Entity that requires tetraheralization.**
+    nobisect : bool, optional
+        Whether to disable bisection during tetraheralization. Defaults to True. **This is only used for Volumetric Entity that requires tetraheralization.**
+    quality : bool, optional
+        Whether to improve quality during tetraheralization. Defaults to True. **This is only used for Volumetric Entity that requires tetraheralization.**
+    maxvolume : float, optional
+        The maximum tetrahedron volume. Defaults to -1.0 (no limit). **This is only used for Volumetric Entity that requires tetraheralization.**
+    verbose : int, optional
+        The verbosity level during tetraheralization. Defaults to 0. **This is only used for Volumetric Entity that requires tetraheralization.**
+    force_retet : bool, optional
+        Whether to force re-tetraheralization. Defaults to False. **This is only used for Volumetric Entity that requires tetraheralization.**
     """
 
     height: float = 1.0
@@ -232,6 +277,22 @@ class Sphere(Primitive):
         Whether this morph, if created as `RigidEntity`, requires jacobian and inverse kinematics. Defaults to False. **This is only used for RigidEntity.**
     fixed : bool, optional
         Whether the baselink of the entity should be fixed. Defaults to False. **This is only used for RigidEntity.**
+    order : int, optional
+        The order of the FEM mesh. Defaults to 1. **This is only used for FEMEntity.**
+    mindihedral : int, optional
+        The minimum dihedral angle in degrees during tetraheralization. Defaults to 10. **This is only used for Volumetric Entity that requires tetraheralization.**
+    minratio : float, optional
+        The minimum tetrahedron quality ratio during tetraheralization. Defaults to 1.1. **This is only used for Volumetric Entity that requires tetraheralization.**
+    nobisect : bool, optional
+        Whether to disable bisection during tetraheralization. Defaults to True. **This is only used for Volumetric Entity that requires tetraheralization.**
+    quality : bool, optional
+        Whether to improve quality during tetraheralization. Defaults to True. **This is only used for Volumetric Entity that requires tetraheralization.**
+    maxvolume : float, optional
+        The maximum tetrahedron volume. Defaults to -1.0 (no limit). **This is only used for Volumetric Entity that requires tetraheralization.**
+    verbose : int, optional
+        The verbosity level during tetraheralization. Defaults to 0. **This is only used for Volumetric Entity that requires tetraheralization.**
+    force_retet : bool, optional
+        Whether to force re-tetraheralization. Defaults to False. **This is only used for Volumetric Entity that requires tetraheralization.**
     """
 
     radius: float = 0.5
@@ -477,19 +538,6 @@ class Mesh(FileMorph):
     fixed: bool = False
     group_by_material: bool = True
     merge_submeshes_for_collision: bool = True
-
-    # FEM specific
-    order: int = 1
-
-    # Volumetric mesh entity
-    mindihedral: int = 10
-    minratio: float = 1.1
-    nobisect: bool = True
-    quality: bool = True
-    maxvolume: float = -1.0
-    verbose: int = 0
-
-    force_retet: bool = False
 
 
 class MeshSet(Mesh):

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -816,7 +816,7 @@ def create_plane(size=1e3, color=None, normal=(0, 0, 1)):
 
 
 def generate_tetgen_config_from_morph(morph):
-    if not isinstance(morph, gs.options.morphs.Morph):
+    if not isinstance(morph, gs.options.morphs.TetGenMixin):
         raise TypeError(f"Expected instance of Morph, got {type(morph).__name__}")
     return dict(
         order=morph.order,

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -817,7 +817,9 @@ def create_plane(size=1e3, color=None, normal=(0, 0, 1)):
 
 def generate_tetgen_config_from_morph(morph):
     if not isinstance(morph, gs.options.morphs.TetGenMixin):
-        raise TypeError(f"Expected instance of Morph, got {type(morph).__name__}")
+        raise TypeError(
+            f"Expected an instance of a class that inherits from TetGenMixin, but got an instance of {type(morph).name}."
+        )
     return dict(
         order=morph.order,
         mindihedral=morph.mindihedral,

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -816,6 +816,7 @@ def create_plane(size=1e3, color=None, normal=(0, 0, 1)):
 
 
 def make_tetgen_switches(cfg):
+    """Build a TetGen switches string from a config dict."""
     flags = ["p"]
 
     if cfg.get("quality", True):
@@ -846,14 +847,11 @@ def tetrahedralize_mesh(mesh, tet_cfg):
         mesh.vertices, np.concatenate([np.full((mesh.faces.shape[0], 1), mesh.faces.shape[1]), mesh.faces], axis=1)
     )
     tet = tetgen.TetGen(pv_obj)
-    # NOTE: Use the 'switches' string to pass options directly,
-    # because the tetgen wrapper may ignore some parameters (e.g., maxvolume).
-    # See: https://github.com/pyvista/tetgen/issues/24
-    # verts, elems = tet.tetrahedralize(**tet_cfg)
+    # Build and apply the switches string directly, since
+    # the Python wrapper sometimes ignores certain kwargs
+    # (e.g. maxvolume). See: https://github.com/pyvista/tetgen/issues/24
     switches = make_tetgen_switches(tet_cfg)
-    print(switches)
     verts, elems = tet.tetrahedralize(switches=switches)
-    print(verts.shape, elems.shape)
     # visualize_tet(tet, pv_obj, show_surface=False, plot_cell_qual=False)
     return verts, elems
 

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -815,6 +815,18 @@ def create_plane(size=1e3, color=None, normal=(0, 0, 1)):
     return mesh
 
 
+def generate_tetgen_config_from_morph(morph):
+    return dict(
+        order=getattr(morph, "order", 1),
+        mindihedral=getattr(morph, "mindihedral", 10),
+        minratio=getattr(morph, "minratio", 1.1),
+        nobisect=getattr(morph, "nobisect", True),
+        quality=getattr(morph, "quality", True),
+        maxvolume=getattr(morph, "maxvolume", -1.0),
+        verbose=getattr(morph, "verbose", 0),
+    )
+
+
 def make_tetgen_switches(cfg):
     """Build a TetGen switches string from a config dict."""
     flags = ["p"]

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -816,14 +816,16 @@ def create_plane(size=1e3, color=None, normal=(0, 0, 1)):
 
 
 def generate_tetgen_config_from_morph(morph):
+    if not isinstance(morph, gs.options.morphs.Morph):
+        raise TypeError(f"Expected instance of Morph, got {type(morph).__name__}")
     return dict(
-        order=getattr(morph, "order", 1),
-        mindihedral=getattr(morph, "mindihedral", 10),
-        minratio=getattr(morph, "minratio", 1.1),
-        nobisect=getattr(morph, "nobisect", True),
-        quality=getattr(morph, "quality", True),
-        maxvolume=getattr(morph, "maxvolume", -1.0),
-        verbose=getattr(morph, "verbose", 0),
+        order=morph.order,
+        mindihedral=morph.mindihedral,
+        minratio=morph.minratio,
+        nobisect=morph.nobisect,
+        quality=morph.quality,
+        maxvolume=morph.maxvolume,
+        verbose=morph.verbose,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,9 +264,8 @@ def gs_sim(
 
 
 @pytest.fixture
-def box_obj_path(tmp_path):
-    """Fixture that generates a temporary cube .obj file"""
-    cx, cy, cz = (0.0, 0.0, 0.0)  # Center of the cube
+def cube_verts_and_faces():
+    cx, cy, cz = (0.0, 0.0, 0.0)
     edge_length = 1.0
 
     h = edge_length / 2.0
@@ -290,6 +289,13 @@ def box_obj_path(tmp_path):
         (3, 4, 8, 7),
         (4, 1, 5, 8),
     ]
+    return verts, faces
+
+
+@pytest.fixture
+def box_obj_path(tmp_path, cube_verts_and_faces):
+    """Fixture that generates a temporary cube .obj file"""
+    verts, faces = cube_verts_and_faces
 
     filename = str(tmp_path / f"{uuid.uuid4()}.obj")
     with open(filename, "w", encoding="utf-8") as f:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import gc
 import os
 import sys
+import uuid
 from enum import Enum
 
 import psutil
@@ -260,3 +261,42 @@ def gs_sim(
     scene.build()
 
     return gs_sim
+
+
+@pytest.fixture
+def box_obj_path(tmp_path):
+    """Fixture that generates a temporary cube .obj file"""
+    cx, cy, cz = (0.0, 0.0, 0.0)  # Center of the cube
+    edge_length = 1.0
+
+    h = edge_length / 2.0
+
+    verts = [
+        (cx - h, cy - h, cz - h),  # v0
+        (cx + h, cy - h, cz - h),  # v1
+        (cx + h, cy + h, cz - h),  # v2
+        (cx - h, cy + h, cz - h),  # v3
+        (cx - h, cy - h, cz + h),  # v4
+        (cx + h, cy - h, cz + h),  # v5
+        (cx + h, cy + h, cz + h),  # v6
+        (cx - h, cy + h, cz + h),  # v7
+    ]
+
+    faces = [
+        (1, 2, 3, 4),
+        (5, 6, 7, 8),
+        (1, 2, 6, 5),
+        (2, 3, 7, 6),
+        (3, 4, 8, 7),
+        (4, 1, 5, 8),
+    ]
+
+    filename = str(tmp_path / f"{uuid.uuid4()}.obj")
+    with open(filename, "w", encoding="utf-8") as f:
+        for x, y, z in verts:
+            f.write(f"v {x:.6f} {y:.6f} {z:.6f}\n")
+        f.write("\n")
+        for a, b, c, d in faces:
+            f.write(f"f {a} {b} {c} {d}\n")
+
+    return filename

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -292,12 +292,11 @@ def cube_verts_and_faces():
 
 
 @pytest.fixture(scope="session")
-def box_obj_path(tmp_path_factory, cube_verts_and_faces):
+def box_obj_path(asset_tmp_path, cube_verts_and_faces):
     """Fixture that generates a temporary cube .obj file"""
     verts, faces = cube_verts_and_faces
 
-    tmp_path = tmp_path_factory.mktemp("obj_fixtures")
-    filename = str(tmp_path / f"fixture_box_obj_path.obj")
+    filename = str(asset_tmp_path / f"fixture_box_obj_path.obj")
     with open(filename, "w", encoding="utf-8") as f:
         for x, y, z in verts:
             f.write(f"v {x:.6f} {y:.6f} {z:.6f}\n")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import gc
 import os
 import sys
-import uuid
 from enum import Enum
 
 import psutil
@@ -297,7 +296,7 @@ def box_obj_path(tmp_path, cube_verts_and_faces):
     """Fixture that generates a temporary cube .obj file"""
     verts, faces = cube_verts_and_faces
 
-    filename = str(tmp_path / f"{uuid.uuid4()}.obj")
+    filename = str(tmp_path / f"fixture_box_obj_path.obj")
     with open(filename, "w", encoding="utf-8") as f:
         for x, y, z in verts:
             f.write(f"v {x:.6f} {y:.6f} {z:.6f}\n")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,7 +262,7 @@ def gs_sim(
     return gs_sim
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def cube_verts_and_faces():
     cx, cy, cz = (0.0, 0.0, 0.0)
     edge_length = 1.0
@@ -291,11 +291,12 @@ def cube_verts_and_faces():
     return verts, faces
 
 
-@pytest.fixture
-def box_obj_path(tmp_path, cube_verts_and_faces):
+@pytest.fixture(scope="session")
+def box_obj_path(tmp_path_factory, cube_verts_and_faces):
     """Fixture that generates a temporary cube .obj file"""
     verts, faces = cube_verts_and_faces
 
+    tmp_path = tmp_path_factory.mktemp("obj_fixtures")
     filename = str(tmp_path / f"fixture_box_obj_path.obj")
     with open(filename, "w", encoding="utf-8") as f:
         for x, y, z in verts:

--- a/tests/test_fem.py
+++ b/tests/test_fem.py
@@ -57,94 +57,26 @@ def test_multiple_fem_entities(fem_material, show_viewer):
 
 
 @pytest.mark.parametrize("backend", [gs.cpu])
-def test_interior_tetrahedralized_vertex(fem_material, show_viewer, tmp_path):
+def test_interior_tetrahedralized_vertex(fem_material, show_viewer, box_obj_path, cube_verts_and_faces):
     """
-    Test tetrahedralization of a FEM entity with a mesh shape that introduces
+    Test tetrahedralization of a FEM entity with a small maxvolume value that introduces
     internal vertices during tetrahedralization:
       1. Verify all surface vertices lie exactly on the original quad faces of the mesh.
       2. Ensure the visualizer's mesh triangles match the FEM entity's surface triangles.
     """
-
-    def _write_extruded_box(center, large_length, small_length, filename):
-        cx, cy, cz = center
-        hL = large_length / 2.0
-        hl = small_length / 2.0
-
-        z0 = cz + hL
-        z1 = z0 + small_length
-
-        verts = [
-            # Vertices of large cube
-            (cx - hL, cy - hL, cz - hL),  # v1
-            (cx + hL, cy - hL, cz - hL),  # v2
-            (cx + hL, cy + hL, cz - hL),  # v3
-            (cx - hL, cy + hL, cz - hL),  # v4
-            (cx - hL, cy - hL, cz + hL),  # v5
-            (cx + hL, cy - hL, cz + hL),  # v6
-            (cx + hL, cy + hL, cz + hL),  # v7
-            (cx - hL, cy + hL, cz + hL),  # v8
-            # Vertices of a extruded small cube on +Z surface of the large cube
-            (cx - hl, cy - hl, z0),  # v9
-            (cx + hl, cy - hl, z0),  # v10
-            (cx + hl, cy + hl, z0),  # v11
-            (cx - hl, cy + hl, z0),  # v12
-            # Other vertices of the extruded small cube
-            (cx - hl, cy - hl, z1),  # v13
-            (cx + hl, cy - hl, z1),  # v14
-            (cx + hl, cy + hl, z1),  # v15
-            (cx - hl, cy + hl, z1),  # v16
-        ]
-
-        faces = []
-
-        # Large cube
-        faces += [
-            (1, 2, 3, 4),  # -Z
-            (1, 2, 6, 5),  # -Y
-            (2, 3, 7, 6),  # +X
-            (3, 4, 8, 7),  # +Y
-            (4, 1, 5, 8),  # -X
-        ]
-
-        # Large cube (+Z)
-        faces += [
-            (5, 6, 10, 9),
-            (6, 7, 11, 10),
-            (7, 8, 12, 11),
-            (8, 5, 9, 12),
-        ]
-
-        # Small cube (+Z)
-        faces += [(9, 10, 14, 13), (10, 11, 15, 14), (11, 12, 16, 15), (12, 9, 13, 16), (13, 14, 15, 16)]
-
-        # Write obj file
-        with open(filename, "w", encoding="utf-8") as f:
-            for x, y, z in verts:
-                f.write(f"v {x:.6f} {y:.6f} {z:.6f}\n")
-            f.write("\n")
-            for face in faces:
-                f.write("f " + " ".join(str(idx) for idx in face) + "\n")
-
-        return verts, faces
+    verts, faces = cube_verts_and_faces
 
     scene = gs.Scene(
         show_viewer=show_viewer,
     )
 
-    obj_path = tmp_path / "fem.obj"
-    verts, faces = _write_extruded_box(
-        center=[0.0, 0.0, 0.0],
-        large_length=1.0,
-        small_length=0.1,
-        filename=str(obj_path),
-    )
-
     fem = scene.add_entity(
         morph=gs.morphs.Mesh(
-            file=str(obj_path),
+            file=box_obj_path,
             nobisect=False,
             minratio=1.5,
             verbose=1,
+            maxvolume=0.01,
         ),
         material=fem_material,
     )
@@ -154,6 +86,9 @@ def test_interior_tetrahedralized_vertex(fem_material, show_viewer, tmp_path):
     state = fem.get_state()
     vertices = state.pos.cpu().numpy()
     surface_indices = np.unique(fem.surface_triangles)
+
+    # Ensure there are interior vertices; this is a prerequisite for this test
+    assert surface_indices.size < vertices.shape[0]
 
     # Verify each surface vertex lies on the original surface mesh
     def _point_on_surface(p, verts, faces, tol=1e-6):

--- a/tests/test_fem.py
+++ b/tests/test_fem.py
@@ -128,8 +128,6 @@ def test_interior_tetrahedralized_vertex(fem_material, show_viewer, tmp_path):
         return verts, faces
 
     scene = gs.Scene(
-        sim_options=gs.options.SimOptions(),
-        fem_options=gs.options.FEMOptions(),
         show_viewer=show_viewer,
     )
 
@@ -241,8 +239,6 @@ def test_interior_tetrahedralized_vertex(fem_material, show_viewer, tmp_path):
 def test_maxvolume(fem_material, show_viewer, box_obj_path):
     """Test that imposing a maximum element volume constraint produces a finer mesh (i.e., more elements)."""
     scene = gs.Scene(
-        sim_options=gs.options.SimOptions(),
-        fem_options=gs.options.FEMOptions(),
         show_viewer=show_viewer,
     )
 

--- a/tests/test_fem.py
+++ b/tests/test_fem.py
@@ -235,3 +235,30 @@ def test_interior_tetrahedralized_vertex(fem_material, show_viewer, tmp_path):
         "FEM entity surface triangles and visualizer mesh triangles do not match.\n"
         f"Differences: {set(entity_tris) ^ set(viz_tris)}"
     )
+
+
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_maxvolume(fem_material, show_viewer, box_obj_path):
+    """Test that imposing a maximum element volume constraint produces a finer mesh (i.e., more elements)."""
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(),
+        fem_options=gs.options.FEMOptions(),
+        show_viewer=show_viewer,
+    )
+
+    # Mesh without any maximum-element-volume constraint
+    fem1 = scene.add_entity(
+        morph=gs.morphs.Mesh(file=box_obj_path, nobisect=False, verbose=1),
+        material=fem_material,
+    )
+
+    # Mesh with maximum element volume limited to 0.01
+    fem2 = scene.add_entity(
+        morph=gs.morphs.Mesh(file=box_obj_path, nobisect=False, maxvolume=0.01, verbose=1),
+        material=fem_material,
+    )
+
+    assert len(fem1.elems) < len(fem2.elems), (
+        f"Mesh with maxvolume=0.01 generated {len(fem2.elems)} elements; "
+        f"expected more than {len(fem1.elems)} elements without a volume limit."
+    )

--- a/tests/test_pbd.py
+++ b/tests/test_pbd.py
@@ -29,7 +29,7 @@ def test_maxvolume(pbd_material, show_viewer, box_obj_path):
         material=pbd_material,
     )
 
-    # Mesh with maximum element volume limited to 0.01
+    # Mesh with maximum element volume limited to 0.001
     pbd2 = scene.add_entity(
         morph=gs.morphs.Mesh(file=box_obj_path, nobisect=False, maxvolume=0.001, verbose=1),
         material=pbd_material,

--- a/tests/test_pbd.py
+++ b/tests/test_pbd.py
@@ -1,0 +1,41 @@
+import uuid
+
+import numpy as np
+import pytest
+
+import genesis as gs
+
+
+@pytest.fixture(scope="session")
+def pbd_material():
+    """Fixture for common FEM material properties"""
+    return gs.materials.PBD.Elastic()
+
+
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_maxvolume(pbd_material, show_viewer, box_obj_path):
+    """Test that imposing a maximum element volume constraint produces a finer mesh (i.e., more elements)."""
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(),
+        pbd_options=gs.options.PBDOptions(
+            particle_size=0.1,
+        ),
+        show_viewer=show_viewer,
+    )
+
+    # Mesh without any maximum-element-volume constraint
+    pbd1 = scene.add_entity(
+        morph=gs.morphs.Mesh(file=box_obj_path, nobisect=False, verbose=1),
+        material=pbd_material,
+    )
+
+    # Mesh with maximum element volume limited to 0.01
+    pbd2 = scene.add_entity(
+        morph=gs.morphs.Mesh(file=box_obj_path, nobisect=False, maxvolume=0.001, verbose=1),
+        material=pbd_material,
+    )
+
+    assert pbd1.n_elems < pbd2.n_elems, (
+        f"Mesh with maxvolume=0.01 generated {pbd2.n_elems} elements; "
+        f"expected more than {pbd1.n_elems} elements without a volume limit."
+    )

--- a/tests/test_pbd.py
+++ b/tests/test_pbd.py
@@ -16,7 +16,6 @@ def pbd_material():
 def test_maxvolume(pbd_material, show_viewer, box_obj_path):
     """Test that imposing a maximum element volume constraint produces a finer mesh (i.e., more elements)."""
     scene = gs.Scene(
-        sim_options=gs.options.SimOptions(),
         pbd_options=gs.options.PBDOptions(
             particle_size=0.1,
         ),


### PR DESCRIPTION
## Description
This PR introduces a `maxvolume` option that lets users cap the maximum tetrahedron volume generated by TetGen.
While adding this feature, the TetGen pipeline was refactored as follows:

* **Using switch string** – A new `utils.mesh.make_tetgen_switches()` helper was introduced to convert a config dict into the canonical TetGen switch string. This addresses an issue where the existing TetGen wrapper could silently ignore options like `maxvolume`.

* **Entity simplification** – Previously, FEM and PBD entities had separate implementations for generating TetGen configurations from a morph instance. These were unified to use a single helper (`utils.mesh.generate_tetgen_config_from_morph`), making behaviour consistent across solvers.

* **Public API change (BREAKING)** – `Mesh.tetrahedralize()` used in `PBD3DEntity` was updated to match FEM by taking a single `tet_cfg` dict instead of a long list of positional kwargs. All in-tree callers were updated accordingly.

* **Tests** –  
  * `tests/test_fem.py::test_maxvolume`  
  * `tests/test_pbd.py::test_maxvolume`  
  verify that tightening `maxvolume` indeed produces a denser mesh.
  * A temporary cube OBJ fixture (`box_obj_path`) was added so that it can be reusable across other tests that requires an arbitrary `Mesh` instance.


## Related Issue
Resolves https://github.com/Genesis-Embodied-AI/Genesis/issues/1087

## Motivation and Context
* Users could previously control mesh quality but not density; large objects were often under-tessellated, hurting simulation accuracy.

## How Has This Been / Can This Be Tested?
* New pytest cases (see above) ensure that the element count increases when small `maxvolume` is set.
* I have manually inspected tetrahedrons introduced with `maxvolume=0.01` and without it (nolimit) as shown in the following screenshot.

## Screenshots (if appropriate):

![finer_tetra](https://github.com/user-attachments/assets/3252e2e9-8cd9-4354-af0b-c64937911089)

* Edge length of the both cube is 1.
* Left cube is tetrahedralized without `maxvolume` option.
* Right cube is tetrahedralized with `maxvolume=0.01` option.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
