### PR TITLE
[MISC] More robust CI slurm container lifetime management.

### DIFF
--- a/.github/workflows/linux-gpu.yml
+++ b/.github/workflows/linux-gpu.yml
@@ -16,6 +16,7 @@ jobs:
 
     env:
       GENESIS_IMAGE_VER: "1_0"
+      TIMEOUT_MINUTES: 180
 
     steps:
       - name: Checkout code
@@ -25,8 +26,8 @@ jobs:
 
       - name: Run unit tests and benchmarks
         run: |
-          artifacts_id="$(uuidgen)_$(date +%Y%m%d_%H%M%S)"
-          echo "artifacts_id=${artifacts_id}" >> $GITHUB_ENV
+          SLURM_JOB_NAME="$(uuidgen)_$(date +%Y%m%d_%H%M%S)"
+          echo "SLURM_JOB_NAME=${SLURM_JOB_NAME}" >> $GITHUB_ENV
 
           mkdir -p "${HOME}/.cache"
 
@@ -36,26 +37,31 @@ jobs:
           /mnt/data/artifacts:/mnt/data/artifacts,\
           "${{ github.workspace }}":/root/workspace,\
           "${HOME}/.cache":/root/.cache \
-            --container-workdir=/root/workspace \
+            --no-container-mount-home --container-workdir=/root/workspace \
             --export=\
           NVIDIA_DRIVER_CAPABILITIES=all \
-            --no-container-mount-home \
-            --partition=hpc-low \
-            --nodes=1 --gpus=1 \
-            --exclusive \
+            --partition=hpc-low --exclusive --nodes=1 --gpus=1 --time="${TIMEOUT_MINUTES}" \
+            --job-name=${SLURM_JOB_NAME} \
             bash -c "
               pip install -e '.[dev,render]' && \
               pytest -v --forked ./tests && \
               pytest -v -m 'benchmarks' --backend gpu ./tests && \
-              cp 'speed_test.txt' '/mnt/data/artifacts/speed_test_${artifacts_id}.txt'
+              cp 'speed_test.txt' '/mnt/data/artifacts/speed_test_${SLURM_JOB_NAME}.txt'
             "
+
+      - name: Kill srun job systematically
+        if: always()
+        run: |
+          if [ -n "${SLURM_JOB_NAME}" ] ; then
+            scancel --user=${USER} --name="${SLURM_JOB_NAME}"
+          fi
 
       - name: Display benchmark stats
         run: |
-          cat "/mnt/data/artifacts/speed_test_${artifacts_id}.txt"
+          cat "/mnt/data/artifacts/speed_test_${SLURM_JOB_NAME}.txt"
 
       - name: Upload benchmark stats as artifact
         uses: actions/upload-artifact@v4
         with:
           name: speed-test-results
-          path: "/mnt/data/artifacts/speed_test_${{ env.artifacts_id }}.txt"
+          path: "/mnt/data/artifacts/speed_test_${{ env.SLURM_JOB_NAME }}.txt"


### PR DESCRIPTION
## Description

Adding a timeout mechanism to make sure ressource always gets released at some point no matter what. Adding a Github step killing the Slurm job systematically, even if the Github Job is aborted.

## Motivation and Context

Currently, Slurm containers may not be properly terminated, mainly if the job is aborted. This is an issue as it will hold ressources that may never be released automatically. 