### PR TITLE
[BUG FIX] Fix 'fixed=False' support for URDF and Drone morph.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -385,6 +385,10 @@ class RigidEntity(Entity):
             j_info["dofs_force_range"] = gu.default_dofs_force_range(6)
             links_j_infos[0].append(j_info)
 
+            # Note that 'invweight' was previously initialized to zero based the root joint was fixed at that time.
+            # It is necessary to re-initialize it to some strictly negative value to trigger recomputation in solver.
+            l_infos[0]["invweight"] = np.full((2,), fill_value=-1.0)
+
         # Remove the world link if fixed and has no geometry attached
         if not isinstance(morph, gs.morphs.URDF) or morph.merge_fixed_links:
             if sum(j_info["n_dofs"] for j_info in links_j_infos[0]) == 0 and not links_g_infos[0]:

--- a/genesis/engine/entities/rigid_entity/rigid_joint.py
+++ b/genesis/engine/entities/rigid_entity/rigid_joint.py
@@ -84,7 +84,7 @@ class RigidJoint(RBC):
         """
         raise DeprecationError(
             "This method has been removed. Please consider operating at link-level to get the cartesian position in "
-            "word frame."
+            "word frame. Alternatively, 'get_anchor_pos' returns the anchor position of the joint in the world frame."
         )
 
     def get_quat(self):
@@ -93,7 +93,7 @@ class RigidJoint(RBC):
         """
         raise DeprecationError(
             "This method has been removed. Please consider operating at link-level to get the cartesian orientation in "
-            "word frame."
+            "word frame. Alternatively, 'get_anchor_axis' returns the anchor axis of the joint in the world frame."
         )
 
     @gs.assert_built

--- a/genesis/engine/solvers/rigid/collider_decomp.py
+++ b/genesis/engine/solvers/rigid/collider_decomp.py
@@ -75,10 +75,12 @@ class Collider:
         geoms_link_idx = self._solver.geoms_info.link_idx.to_numpy()
         geoms_contype = self._solver.geoms_info.contype.to_numpy()
         geoms_conaffinity = self._solver.geoms_info.conaffinity.to_numpy()
+        links_entity_idx = self._solver.links_info.entity_idx.to_numpy()
         links_root_idx = self._solver.links_info.root_idx.to_numpy()
         links_parent_idx = self._solver.links_info.parent_idx.to_numpy()
         links_is_fixed = self._solver.links_info.is_fixed.to_numpy()
         if self._solver._options.batch_links_info:
+            links_entity_idx = links_entity_idx[:, 0]
             links_root_idx = links_root_idx[:, 0]
             links_parent_idx = links_parent_idx[:, 0]
             links_is_fixed = links_is_fixed[:, 0]
@@ -104,7 +106,7 @@ class Collider:
                         continue
 
                 # contype and conaffinity
-                if not (
+                if links_entity_idx[i_la] == links_entity_idx[i_lb] and not (
                     (geoms_contype[i_ga] & geoms_conaffinity[i_gb]) or (geoms_contype[i_gb] & geoms_conaffinity[i_ga])
                 ):
                     continue
@@ -722,7 +724,7 @@ class Collider:
                 is_valid = False
 
         # contype and conaffinity
-        if not (
+        if self._solver.links_info[I_la].entity_idx == self._solver.links_info[I_lb].entity_idx and not (
             (self._solver.geoms_info[i_ga].contype & self._solver.geoms_info[i_gb].conaffinity)
             or (self._solver.geoms_info[i_gb].contype & self._solver.geoms_info[i_ga].conaffinity)
         ):

--- a/genesis/engine/solvers/rigid/constraint_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/constraint_solver_decomp.py
@@ -657,7 +657,7 @@ class ConstraintSolver:
         else:
             for i_c in range(self.n_constraints[i_b]):
                 for i_d1 in range(self._solver.n_dofs):
-                    if ti.abs(self.jac[i_c, i_d1, i_b]) > 1e-8:
+                    if ti.abs(self.jac[i_c, i_d1, i_b]) > gs.EPS:
                         for i_d2 in range(i_d1 + 1):
                             self.nt_H[i_d1, i_d2, i_b] = (
                                 self.nt_H[i_d1, i_d2, i_b]
@@ -688,13 +688,12 @@ class ConstraintSolver:
             for j_d in range(i_d):
                 tmp = tmp - (self.nt_H[i_d, j_d, i_b] * self.nt_H[i_d, j_d, i_b])
 
-            mindiag = 1e-8
-            if tmp < mindiag:
-                tmp = mindiag
+            if tmp < gs.EPS:
+                tmp = gs.EPS
                 rank = rank - 1
             self.nt_H[i_d, i_d, i_b] = ti.sqrt(tmp)
 
-            tmp = 1 / self.nt_H[i_d, i_d, i_b]
+            tmp = 1.0 / self.nt_H[i_d, i_d, i_b]
 
             for j_d in range(i_d + 1, self._solver.n_dofs):
                 dot = gs.ti_float(0.0)
@@ -711,6 +710,7 @@ class ConstraintSolver:
         for i_d in range(self._solver.n_dofs):
             for j_d in range(i_d):
                 self.Mgrad[i_d, i_b] = self.Mgrad[i_d, i_b] - (self.nt_H[i_d, j_d, i_b] * self.Mgrad[j_d, i_b])
+
             self.Mgrad[i_d, i_b] = self.Mgrad[i_d, i_b] / self.nt_H[i_d, i_d, i_b]
 
         for i_d_ in range(self._solver.n_dofs):

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -282,7 +282,7 @@ class RigidSolver(Solver):
         ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for I in ti.grouped(self.links_info):
             for j in range(2):
-                if self.links_info[I].invweight[j] < 0:
+                if self.links_info[I].invweight[j] <= gs.EPS:
                     self.links_info[I].invweight[j] = invweight[I[0], j]
 
     @ti.kernel
@@ -1743,7 +1743,7 @@ class RigidSolver(Solver):
         from genesis.utils.tools import create_timer
 
         timer = create_timer(name="constraint_force", level=2, ti_sync=True, skip_first_call=True)
-        if self._enable_collision or self._enable_joint_limit:
+        if self._enable_collision or self._enable_joint_limit or self.n_equalities > 0:
             self.constraint_solver.clear()
         timer.stamp("constraint_solver.clear")
 

--- a/genesis/engine/solvers/tool_solver.py
+++ b/genesis/engine/solvers/tool_solver.py
@@ -7,8 +7,7 @@ from genesis.utils.misc import *
 
 from .base_solver import Solver
 
-if TYPE_CHECKING:
-    from genesis.engine.entities.tool_entity.tool_entity import ToolEntity
+from genesis.engine.entities.tool_entity.tool_entity import ToolEntity
 
 
 @ti.data_oriented


### PR DESCRIPTION
## Description

* Only apply collision pairs filtering based on 'contype', 'conaffinity' bitmasks to geometries associated with the same entity (eventually having different roots)
* Fix constraint solver not cleared if collisions and joint limits are disabled whereas there are some equality constraints
* Fix 'invweight' not being updated (equals to zero) for the root joint of URDF morph when 'fixed=False'

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/1135

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
