### PR TITLE
[BUG FIX] Make first few FPSs output by FPSTracker more self-consistent

### DIFF
--- a/genesis/utils/tools.py
+++ b/genesis/utils/tools.py
@@ -171,18 +171,26 @@ class Rate:
 
 
 class FPSTracker:
-    def __init__(self, n_envs, alpha=0.95, compensate_logging_cost=True):
-        self.last_time = time.perf_counter()
+    def __init__(self, n_envs, alpha=0.95):
+        self.last_time = None
         self.n_envs = n_envs
-        self.dt = 0
+        self.dt_ema = None
         self.alpha = alpha
-        self.compensate_logging_cost = compensate_logging_cost
 
     def step(self):
         current_time = time.perf_counter()
-        dt = current_time - self.last_time
-        self.dt = self.alpha * self.dt + (1 - self.alpha) * dt
-        fps = 1 / self.dt
+
+        if self.last_time:
+            dt = current_time - self.last_time
+        else:
+            self.last_time = current_time
+            return
+
+        if self.dt_ema:
+            self.dt_ema = self.alpha * self.dt_ema + (1 - self.alpha) * dt
+        else:
+            self.dt_ema = dt
+        fps = 1 / self.dt_ema
         if self.n_envs > 0:
             self.total_fps = fps * self.n_envs
             gs.logger.info(
@@ -191,7 +199,4 @@ class FPSTracker:
         else:
             self.total_fps = fps
             gs.logger.info(f"Running at ~<{fps:.2f}>~ FPS.")
-        if self.compensate_logging_cost:  # skip logging cost
-            self.last_time = time.perf_counter()
-        else:
-            self.last_time = current_time
+        self.last_time = current_time


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->

The FPS Tracker,  before this change:
- initializes the dt expoential moving average to 0, meaning it takes a while to settle down
    - this pr intiializes it with the first value of dt
- has an initial value of dt also near zero, because:
    - when the calss is instantiated, last_time is set to current time
    - then the first time step is called, dt is calculatd from the last_time set in intializtion
        - these are often very close together
    - this pr doesn't calculate a value for dt until the second time step() is called
 
Before this change, first few fps look like:
![Screenshot 2025-06-05 at 5 11 40 PM](https://github.com/user-attachments/assets/638f4fb5-2669-4188-a781-7270116da98b)

After this change, looks like:
![Screenshot 2025-06-05 at 5 15 51 PM](https://github.com/user-attachments/assets/6dd97876-c208-4e93-9bfc-9b380993c448)

(much more consistent)

In addtion, this PR removes compensate_logging_cost, which is only valid on CPU, not on GPU (I suppose we could keep it, but make it default to False, but I dont feel we will want to benchmark on CPU anyway?)

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

See description above

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

By running `python examples/rigid/single_franka_envs.py -n 2048`

## Screenshots (if appropriate):

See description above

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [ ] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
