### PR TITLE
[BUG FIX] More robust equality parsing. Refactor MJCF parsing.

### DIFF
--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -1419,7 +1419,10 @@ def test_urdf_mimic_panda(show_viewer, tol):
     )
 
     hand = scene.add_entity(
-        gs.morphs.URDF(file="urdf/panda_bullet/hand.urdf"),
+        gs.morphs.URDF(
+            file="urdf/panda_bullet/hand.urdf",
+            fixed=True,
+        ),
     )
     scene.build()
 


### PR DESCRIPTION
## Description

This PR replaces equality constraint object indices (either joint or link depending on constraint type) by names at parser-level. Mapping from names to indices is moved at RigidEntity-level. 

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/1143

## Motivation and Context

Equality constraints are holding "references" to the "objects" they are affecting, e.g. bodies, joints, tendons...etc Currently, these references are the indices in RigidEntity data structure. This is problematic, because the actual data structure is not available when parsing robot description files (URDF, MJCF), which means that it is necessary to reverse-engineering RigidEntity within the parsers to guess what should be the right indices. This is problematic because it is error-prone. Ideally, the parser can be order independent and therefore agnostic to link and joint processing that is happening internally in RigidEntity.

## How Has This Been / Can This Be Tested?

Running the existing unit tests successfully. It would be nice to add a new unit test for this one.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
