### PR TITLE
[MISC] Add compile- and run-time performance monitoring.

### DIFF
--- a/.github/workflows/linux-gpu.yml
+++ b/.github/workflows/linux-gpu.yml
@@ -1,20 +1,18 @@
 name: Linux x86 - Nvidia GPU
 
 on:
-  pull_request:
+  # Trigger the workflow on push on the master branch, or for any pull request
+  push:
     branches:
       - main
+  pull_request:
 
 jobs:
   linux-gpu:
     runs-on: [self-hosted, coreweave]
 
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.12"]
-
     env:
+      WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       HF_HUB_DOWNLOAD_TIMEOUT: 60
       GENESIS_IMAGE_VER: "1_0"
@@ -24,9 +22,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          # Checkout of the full history is required for running benchmarks on old commits but not current
           fetch-depth: 1
 
-      - name: Run unit tests and benchmarks
+      - name: Run unit tests
+        if: github.event_name == 'pull_request'
         run: |
           SLURM_JOB_NAME="$(uuidgen)_$(date +%Y%m%d_%H%M%S)"
           echo "SLURM_JOB_NAME=${SLURM_JOB_NAME}" >> $GITHUB_ENV
@@ -36,18 +36,41 @@ jobs:
           srun \
             --container-image="/mnt/data/images/genesis-v${GENESIS_IMAGE_VER}.sqsh" \
             --container-mounts=\
-          /mnt/data/artifacts:/mnt/data/artifacts,\
           "${{ github.workspace }}":/root/workspace,\
           "${HOME}/.cache":/root/.cache \
             --no-container-mount-home --container-workdir=/root/workspace \
             --export=\
+          HF_TOKEN="${HF_TOKEN}",\
           NVIDIA_DRIVER_CAPABILITIES=all \
+            --partition=hpc-low --nodes=1 --gpus=1 --time="${TIMEOUT_MINUTES}" \
+            --job-name=${SLURM_JOB_NAME} \
+            bash -c "
+              pip install -e '.[dev,render]' && \
+              pytest -v --forked ./tests
+            "
+
+      - name: Run benchmarks
+        run: |
+          SLURM_JOB_NAME="$(uuidgen)_$(date +%Y%m%d_%H%M%S)"
+          echo "SLURM_JOB_NAME=${SLURM_JOB_NAME}" >> $GITHUB_ENV
+
+          SLURM_ENV_VARS="NVIDIA_DRIVER_CAPABILITIES=all,HF_TOKEN='${HF_TOKEN}'"
+          if [[ "${{ github.repository }}" == 'Genesis-Embodied-AI/Genesis' && "${{ github.ref }}" == 'refs/heads/main' ]] ; then
+            SLURM_ENV_VARS="${SLURM_ENV_VARS},WANDB_API_KEY='${WANDB_API_KEY}'"
+          fi
+
+          srun \
+            --container-image="/mnt/data/images/genesis-v${GENESIS_IMAGE_VER}.sqsh" \
+            --container-mounts=\
+          /mnt/data/artifacts:/mnt/data/artifacts,\
+          "${{ github.workspace }}":/root/workspace \
+            --no-container-mount-home --container-workdir=/root/workspace \
+            --export=${SLURM_ENV_VARS} \
             --partition=hpc-low --exclusive --nodes=1 --gpus=1 --time="${TIMEOUT_MINUTES}" \
             --job-name=${SLURM_JOB_NAME} \
             bash -c "
               pip install -e '.[dev,render]' && \
-              pytest -v --forked ./tests && \
-              pytest -v -m 'benchmarks' --backend gpu ./tests && \
+              pytest --print -x -m 'benchmarks' --backend gpu ./tests && \
               cp 'speed_test.txt' '/mnt/data/artifacts/speed_test_${SLURM_JOB_NAME}.txt'
             "
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -82,6 +82,7 @@ xhost +local:root # 允许容器访问显示器
 
 docker run --gpus all --rm -it \
 -e DISPLAY=$DISPLAY \
+-v /dev/dri:/dev/dri \
 -v /tmp/.X11-unix/:/tmp/.X11-unix \
 -v $PWD:/workspace \
 genesis

--- a/README_FR.md
+++ b/README_FR.md
@@ -102,6 +102,7 @@ xhost +local:root # Autoriser le conteneur à accéder à l'affichage
 
 docker run --gpus all --rm -it \
 -e DISPLAY=$DISPLAY \
+-v /dev/dri:/dev/dri \
 -v /tmp/.X11-unix/:/tmp/.X11-unix \
 -v $PWD:/workspace \
 genesis

--- a/README_JA.md
+++ b/README_JA.md
@@ -105,6 +105,7 @@ xhost +local:root # コンテナがディスプレイにアクセスできるよ
 
 docker run --gpus all --rm -it \
 -e DISPLAY=$DISPLAY \
+-v /dev/dri:/dev/dri \
 -v /tmp/.X11-unix/:/tmp/.X11-unix \
 -v $PWD:/workspace \
 genesis

--- a/README_KR.md
+++ b/README_KR.md
@@ -97,6 +97,7 @@ xhost +local:root # 컨테이너가 디스플레이에 접근할 수 있도록 �
 
 docker run --gpus all --rm -it \
 -e DISPLAY=$DISPLAY \
+-v /dev/dri:/dev/dri \
 -v /tmp/.X11-unix/:/tmp/.X11-unix \
 -v $PWD:/workspace \
 genesis

--- a/genesis/engine/entities/fem_entity.py
+++ b/genesis/engine/entities/fem_entity.py
@@ -302,9 +302,12 @@ class FEMEntity(Entity):
         Exception
             If no vertices are provided.
         """
+        verts = verts.astype(gs.np_float)
+        elems = elems.astype(gs.np_int)
+
         # rotate
-        R = gu.quat_to_R(np.array(self.morph.quat))
-        verts_COM = verts.mean(0)
+        R = gu.quat_to_R(np.array(self.morph.quat, dtype=gs.np_float))
+        verts_COM = verts.mean(axis=0)
         init_positions = (verts - verts_COM) @ R.T + verts_COM
 
         if not init_positions.shape[0] > 0:

--- a/genesis/engine/entities/rigid_entity/rigid_joint.py
+++ b/genesis/engine/entities/rigid_entity/rigid_joint.py
@@ -313,7 +313,7 @@ class RigidJoint(RBC):
         single one, or none, respectively.
         """
         gs.logger.warning(
-            "This property is deprecated and will be removed in future release. Please use 'dof_idx_local' instead."
+            "This property is deprecated and will be removed in future release. Please use 'dofs_idx_local' instead."
         )
         if self.n_dofs == 1:
             return self.dof_start - self._entity.dof_start

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -417,11 +417,11 @@ class FileMorph(Morph):
 
         if self.decompose_nonconvex is not None:
             if self.decompose_nonconvex:
+                # Convex decomposition is automatically disabled if convexify itself is already disabled.
                 self.convexify = True
                 self.decompose_object_error_threshold = 0.0
                 self.decompose_robot_error_threshold = 0.0
             else:
-                self.convexify = False
                 self.decompose_object_error_threshold = float("inf")
                 self.decompose_robot_error_threshold = float("inf")
             gs.logger.warning(

--- a/genesis/utils/geom.py
+++ b/genesis/utils/geom.py
@@ -593,12 +593,12 @@ def trans_quat_to_T(trans, quat):
         T = np.eye(4, dtype=np.result_type(trans, quat))
         if trans.ndim == 1:
             T[:3, 3] = trans
-            T[:3, :3] = Rotation.from_quat(quat, scalar_first=True).as_matrix()
+            T[:3, :3] = quat_to_R(quat)
         elif trans.ndim == 2:
             assert quat.ndim == 2
             T = np.tile(T, [trans.shape[0], 1, 1])
             T[:, :3, 3] = trans
-            T[:, :3, :3] = Rotation.from_quat(quat, scalar_first=True).as_matrix()
+            T[:, :3, :3] = quat_to_R(quat)
         else:
             gs.raise_exception(f"ndim expected to be 1 or 2, but got {trans.ndim=}")
         return T

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -316,7 +316,7 @@ def postprocess_collision_geoms(
                 tmesh._cache.clear()
                 tmesh.visual._cache.clear()
 
-    # Check if all the geometries can be convexify without decomposition
+    # Check if all the geometries can be convexified without decomposition
     must_decompose = False
     if convexify:
         for g_info in g_infos:

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -642,8 +642,8 @@ class RasterizerContext:
     def on_fem(self):
         if self.sim.fem_solver.is_active():
             vertices_all, triangles_all = self.sim.fem_solver.get_state_render(self.sim.cur_substep_local)
-            vertices_all = vertices_all.to_numpy(dtype="float")[:, self.rendered_envs_idx[0], :]
-            triangles_all = triangles_all.to_numpy(dtype="int").reshape([-1, 3])
+            vertices_all = vertices_all.to_numpy(dtype=gs.np_float)[:, self.rendered_envs_idx[0]]
+            triangles_all = triangles_all.to_numpy(dtype=gs.np_int).reshape((-1, 3))
 
             for fem_entity in self.sim.fem_solver.entities:
                 if fem_entity.surface.vis_mode == "visual":
@@ -669,8 +669,8 @@ class RasterizerContext:
     def update_fem(self, buffer_updates):
         if self.sim.fem_solver.is_active():
             vertices_all, triangles_all = self.sim.fem_solver.get_state_render(self.sim.cur_substep_local)
-            vertices_all = vertices_all.to_numpy(dtype="float")[:, self.rendered_envs_idx[0], :]
-            triangles_all = triangles_all.to_numpy(dtype="int").reshape([-1, 3])
+            vertices_all = vertices_all.to_numpy(dtype=gs.np_float)[:, self.rendered_envs_idx[0]]
+            triangles_all = triangles_all.to_numpy(dtype=gs.np_int).reshape((-1, 3))
 
             for fem_entity in self.sim.fem_solver.entities:
                 if fem_entity.surface.vis_mode == "visual":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,9 @@ dev = [
     "pytest-xdist",
     "pytest-forked",
     "pytest-random-order",
+    "pytest-print",
     "huggingface_hub",
+    "wandb",
 ]
 docs = [
     # Note that currently sphinx 7 does not work, so we must use v6.2.1. See https://github.com/kivy/kivy/issues/8230 which tracks this issue. Once fixed we can use a later version

--- a/tests/run_benchmarks.py
+++ b/tests/run_benchmarks.py
@@ -1,0 +1,52 @@
+import os
+import subprocess
+import tempfile
+from traceback import TracebackException
+
+import pytest
+
+START_REF = "v0.2.1"
+END_REF = "upstream/main"
+
+BENCHMARK_SCRIPT = r"""
+#!/bin/bash
+set -e
+
+# Make sure that WanDB is configured, otherwise running the benchmarks is useless
+if [[ -z "${WANDB_API_KEY}" ]] ; then
+    exit 1;
+fi
+
+# Make sure that Genesis is properly installed, with including all its requirements
+pip uninstall --no-input -y genesis-world
+pip install --no-input --no-user --no-cache --quiet -e ".[dev]" "libigl==2.5.1"
+
+# Run the benchmarks
+pytest --print -x -m benchmarks --backend gpu "./tests_2/test_rigid_benchmarks.py"
+"""
+
+# Get all commit hashes after a given date (oldest to newest)
+commits = subprocess.check_output(
+    ["git", "rev-list", "--reverse", f"{START_REF}^..{END_REF}"],
+    cwd=os.path.dirname(__file__),
+    stderr=subprocess.DEVNULL,
+    encoding="utf-8",
+).splitlines()
+print(f"Found {len(commits)} commits since {START_REF}")
+
+with tempfile.NamedTemporaryFile("w", suffix=".sh") as fd:
+    script_fullpath = fd.name
+    fd.write(BENCHMARK_SCRIPT)
+    fd.flush()
+    os.chmod(fd.name, 0o755)  # Make the script executable
+
+    for i, commit in enumerate(commits):
+        print(f"\n[{i+1}/{len(commits)}] Checking out {commit}")
+        subprocess.run(["git", "checkout", "-f", commit], check=True)
+
+        print("================= ...Running benchmarks... ==================")
+        process = subprocess.Popen(
+            ["bash", script_fullpath],
+            cwd=os.path.dirname(__file__),
+        )
+        process.wait()

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -1450,14 +1450,12 @@ def test_convexify(euler, backend, show_viewer):
 
     # Check resting conditions repeateadly rather not just once, for numerical robustness
     # cam.start_recording()
-    num_steps = 1300 if euler == (90, 0, 90) else 1100
-    atol = 0.65 if euler == (90, 0, 90) and backend == gs.gpu else 1.5
-    for i in range(num_steps):
+    for i in range(1700):
         scene.step()
         # cam.render()
-        if i > num_steps - 100:
+        if i > 1600:
             qvel = gs_sim.rigid_solver.get_dofs_velocity().cpu()
-            assert_allclose(qvel, 0, atol=atol)
+            assert_allclose(qvel, 0, atol=0.65)
     # cam.stop_recording(save_to_filename="video.mp4", fps=60)
 
     for obj in objs:


### PR DESCRIPTION
## Description

* Improve the reliability / compliance of benchmark infra to make sure it runs fine on all commits from latest official release on PyPI (`v0.2.1`) to current main branch.
* Best effort to make metrics comparable between commits by enforcing equivalent options over the whole history whenever possible
* Add monitoring of compilation time
* Push data on WanDB server (will be released publicly soon) for performance monitoring
* Fix FEM support on Apple Metal.

## Related Issue

Related to Genesis-Embodied-AI/Genesis/issues/1155
Related to Genesis-Embodied-AI/Genesis/issues/412

## Motivation and Context

Continuous monitoring of the performance enables to detect regressions as soon as possible, which makes it dramatically easier to diagnose the root, and in turns, come up with effective mitigations. Beyond that, having quantitative metrics regarding the performance of the simulation for various scenarios is a powerful tool to help making the best design choice for end-user applications and provide them reference baselines against which to compare.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
