### PR TITLE
[BUG FIX] Apple Metal only support float32 for FEM

### DIFF
--- a/genesis/engine/entities/fem_entity.py
+++ b/genesis/engine/entities/fem_entity.py
@@ -307,6 +307,10 @@ class FEMEntity(Entity):
         verts_COM = verts.mean(0)
         init_positions = (verts - verts_COM) @ R.T + verts_COM
 
+        if gs.backend == gs.metal:
+            init_positions = init_positions.astype(np.float32)
+            verts_COM = verts_COM.astype(np.float32)
+
         if not init_positions.shape[0] > 0:
             gs.raise_exception(f"Entity has zero vertices.")
 

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -642,7 +642,7 @@ class RasterizerContext:
     def on_fem(self):
         if self.sim.fem_solver.is_active():
             vertices_all, triangles_all = self.sim.fem_solver.get_state_render(self.sim.cur_substep_local)
-            vertices_all = vertices_all.to_numpy(dtype="float")[:, self.rendered_envs_idx[0], :]
+            vertices_all = vertices_all.to_numpy()[:, self.rendered_envs_idx[0], :]
             triangles_all = triangles_all.to_numpy(dtype="int").reshape([-1, 3])
 
             for fem_entity in self.sim.fem_solver.entities:
@@ -669,7 +669,7 @@ class RasterizerContext:
     def update_fem(self, buffer_updates):
         if self.sim.fem_solver.is_active():
             vertices_all, triangles_all = self.sim.fem_solver.get_state_render(self.sim.cur_substep_local)
-            vertices_all = vertices_all.to_numpy(dtype="float")[:, self.rendered_envs_idx[0], :]
+            vertices_all = vertices_all.to_numpy()[:, self.rendered_envs_idx[0], :]
             triangles_all = triangles_all.to_numpy(dtype="int").reshape([-1, 3])
 
             for fem_entity in self.sim.fem_solver.entities:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
Make FEM compatible with Apple Metal Platform by converting arrays to np.float32

## Motivation and Context
Improve Compatibility

## How Has This Been / Can This Be Tested?
```python
import genesis as gs
import time
gs.init(backend=gs.gpu, precision="32", logging_level="debug")

scene = gs.Scene(
    sim_options=gs.options.SimOptions(
        dt=0.001,
        substeps=10,
    ),
    show_viewer=True,
)

scene.add_entity(
    material=gs.materials.FEM.Elastic(),
    morph=gs.morphs.Mesh(
        file="./cube8.obj",
        scale=0.1,
        pos=(0, 0, 1.0),
    ),
)
scene.build()

for i in range(100):
    scene.step()
```


[cube8.zip](https://github.com/user-attachments/files/20470941/cube8.zip)
@YilingQiao 