### PR TITLE
[BUG FIX] Simplify URDF/MJCF parser post-processing.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -385,10 +385,10 @@ class RigidEntity(Entity):
                 del l_infos[0], links_j_infos[0], links_g_infos[0]
                 for l_info in l_infos:
                     l_info["parent_idx"] = max(l_info["parent_idx"] - 1, -1)
+                    if "root_idx" in l_info:
+                        l_info["root_idx"] = max(l_info["root_idx"] - 1, -1)
 
-        # Define a flag that determines whether the link at hand is associated with a robot, and make sure that the
-        # parent index of free joints is "world" (-1) itself rather than the previous link. This is important because
-        # otherwise the corresponding links will be classified as part of the same entity.
+        # Define a flag that determines whether the link at hand is associated with a robot.
         # Note that 0d array is used rather than native type because this algo requires mutable objects.
         for i, (l_info, link_j_infos) in enumerate(zip(l_infos, links_j_infos)):
             if not link_j_infos or all(j_info["type"] == gs.JOINT_TYPE.FIXED for j_info in link_j_infos):
@@ -398,7 +398,6 @@ class RigidEntity(Entity):
                     l_info["is_robot"] = np.array(False, dtype=np.bool_)
             elif all(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in link_j_infos):
                 l_info["is_robot"] = np.array(False, dtype=np.bool_)
-                l_info["parent_idx"] = -1
             else:
                 l_info["is_robot"] = np.array(True, dtype=np.bool_)
                 if l_info["parent_idx"] >= 0:
@@ -525,6 +524,9 @@ class RigidEntity(Entity):
         parent_idx = l_info["parent_idx"]
         if parent_idx >= 0:
             parent_idx += self._link_start
+        root_idx = l_info.get("root_idx")
+        if root_idx is not None and root_idx >= 0:
+            root_idx += self._link_start
 
         link = RigidLink(
             entity=self,
@@ -548,6 +550,7 @@ class RigidEntity(Entity):
             inertial_i=l_info.get("inertial_i"),
             inertial_mass=l_info.get("inertial_mass"),
             parent_idx=parent_idx,
+            root_idx=root_idx,
             invweight=l_info.get("invweight"),
             visualize_contact=self.visualize_contact,
         )

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -39,6 +39,7 @@ class RigidLink(RBC):
         inertial_i,
         inertial_mass,
         parent_idx,
+        root_idx,
         invweight,
         visualize_contact,
     ):
@@ -50,6 +51,7 @@ class RigidLink(RBC):
         self._uid = gs.UID()
         self._idx = idx
         self._parent_idx = parent_idx
+        self._root_idx = root_idx
         self._child_idxs = list()
         self._invweight = invweight
 
@@ -95,7 +97,8 @@ class RigidLink(RBC):
             link = solver_links[link.parent_idx]
             if not all(joint.type is gs.JOINT_TYPE.FIXED for joint in link.joints):
                 is_fixed = False
-        self.root_idx = gs.np_int(link.idx)
+        if self._root_idx is None:
+            self._root_idx = gs.np_int(link.idx)
         self.is_fixed = gs.np_int(is_fixed)
 
         # inertial_mass and inertia_i
@@ -509,6 +512,13 @@ class RigidLink(RBC):
         The global index of the link's parent link in the RigidSolver. If the link is the root link, return -1.
         """
         return self._parent_idx
+
+    @property
+    def root_idx(self):
+        """
+        The global index of the link's root link in the RigidSolver.
+        """
+        return self._root_idx
 
     @property
     def child_idxs(self):

--- a/genesis/engine/solvers/rigid/collider_decomp.py
+++ b/genesis/engine/solvers/rigid/collider_decomp.py
@@ -93,14 +93,15 @@ class Collider:
                     continue
 
                 # self collision
-                if not self._solver._enable_self_collision and links_root_idx[i_la] == links_root_idx[i_lb]:
-                    continue
+                if links_root_idx[i_la] == links_root_idx[i_lb]:
+                    if not self._solver._enable_self_collision:
+                        continue
 
-                # adjacent links
-                if not self._solver._enable_adjacent_collision and (
-                    links_parent_idx[i_la] == i_lb or links_parent_idx[i_lb] == i_la
-                ):
-                    continue
+                    # adjacent links
+                    if not self._solver._enable_adjacent_collision and (
+                        links_parent_idx[i_la] == i_lb or links_parent_idx[i_lb] == i_la
+                    ):
+                        continue
 
                 # contype and conaffinity
                 if not (
@@ -709,18 +710,16 @@ class Collider:
         if i_la == i_lb:
             is_valid = False
 
-        # self collision
-        if (
-            ti.static(not self._solver._enable_self_collision)
-            and self._solver.links_info[I_la].root_idx == self._solver.links_info[I_lb].root_idx
-        ):
-            is_valid = False
+        if self._solver.links_info[I_la].root_idx == self._solver.links_info[I_lb].root_idx:
+            # self collision
+            if ti.static(not self._solver._enable_self_collision):
+                is_valid = False
 
-        # adjacent links
-        if ti.static(not self._solver._enable_adjacent_collision) and (
-            self._solver.links_info[I_la].parent_idx == i_lb or self._solver.links_info[I_lb].parent_idx == i_la
-        ):
-            is_valid = False
+            # adjacent links
+            if ti.static(not self._solver._enable_adjacent_collision) and (
+                self._solver.links_info[I_la].parent_idx == i_lb or self._solver.links_info[I_lb].parent_idx == i_la
+            ):
+                is_valid = False
 
         # contype and conaffinity
         if not (

--- a/genesis/ext/urdfpy/urdf.py
+++ b/genesis/ext/urdfpy/urdf.py
@@ -602,12 +602,12 @@ class Mesh(URDFType):
         fn = get_filename(path, self.filename, makedirs=True)
 
         # Export the meshes as a single file
-        meshes = self.meshes
-        if len(meshes) == 1:
-            meshes = meshes[0]
-        elif os.path.splitext(fn)[1] == ".glb":
-            meshes = trimesh.scene.Scene(geometry=meshes)
-        trimesh.exchange.export.export_mesh(meshes, fn)
+        # meshes = self.meshes
+        # if len(meshes) == 1:
+        #     meshes = meshes[0]
+        # elif os.path.splitext(fn)[1] == ".glb":
+        #     meshes = trimesh.scene.Scene(geometry=meshes)
+        # trimesh.exchange.export.export_mesh(meshes, fn)
 
         # Unparse the node
         node = self._unparse(path)
@@ -3544,9 +3544,9 @@ class URDF(URDFType):
             The parsed URDF.
         """
         if isinstance(file_obj, str):
-            path, _ = os.path.split(file_obj)
+            path = os.path.dirname(file_obj)
         else:
-            path, _ = os.path.split(os.path.realpath(file_obj.name))
+            path = os.path.dirname(os.path.realpath(file_obj.name))
 
         node = self._to_xml(None, path)
         tree = ET.ElementTree(node)
@@ -3641,15 +3641,13 @@ class URDF(URDFType):
         """
         if isinstance(file_obj, str):
             if os.path.isfile(file_obj):
-                with open(file_obj, "r") as f:
-                    file_str = f.read()
-                tree = ET.parse(io.StringIO(file_str))
-                path, _ = os.path.split(file_obj)
+                tree = ET.parse(file_obj)
+                path = os.path.dirname(file_obj)
             else:
                 raise ValueError("{} is not a file".format(file_obj))
         else:
             tree = ET.parse(file_obj)
-            path, _ = os.path.split(file_obj.name)
+            path = os.path.dirname(file_obj.name)
 
         node = tree.getroot()
         return URDF._from_xml(node, node, path)

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -787,6 +787,10 @@ class Drone(FileMorph):
         The names of the links that represent the propellers. Defaults to ['prop0_link', 'prop1_link', 'prop2_link', 'prop3_link'].
     propellers_spin : sequence of int, optional
         The spin direction of the propellers. 1: CCW, -1: CW. Defaults to [-1, 1, -1, 1].
+    merge_fixed_links : bool, optional
+        Whether to merge links connected via a fixed joint. Defaults to True.
+    links_to_keep : list of str, optional
+        A list of link names that should not be skipped during link merging. Defaults to [].
     """
 
     model: str = "CF2X"
@@ -795,6 +799,8 @@ class Drone(FileMorph):
     propellers_link_names: Optional[Sequence[str]] = None
     propellers_link_name: Sequence[str] = ("prop0_link", "prop1_link", "prop2_link", "prop3_link")
     propellers_spin: Sequence[int] = (-1, 1, -1, 1)  # 1: CCW, -1: CW
+    merge_fixed_links: bool = True
+    links_to_keep: List[str] = []
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -805,6 +811,11 @@ class Drone(FileMorph):
                 "'propellers_link_name' instead."
             )
             self.propellers_link_name = self.propellers_link_names
+
+        # Make sure that Propellers and COM links are preserved
+        for link_name in (*self.propellers_link_name, self.COM_link_name):
+            if not link_name in self.links_to_keep:
+                self.links_to_keep.append(link_name)
 
         if isinstance(self.file, str) and not self.file.endswith(".urdf"):
             gs.raise_exception(f"Drone only supports `.urdf` extension: {self.file}")

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -122,6 +122,7 @@ def parse_link(mj, i_l, scale):
         l_info["parent_idx"] = -1
     else:
         l_info["parent_idx"] = int(mj.body_parentid[i_l])
+    l_info["root_idx"] = int(mj.body_rootid[i_l])
     l_info["invweight"] = mj.body_invweight0[i_l]
 
     jnt_adr = mj.body_jntadr[i_l]

--- a/genesis/utils/urdf.py
+++ b/genesis/utils/urdf.py
@@ -61,7 +61,7 @@ def parse_urdf(morph, surface):
         robot = morph.file
 
     # Merge links connected by fixed joints
-    if isinstance(morph, gs.morphs.URDF) and morph.merge_fixed_links:
+    if morph.merge_fixed_links:
         robot = merge_fixed_links(robot, morph.links_to_keep)
 
     link_name_to_idx = dict()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -380,6 +380,13 @@ def check_mujoco_model_consistency(
     else:
         assert False
 
+    gs_root_idx = sorted(
+        gs_sim.rigid_solver.links[i].name
+        for i in set(gs_sim.rigid_solver.links_info.root_idx.to_numpy()[gs_bodies_idx])
+    )
+    mj_root_idx = sorted(mj_sim.model.body(i).name for i in set(mj_sim.model.body_rootid[mj_bodies_idx]))
+    assert gs_root_idx == mj_root_idx
+
     # body
     for gs_i, mj_i in zip(gs_bodies_idx, mj_bodies_idx):
         gs_invweight_i = gs_sim.rigid_solver.links_info.invweight.to_numpy()[gs_i]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,6 +9,7 @@ import mujoco
 
 import genesis as gs
 import genesis.utils.geom as gu
+from genesis.utils import mjcf as mju
 from genesis.utils.mesh import get_assets_dir
 from genesis.engine.solvers.rigid.rigid_solver_decomp import _sanitize_sol_params
 
@@ -153,17 +154,12 @@ def _get_model_mappings(
             joint.name for entity in gs_sim.entities for joint in entity.joints if joint.type != gs.JOINT_TYPE.FIXED
         ]
     if bodies_name is None:
-        bodies_name = []
-        for entity in gs_sim.entities:
-            for body in entity.links:
-                if body.is_fixed and body.parent_idx < 0:
-                    if gs_sim.rigid_solver.links_state[body.idx, 0].mass_sum < gs.EPS:
-                        continue
-                    try:
-                        mj_sim.model.body(body.name)
-                    except KeyError:
-                        continue
-                bodies_name.append(body.name)
+        bodies_name = [
+            body.name
+            for entity in gs_sim.entities
+            for body in entity.links
+            if not (body.is_fixed and body.parent_idx < 0)
+        ]
 
     motors_name: list[str] = []
     mj_joints_idx: list[int] = []
@@ -243,7 +239,7 @@ def build_mujoco_sim(xml_path, gs_solver, gs_integrator, multi_contact, adjacent
         raise ValueError(f"Integrator '{gs_integrator}' not supported")
 
     xml_path = os.path.join(get_assets_dir(), xml_path)
-    model = mujoco.MjModel.from_xml_path(xml_path)
+    model = mju.build_model(xml_path, merge_fixed_links=True, discard_visual=True)
 
     model.opt.solver = mj_solver
     model.opt.integrator = mj_integrator
@@ -308,6 +304,7 @@ def build_genesis_sim(
     else:
         morph = gs.morphs.URDF(
             fixed=True,
+            merge_fixed_links=True,
             **morph_kwargs,
         )
     gs_robot = scene.add_entity(
@@ -638,11 +635,13 @@ def check_mujoco_data_consistency(
     gs_sim.rigid_solver._kernel_forward_kinematics_links_geoms(np.array([0]))
 
     gs_com = gs_sim.rigid_solver.links_state.COM.to_numpy()[:, 0]
+    gs_root_idx = np.unique(gs_sim.rigid_solver.links_info.root_idx.to_numpy()[gs_bodies_idx])
     mj_com = mj_sim.data.subtree_com
-    assert_allclose(gs_com[gs_bodies_idx][0], mj_com[mj_bodies_idx][0], tol=tol)
+    mj_root_idx = np.unique(mj_sim.model.body_rootid[mj_bodies_idx])
+    assert_allclose(gs_com[gs_root_idx], mj_com[mj_root_idx], tol=tol)
 
     gs_xipos = gs_sim.rigid_solver.links_state.i_pos.to_numpy()[:, 0]
-    mj_xipos = mj_sim.data.xipos - mj_sim.data.subtree_com[0]
+    mj_xipos = mj_sim.data.xipos - mj_sim.data.subtree_com[mj_sim.model.body_rootid]
     assert_allclose(gs_xipos[gs_bodies_idx], mj_xipos[mj_bodies_idx], tol=tol)
 
     gs_xpos = gs_sim.rigid_solver.links_state.pos.to_numpy()[:, 0]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -239,7 +239,7 @@ def build_mujoco_sim(xml_path, gs_solver, gs_integrator, multi_contact, adjacent
         raise ValueError(f"Integrator '{gs_integrator}' not supported")
 
     xml_path = os.path.join(get_assets_dir(), xml_path)
-    model = mju.build_model(xml_path, merge_fixed_links=True, discard_visual=True)
+    model = mju.build_model(xml_path, discard_visual=True, merge_fixed_links=True, links_to_keep=())
 
     model.opt.solver = mj_solver
     model.opt.integrator = mj_integrator
@@ -305,6 +305,7 @@ def build_genesis_sim(
         morph = gs.morphs.URDF(
             fixed=True,
             merge_fixed_links=True,
+            links_to_keep=(),
             **morph_kwargs,
         )
     gs_robot = scene.add_entity(
@@ -380,12 +381,12 @@ def check_mujoco_model_consistency(
     else:
         assert False
 
-    gs_root_idx = sorted(
+    gs_roots_name = sorted(
         gs_sim.rigid_solver.links[i].name
         for i in set(gs_sim.rigid_solver.links_info.root_idx.to_numpy()[gs_bodies_idx])
     )
-    mj_root_idx = sorted(mj_sim.model.body(i).name for i in set(mj_sim.model.body_rootid[mj_bodies_idx]))
-    assert gs_root_idx == mj_root_idx
+    mj_roots_name = sorted(mj_sim.model.body(i).name for i in set(mj_sim.model.body_rootid[mj_bodies_idx]))
+    assert gs_roots_name == mj_roots_name
 
     # body
     for gs_i, mj_i in zip(gs_bodies_idx, mj_bodies_idx):


### PR DESCRIPTION
## Description

* Remove fragile and convoluted URDF/MJCF kinematic chain post-processing introduced by https://github.com/Genesis-Embodied-AI/Genesis/pull/1159. 
* Parse root index in URDF/MJCF files.
* Unify fixed link merging pre-processing for URDF and Drone morphs.
* Making the unit tests more robust to make sure mujoco consistent unit tests are still passing despite these changes.

## Motivation and Context

Handling special cases increases maintenance burden. This should be avoid if possible.

## How Has This Been / Can This Be Tested?

Running the unit tests successfully.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
