### PR TITLE
[PATCH] Fix collision free path plan

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1596,7 +1596,7 @@ class RigidEntity(Entity):
             if ignore_collision:
                 return True
             qpos = torch.tensor([state[i] for i in range(self.n_qs)], dtype=gs.tc_float, device=gs.device)
-            self.set_qpos(qpos, zero_velocity=False)
+            self.set_qpos(qpos)
             collision_pairs = set(map(tuple, self.detect_collision()))
             return not (collision_pairs - mask_collision_pairs)
 

--- a/genesis/engine/solvers/tool_solver.py
+++ b/genesis/engine/solvers/tool_solver.py
@@ -6,9 +6,7 @@ from genesis.engine.states.solvers import ToolSolverState
 from genesis.utils.misc import *
 
 from .base_solver import Solver
-
-if TYPE_CHECKING:
-    from genesis.engine.entities.tool_entity.tool_entity import ToolEntity
+from genesis.engine.entities.tool_entity.tool_entity import ToolEntity
 
 
 @ti.data_oriented


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->

Fix collision free path planning fails to plan a path due to collision state not appropriately updated in `is_ompl_state_valid` in `plan_path`.
@abhaybd `zero_velocity` should not affect the `detect_collision` so this patch of making `zero_velocity=True` is a temporal fix (it will be helpful if you can take a look). Currently, following line is required to get the correct collision states...

```python
if zero_velocity:
    self.zero_all_dofs_velocity(envs_idx, unsafe=unsafe)
```

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

```python
import argparse
import os
import numpy as np
import genesis as gs
from genesis.utils.geom import T_to_trans_quat, transform_quat_by_quat
import torch 


parser = argparse.ArgumentParser()
parser.add_argument("-v", "--vis", action="store_true", default=False)
args = parser.parse_args()

########################## init ##########################
gs.init(backend=gs.gpu)

########################## create a scene ##########################
scene = gs.Scene(
    viewer_options=gs.options.ViewerOptions(
        camera_pos=(3, 1, 1.5),
        camera_lookat=(0.0, 0.0, 0.5),
        camera_fov=30,
        max_FPS=60,
    ),
    sim_options=gs.options.SimOptions(
        dt=0.01,
        substeps=4,  # for more stable grasping contact
    ),
    show_viewer=args.vis,
    vis_options=gs.options.VisOptions(
        show_link_frame=True,
    ),
    show_FPS=False
)

cube = scene.add_entity(
    gs.morphs.Box(
        lower=(0.1, -0.1, 0.05),
        upper=(0.4, 0.1, 0.25),
    )
)

plane = scene.add_entity(
    gs.morphs.Plane(pos=(0,0,0))
)

franka = scene.add_entity(
    gs.morphs.MJCF(
        file="xml/franka_emika_panda/panda.xml",
    )
)

cam = scene.add_camera(
    res=(1280, 960),
    pos=(2.0, 0.0, 1.5),
    lookat=(0.5, 0.0, 0.5),
    fov=30,
    GUI=False,
)
########################## build ##########################
scene.build()

quat = np.array([0.3073, 0.5303, 0.7245, -0.2819])
qpos = franka.inverse_kinematics(franka.get_link("hand"), pos=torch.tensor([0.3, 0.2, 0.1], device=gs.device), quat=quat)
# gripper open pos
qpos[-2:] = 0.04
path = franka.plan_path(
    qpos_goal=qpos,
    num_waypoints=200,  # 2s duration
)

print("="*100)
cam.start_recording()
# execute the planned path
for waypoint in path:
    franka.set_qpos(waypoint)
    print(waypoint, set(map(tuple, franka.detect_collision())))
    scene.step()
    cam.render()
```

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [ ] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
