### PR TITLE
[MISC] Relax pydantic version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.10,<3.13"
 dependencies = [
     "psutil",
     "taichi >= 1.7.2",
-    "pydantic == 2.7.1",
+    "pydantic >= 2.7.1",
     "numpy >= 1.26.4",
     "trimesh",
     "scipy >= 1.14",


### PR DESCRIPTION
## Description

Remove the version pin on `pydantic`.

## Motivation and Context

Ease interoperability with other packages/dependencies.

## How Has This Been / Can This Be Tested?

`uv pip install -e ".[dev]"` shows:

```
 + pydantic==2.11.4
 + pydantic-core==2.33.2
```

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
