### PR TITLE
[BUG FIX] draw_debug_path for tensors allocated on GPU or CPU

### DIFF
--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -987,8 +987,14 @@ class Scene(RBC):
 
             for i in range(N_new):
                 pos, quat = entity.forward_kinematics(qposs[indices[i]])
-                Ts[i] = gu.trans_quat_to_T(pos[link_idx], quat[link_idx])
-
+                trans = gu.trans_quat_to_T(pos[link_idx], quat[link_idx])
+                if isinstance(trans, torch.Tensor):
+                    if trans.get_device() == -1:
+                        Ts[i] = trans
+                    else:
+                        Ts[i] = trans.cpu()
+                else:
+                    Ts[i] = trans
             return self._visualizer.context.draw_debug_frames(
                 Ts, axis_length=frame_scaling * 0.1, origin_size=0.001, axis_radius=frame_scaling * 0.005
             )


### PR DESCRIPTION
## Description
Add supports for both CPU and GPU tensors. Originally when tensors are hosted on GPU the function "draw_debug_path" breaks as the current implementation tries to allocate a tensor to a numpy array. That only works when tensors are hosted on CPU instead of GPU. 

##To Reproduce
Run example IK_motion_planning_grasp.py

##Expected behavior
The function draw_debug_path must render/display the path independently of where tensors are originally stored (CPU or GPU)
 
## Related Issue
Resolves Genesis-Embodied-AI/Genesis#

## Motivation and Context

## How Has This Been / Can This Be Tested?
Being able to execute IK_motion_planning_grasp.py when running with GPU and CPU


## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

