### PR TITLE
[BUG FIX] Unified scene loading for MJCF and URDF files.

### DIFF
--- a/examples/rigid/grasp_bottle.py
+++ b/examples/rigid/grasp_bottle.py
@@ -78,6 +78,8 @@ def main():
     for waypoint in path:
         franka.control_dofs_position(waypoint)
         scene.step()
+    for i in range(30):
+        scene.step()
 
     # reach
     qpos = franka.inverse_kinematics(

--- a/genesis/engine/entities/drone_entity.py
+++ b/genesis/engine/entities/drone_entity.py
@@ -12,8 +12,8 @@ from .rigid_entity import RigidEntity
 
 @ti.data_oriented
 class DroneEntity(RigidEntity):
-    def _load_URDF(self, morph, surface):
-        super()._load_URDF(morph, surface)
+    def _load_scene(self, morph, surface):
+        super()._load_scene(morph, surface)
 
         # additional drone specific attributes
         properties = ET.parse(os.path.join(mu.get_assets_dir(), morph.file)).getroot()[0].attrib

--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -235,17 +235,11 @@ class RigidGeom(RBC):
         self.vert_neighbor_start = gsd_dict["vert_neighbor_start"]
 
     def _compute_sd(self, query_points):
-        try:
-            sd, _, _ = igl.signed_distance(query_points, self._sdf_verts, self._sdf_faces)
-        except:
-            sd, _, _, _ = igl.signed_distance(query_points, self._sdf_verts, self._sdf_faces)
+        sd, *_ = igl.signed_distance(query_points, self._sdf_verts, self._sdf_faces)
         return sd
 
     def _compute_closest_verts(self, query_points):
-        try:
-            _, closest_faces, _ = igl.signed_distance(query_points, self._init_verts, self._init_faces)
-        except:
-            _, closest_faces, _, _ = igl.signed_distance(query_points, self._init_verts, self._init_faces)
+        _, closest_faces, *_ = igl.signed_distance(query_points, self._init_verts, self._init_faces)
         verts_ids = self._init_faces[closest_faces]
         verts_ids = verts_ids[
             np.arange(len(query_points)).astype(int),

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -27,6 +27,7 @@ from genesis.options import (
 from genesis.options.renderers import Rasterizer, Renderer
 from genesis.repr_base import RBC
 from genesis.utils.tools import FPSTracker
+from genesis.utils.misc import redirect_libc_stderr
 from genesis.vis import Visualizer
 
 
@@ -592,7 +593,8 @@ class Scene(RBC):
             self._parallelize(n_envs, env_spacing, n_envs_per_row, center_envs_at_origin)
 
             # simulator
-            self._sim.build()
+            with open(os.devnull, "w") as stderr, redirect_libc_stderr(stderr):
+                self._sim.build()
 
             # reset state
             self._reset()

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -1,13 +1,13 @@
+import os
+
 import numpy as np
 import torch
 
 import genesis as gs
+import genesis.utils.geom as gu
 from genesis.engine.entities.base_entity import Entity
 from genesis.engine.force_fields import ForceField
 from genesis.engine.materials.base import Material
-from genesis.options.morphs import Morph
-from genesis.options.surfaces import Surface
-import genesis.utils.geom as gu
 from genesis.engine.entities import Emitter
 from genesis.engine.simulator import Simulator
 from genesis.options import (
@@ -24,6 +24,8 @@ from genesis.options import (
     ViewerOptions,
     VisOptions,
 )
+from genesis.options.morphs import Morph
+from genesis.options.surfaces import Surface
 from genesis.options.renderers import Rasterizer, Renderer
 from genesis.repr_base import RBC
 from genesis.utils.tools import FPSTracker

--- a/genesis/engine/solvers/rigid/collider_decomp.py
+++ b/genesis/engine/solvers/rigid/collider_decomp.py
@@ -83,10 +83,10 @@ class Collider:
             links_parent_idx = links_parent_idx[:, 0]
             links_is_fixed = links_is_fixed[:, 0]
         n_possible_pairs = 0
-        for i in range(self._solver.n_geoms):
-            for j in range(i + 1, self._solver.n_geoms):
-                i_la = geoms_link_idx[i]
-                i_lb = geoms_link_idx[j]
+        for i_ga in range(self._solver.n_geoms):
+            for i_gb in range(i_ga + 1, self._solver.n_geoms):
+                i_la = geoms_link_idx[i_ga]
+                i_lb = geoms_link_idx[i_gb]
 
                 # geoms in the same link
                 if i_la == i_lb:
@@ -103,7 +103,9 @@ class Collider:
                     continue
 
                 # contype and conaffinity
-                if not ((geoms_contype[i] & geoms_conaffinity[j]) or (geoms_contype[j] & geoms_conaffinity[i])):
+                if not (
+                    (geoms_contype[i_ga] & geoms_conaffinity[i_gb]) or (geoms_contype[i_gb] & geoms_conaffinity[i_ga])
+                ):
                     continue
 
                 # pair of fixed links wrt the world
@@ -700,6 +702,7 @@ class Collider:
         i_lb = self._solver.geoms_info[i_gb].link_idx
         I_la = [i_la, i_b] if ti.static(self._solver._options.batch_links_info) else i_la
         I_lb = [i_lb, i_b] if ti.static(self._solver._options.batch_links_info) else i_lb
+
         is_valid = True
 
         # geoms in the same link

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -2007,9 +2007,10 @@ class RigidSolver(Solver):
 
                 i_r = self.links_info[I_l].root_idx
                 if i_l == i_r:
-                    self.links_state[i_l, i_b].root_COM = (
-                        self.links_state[i_l, i_b].root_COM / self.links_state[i_l, i_b].mass_sum
-                    )
+                    if self.links_state[i_l, i_b].mass_sum > 0.0:
+                        self.links_state[i_l, i_b].root_COM = (
+                            self.links_state[i_l, i_b].root_COM / self.links_state[i_l, i_b].mass_sum
+                        )
 
             ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.ALL)
             for i_l in range(self.n_links):

--- a/genesis/logging/logger.py
+++ b/genesis/logging/logger.py
@@ -129,7 +129,6 @@ class Logger:
             self._logger.critical(message)
 
     def raw(self, message):
-
         self._stream.write(self._formatter.extra_fmt(message))
         self._stream.flush()
         if message.endswith("\n"):

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -775,8 +775,6 @@ class Drone(FileMorph):
         Whether the entity needs to be visualized. Set it to False if you need a invisible object only for collision purposes. Defaults to True. `visualization` and `collision` cannot both be False.
     collision : bool, optional
         **NB**: Drone doesn't support collision checking for now.
-    fixed : bool, optional
-        Whether the baselink of the entity should be fixed. Defaults to False.
     prioritize_urdf_material : bool, optional
         Sometimes a geom in a urdf file will be assigned a color, and the geom asset file also contains its own visual material. This parameter controls whether to prioritize the URDF-defined material over the asset's own material. Defaults to False.
     model : str, optional
@@ -792,7 +790,6 @@ class Drone(FileMorph):
     """
 
     model: str = "CF2X"
-    fixed: bool = False
     prioritize_urdf_material: bool = False
     COM_link_name: str = "center_of_mass_link"
     propellers_link_names: Optional[Sequence[str]] = None

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -190,7 +190,7 @@ def compute_sdf_data(mesh, res):
     X, Y, Z = np.meshgrid(x, y, z, indexing="ij")
     query_points = np.stack([X, Y, Z], axis=-1).reshape((-1, 3))
 
-    voxels = igl.signed_distance(query_points, mesh.vertices, mesh.faces)[0]
+    voxels, *_ = igl.signed_distance(query_points, mesh.vertices, mesh.faces)
     voxels = voxels.reshape([res, res, res])
 
     T_mesh_to_sdf = np.eye(4)

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import redirect_stderr
 from itertools import chain
 from bisect import bisect_right
 

--- a/genesis/utils/particle.py
+++ b/genesis/utils/particle.py
@@ -67,7 +67,8 @@ def trimesh_to_particles_simple(mesh, p_size, sampler):
             box_center = (mesh.bounds[1] + mesh.bounds[0]) / 2
             positions = _box_to_particles(p_size=p_size, pos=box_center, size=box_size, sampler=sampler)
             # reject out-of-boundary particles
-            positions = positions[igl.signed_distance(positions, mesh.vertices, mesh.faces)[0] < 0]
+            sd, *_ = igl.signed_distance(positions, mesh.vertices, mesh.faces)
+            positions = positions[sd < 0]
 
             os.makedirs(os.path.dirname(ptc_file_path), exist_ok=True)
             with open(ptc_file_path, "wb") as file:

--- a/genesis/utils/urdf.py
+++ b/genesis/utils/urdf.py
@@ -1,4 +1,5 @@
 import os
+from itertools import chain
 
 import trimesh
 import numpy as np
@@ -21,10 +22,10 @@ def _order_links(l_infos, j_infos, links_g_infos=None):
         lp = l_infos[lc]["parent_idx"]
         if lp != -1:
             dict_child[lp].append(lc)
+
     ordered_links_idx = []
     n_level = 0
     stack_topology = [lc for lc in range(n_links) if l_infos[lc]["parent_idx"] == -1]
-
     while len(stack_topology) > 0:
         next_stack = []
         ordered_links_idx.append([])
@@ -33,12 +34,11 @@ def _order_links(l_infos, j_infos, links_g_infos=None):
             next_stack += dict_child[link]
         n_level += 1
         stack_topology = next_stack
+    ordered_links_idx = tuple(chain.from_iterable(ordered_links_idx))
 
     if not ordered_links_idx:
         # avoid case with worldbody without any body (geom directly assigned to worldbody)
-        return [], [], []
-
-    ordered_links_idx = np.concatenate(ordered_links_idx).tolist()
+        return [], [], [], []
 
     for l_info in l_infos:
         if l_info["parent_idx"] >= 0:  # non-base link
@@ -60,8 +60,8 @@ def parse_urdf(morph, surface):
     else:
         robot = morph.file
 
-    # merge links connected by fixed joints
-    if hasattr(morph, "merge_fixed_links") and morph.merge_fixed_links:
+    # Merge links connected by fixed joints
+    if isinstance(morph, gs.morphs.URDF) and morph.merge_fixed_links:
         robot = merge_fixed_links(robot, morph.links_to_keep)
 
     link_name_to_idx = dict()
@@ -72,11 +72,18 @@ def parse_urdf(morph, surface):
     n_links = len(robot.links)
     assert n_links == len(robot.joints) + 1
     l_infos = [dict() for _ in range(n_links)]
-    j_infos = [dict() for _ in range(n_links)]
+    links_j_infos = [[] for _ in range(n_links)]
     links_g_infos = [[] for _ in range(n_links)]
 
     for link, l_info, link_g_infos in zip(robot.links, l_infos, links_g_infos):
         l_info["name"] = link.name
+
+        # No parent by default. It will be overwritten latter on if appropriate.
+        l_info["parent_idx"] = -1
+
+        # Neutral pose by default. It will be overwritten latter on if necessary.
+        l_info["pos"] = gu.zero_pos()
+        l_info["quat"] = gu.identity_quat()
 
         # we compute urdf's invweight later
         l_info["invweight"] = np.full((2,), fill_value=-1.0)
@@ -94,11 +101,15 @@ def parse_urdf(morph, surface):
             l_info["inertial_mass"] = link.inertial.mass
 
         for geom in (*link.collisions, *link.visuals):
+            link_g_infos_ = []
             geom_is_col = not isinstance(geom, urdfpy.Visual)
             if isinstance(geom.geometry.geometry, urdfpy.Mesh):
+                geom_type = gs.GEOM_TYPE.MESH
+                geom_data = None
+
                 # One asset (.obj) can contain multiple meshes. Each mesh is one RigidGeom in genesis.
                 for tmesh in geom.geometry.meshes:
-                    scale = morph.scale
+                    scale = float(morph.scale)
                     if geom.geometry.geometry.scale is not None:
                         scale *= geom.geometry.geometry.scale
 
@@ -117,35 +128,20 @@ def parse_urdf(morph, surface):
                         if geom.material is not None and geom.material.color is not None:
                             mesh.set_color(geom.material.color)
 
-                    geom_type = gs.GEOM_TYPE.MESH
-
-                    g_info = {
-                        "type": geom_type,
-                        "data": None,
-                        "pos": geom.origin[:3, 3].copy(),
-                        "quat": gu.R_to_quat(geom.origin[:3, :3]),
-                        "contype": geom_is_col,
-                        "conaffinity": geom_is_col,
-                    }
-                    if geom_is_col:
-                        g_info["mesh"] = mesh
-                    else:
-                        g_info["vmesh"] = mesh
-                    link_g_infos.append(g_info)
+                    g_info = {"mesh" if geom_is_col else "vmesh": mesh}
+                    link_g_infos_.append(g_info)
             else:
                 # Each geometry primitive is one RigidGeom in genesis.
                 if isinstance(geom.geometry.geometry, urdfpy.Box):
                     tmesh = trimesh.creation.box(extents=geom.geometry.geometry.size)
                     geom_type = gs.GEOM_TYPE.BOX
                     geom_data = np.array(geom.geometry.geometry.size)
-
                 elif isinstance(geom.geometry.geometry, urdfpy.Cylinder):
                     tmesh = trimesh.creation.cylinder(
                         radius=geom.geometry.geometry.radius, height=geom.geometry.geometry.length
                     )
                     geom_type = gs.GEOM_TYPE.CYLINDER
                     geom_data = None
-
                 elif isinstance(geom.geometry.geometry, urdfpy.Sphere):
                     if geom_is_col:
                         tmesh = trimesh.creation.icosphere(radius=geom.geometry.geometry.radius, subdivisions=2)
@@ -164,25 +160,26 @@ def parse_urdf(morph, surface):
                     if geom.material is not None and geom.material.color is not None:
                         mesh.set_color(geom.material.color)
 
-                g_info = {
-                    "type": geom_type,
-                    "data": geom_data,
-                    "pos": geom.origin[:3, 3],
-                    "quat": gu.R_to_quat(geom.origin[:3, :3]),
-                    "contype": geom_is_col,
-                    "conaffinity": geom_is_col,
-                }
-                if geom_is_col:
-                    g_info["mesh"] = mesh
-                else:
-                    g_info["vmesh"] = mesh
-                link_g_infos.append(g_info)
+                g_info = {"mesh" if geom_is_col else "vmesh": mesh}
+                link_g_infos_.append(g_info)
+
+            for g_info in link_g_infos_:
+                g_info["type"] = geom_type
+                g_info["data"] = geom_data
+                g_info["pos"] = geom.origin[:3, 3].copy()
+                g_info["quat"] = gu.R_to_quat(geom.origin[:3, :3])
+                g_info["contype"] = 1 if geom_is_col else 0
+                g_info["conaffinity"] = 1 if geom_is_col else 0
+                g_info["friction"] = gu.default_friction()
+                g_info["sol_params"] = gu.default_solver_params()
+            link_g_infos += link_g_infos_
 
     #########################  non-base joints and links #########################
     for joint in robot.joints:
         idx = link_name_to_idx[joint.child]
         l_info = l_infos[idx]
-        j_info = j_infos[idx]
+        j_info = dict()
+        links_j_infos[idx].append(j_info)
 
         j_info["name"] = joint.name
         j_info["pos"] = gu.zero_pos()
@@ -271,7 +268,7 @@ def parse_urdf(morph, surface):
         j_info["dofs_kv"] = gu.default_dofs_kv(j_info["n_dofs"])
         j_info["dofs_force_range"] = gu.default_dofs_force_range(j_info["n_dofs"])
 
-        if joint.joint_type in ["floating", "fixed"]:
+        if joint.joint_type in ("floating", "fixed"):
             j_info["dofs_damping"] = gu.free_dofs_damping(j_info["n_dofs"])
             j_info["dofs_armature"] = gu.free_dofs_armature(j_info["n_dofs"])
         else:
@@ -290,49 +287,8 @@ def parse_urdf(morph, surface):
                     j_info["dofs_force_range"] / np.abs(j_info["dofs_force_range"]) * joint.limit.effort
                 )
 
-    l_infos, j_infos, links_g_infos, _ = _order_links(l_infos, j_infos, links_g_infos)
-    ######################### first joint and base link #########################
-    j_info = j_infos[0]
-    l_info = l_infos[0]
-
-    j_info["pos"] = gu.zero_pos()
-    j_info["quat"] = gu.identity_quat()
-    j_info["name"] = f'joint_{l_info["name"]}'
-
-    l_info["pos"] = gu.zero_pos()
-    l_info["quat"] = gu.identity_quat()
-
-    if not morph.fixed:
-        j_info["dofs_motion_ang"] = np.eye(6, 3, -3)
-        j_info["dofs_motion_vel"] = np.eye(6, 3)
-        j_info["dofs_limit"] = np.tile([-np.inf, np.inf], (6, 1))
-        j_info["dofs_stiffness"] = np.zeros(6)
-
-        j_info["type"] = gs.JOINT_TYPE.FREE
-        j_info["n_qs"] = 7
-        j_info["n_dofs"] = 6
-        j_info["init_qpos"] = np.concatenate([gu.zero_pos(), gu.identity_quat()])
-    else:
-        j_info["dofs_motion_ang"] = np.zeros((0, 3))
-        j_info["dofs_motion_vel"] = np.zeros((0, 3))
-        j_info["dofs_limit"] = np.zeros((0, 2))
-        j_info["dofs_stiffness"] = np.zeros((0))
-
-        j_info["type"] = gs.JOINT_TYPE.FIXED
-        j_info["n_qs"] = 0
-        j_info["n_dofs"] = 0
-        j_info["init_qpos"] = np.zeros(0)
-
-    j_info["dofs_invweight"] = gu.default_dofs_invweight(j_info["n_dofs"])
-    j_info["dofs_damping"] = gu.free_dofs_damping(j_info["n_dofs"])
-    j_info["dofs_armature"] = gu.free_dofs_armature(j_info["n_dofs"])
-
-    j_info["dofs_kp"] = gu.default_dofs_kp(j_info["n_dofs"])
-    j_info["dofs_kv"] = gu.default_dofs_kv(j_info["n_dofs"])
-    j_info["dofs_force_range"] = gu.default_dofs_force_range(j_info["n_dofs"])
-
-    # apply scale
-    for l_info, j_info, link_g_infos in zip(l_infos, j_infos, links_g_infos):
+    # Apply scaling factor
+    for l_info, link_j_infos, link_g_infos in zip(l_infos, links_j_infos, links_g_infos):
         l_info["pos"] *= morph.scale
         l_info["inertial_pos"] *= morph.scale
 
@@ -341,18 +297,18 @@ def parse_urdf(morph, surface):
         if l_info["inertial_i"] is not None:
             l_info["inertial_i"] *= morph.scale**5
 
-        j_info["pos"] *= morph.scale
+        for j_info in link_j_infos:
+            j_info["pos"] *= morph.scale
 
         for g_info in link_g_infos:
             g_info["pos"] *= morph.scale
 
-            # TODO: parse friction
-            g_info["friction"] = gu.default_friction()
-            g_info["sol_params"] = gu.default_solver_params()
+    # Re-order kinematic tree info
+    l_infos, links_j_infos, links_g_infos, _ = _order_links(l_infos, links_j_infos, links_g_infos)
 
     eqs_info = parse_equalities(robot, morph)
 
-    return l_infos, j_infos, links_g_infos, eqs_info
+    return l_infos, links_j_infos, links_g_infos, eqs_info
 
 
 def parse_equalities(robot, morph):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import gc
-import os
 import sys
 from enum import Enum
 
@@ -9,11 +8,9 @@ import numpy as np
 import pytest
 from _pytest.mark import Expression, MarkMatcher
 
-import mujoco
 import genesis as gs
-from genesis.utils.mesh import get_assets_dir
 
-from .utils import MjSim
+from .utils import MjSim, build_mujoco_sim, build_genesis_sim
 
 
 TOL_SINGLE = 5e-5
@@ -172,93 +169,16 @@ def dof_damping(request):
 
 @pytest.fixture
 def mj_sim(xml_path, gs_solver, gs_integrator, multi_contact, adjacent_collision, dof_damping):
-    if gs_solver == gs.constraint_solver.CG:
-        mj_solver = mujoco.mjtSolver.mjSOL_CG
-    elif gs_solver == gs.constraint_solver.Newton:
-        mj_solver = mujoco.mjtSolver.mjSOL_NEWTON
-    else:
-        raise ValueError(f"Solver '{gs_solver}' not supported")
-    if gs_integrator == gs.integrator.Euler:
-        mj_integrator = mujoco.mjtIntegrator.mjINT_EULER
-    elif gs_integrator == gs.integrator.implicitfast:
-        mj_integrator = mujoco.mjtIntegrator.mjINT_IMPLICITFAST
-    else:
-        raise ValueError(f"Integrator '{gs_integrator}' not supported")
-
-    if not os.path.isabs(xml_path):
-        xml_path = os.path.join(get_assets_dir(), xml_path)
-
-    model = mujoco.MjModel.from_xml_path(xml_path)
-    model.opt.solver = mj_solver
-    model.opt.integrator = mj_integrator
-    model.opt.cone = mujoco.mjtCone.mjCONE_PYRAMIDAL
-    model.opt.disableflags &= ~np.uint32(mujoco.mjtDisableBit.mjDSBL_EULERDAMP)
-    model.opt.disableflags &= ~np.uint32(mujoco.mjtDisableBit.mjDSBL_REFSAFE)
-    model.opt.disableflags &= ~np.uint32(mujoco.mjtDisableBit.mjDSBL_GRAVITY)
-    model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_NATIVECCD
-    if multi_contact:
-        model.opt.enableflags |= mujoco.mjtEnableBit.mjENBL_MULTICCD
-    else:
-        model.opt.enableflags &= ~np.uint32(mujoco.mjtEnableBit.mjENBL_MULTICCD)
-    if adjacent_collision:
-        model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_FILTERPARENT
-    else:
-        model.opt.disableflags &= ~np.uint32(mujoco.mjtDisableBit.mjDSBL_FILTERPARENT)
-    data = mujoco.MjData(model)
-
-    return MjSim(model, data)
+    return build_mujoco_sim(xml_path, gs_solver, gs_integrator, multi_contact, adjacent_collision, dof_damping)
 
 
 @pytest.fixture
 def gs_sim(
     xml_path, gs_solver, gs_integrator, multi_contact, mujoco_compatibility, adjacent_collision, show_viewer, mj_sim
 ):
-    scene = gs.Scene(
-        viewer_options=gs.options.ViewerOptions(
-            camera_pos=(3, -1, 1.5),
-            camera_lookat=(0.0, 0.0, 0.5),
-            camera_fov=30,
-            res=(960, 640),
-            max_FPS=60,
-        ),
-        sim_options=gs.options.SimOptions(
-            dt=mj_sim.model.opt.timestep,
-            substeps=1,
-            gravity=mj_sim.model.opt.gravity.tolist(),
-        ),
-        rigid_options=gs.options.RigidOptions(
-            integrator=gs_integrator,
-            constraint_solver=gs_solver,
-            enable_mujoco_compatibility=mujoco_compatibility,
-            box_box_detection=True,
-            enable_self_collision=True,
-            enable_adjacent_collision=adjacent_collision,
-            enable_multi_contact=multi_contact,
-            iterations=mj_sim.model.opt.iterations,
-            tolerance=mj_sim.model.opt.tolerance,
-            ls_iterations=mj_sim.model.opt.ls_iterations,
-            ls_tolerance=mj_sim.model.opt.ls_tolerance,
-        ),
-        show_viewer=show_viewer,
-        show_FPS=False,
+    return build_genesis_sim(
+        xml_path, gs_solver, gs_integrator, multi_contact, mujoco_compatibility, adjacent_collision, show_viewer, mj_sim
     )
-    gs_robot = scene.add_entity(
-        gs.morphs.MJCF(
-            file=xml_path,
-            convexify=True,
-            decompose_robot_error_threshold=float("inf"),
-        ),
-        visualize_contact=True,
-    )
-    gs_sim = scene.sim
-
-    # Force matching Mujoco safety factor for constraint time constant.
-    # Note that this time constant affects the penetration depth at rest.
-    gs_sim.rigid_solver._sol_min_timeconst = 2.0 * gs_sim._substep_dt
-
-    scene.build()
-
-    return gs_sim
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Description

This PR unifies parsing of MJCF and URDF files to rely systematically on Mujoco internal parser if possible. This may fail because some mesh format for visual geometries are not supported my Mujoco, notably Collada `.dae`. In this case, falling back to the now legacy custom URDF parser. Besides, links and joints ordering should now better align with Mujoco, notably world would be in front of the kinematic string if any.

* Improve 'libigl' API workaround.
* Add utils to properly redirect libc stderr.
* Unify MJCF and URDF loading to avoid discrepancies if possible.
* Fix grapsing bottle example.

## Related Issue

Related to Genesis-Embodied-AI/Genesis/issues/1135

## Motivation and Context

Many fields are missing in URDF files to uniquely initialise the physics. Currently, Genesis is relying on default values that are different from Mujoco and arguably somewhat unphysical. This behaviour is both undesirable and confusing for the end-user. It would be better to rely on Mujoco heuristic for loading URDF file, since this approach has already been proven reliable for MJCF files.

## How Has This Been / Can This Be Tested?

<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.