### PR TITLE
[BUG FIX] fix bug in face normal rendering from keyboard instruction

### DIFF
--- a/genesis/ext/pyrender/shader_program.py
+++ b/genesis/ext/pyrender/shader_program.py
@@ -221,7 +221,8 @@ class ShaderProgram(object):
                 func1(loc, 1, GL_TRUE, value)
 
         # Call correct uniform function
-        elif isinstance(value, float):
+        elif isinstance(value, float) or isinstance(value, np.float32):
+            value = float(value)
             glUniform1f(loc, value)
         elif isinstance(value, int):
             if unsigned:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Previously, when use key board instruction to render face normal, error will occur:

```
Traceback (most recent call last):
  File "/home/boris/miniconda3/envs/maniFM-genesis/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/home/boris/miniconda3/envs/maniFM-genesis/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/home/boris/Desktop/maniFM-proof-of-concept/Genesis/genesis/ext/pyrender/viewer.py", line 1215, in start
    self.refresh()
  File "/home/boris/Desktop/maniFM-proof-of-concept/Genesis/genesis/ext/pyrender/viewer.py", line 1245, in refresh
    pyglet.clock.tick()
  File "/home/boris/miniconda3/envs/maniFM-genesis/lib/python3.10/site-packages/pyglet/clock.py", line 528, in tick
    return _default.tick(poll)
  File "/home/boris/miniconda3/envs/maniFM-genesis/lib/python3.10/site-packages/pyglet/clock.py", line 270, in tick
    self.call_scheduled_functions(delta_t)
  File "/home/boris/miniconda3/envs/maniFM-genesis/lib/python3.10/site-packages/pyglet/clock.py", line 217, in call_scheduled_functions
    item.func(now - item.last_ts, *item.args, **item.kwargs)
  File "/home/boris/Desktop/maniFM-proof-of-concept/Genesis/genesis/ext/pyrender/viewer.py", line 991, in _time_event
    self.on_draw()
  File "/home/boris/Desktop/maniFM-proof-of-concept/Genesis/genesis/ext/pyrender/viewer.py", line 690, in on_draw
    self._render()
  File "/home/boris/Desktop/maniFM-proof-of-concept/Genesis/genesis/ext/pyrender/viewer.py", line 1114, in _render
    retval = renderer.render(self.scene, flags, seg_node_map=seg_node_map)
  File "/home/boris/Desktop/maniFM-proof-of-concept/Genesis/genesis/ext/pyrender/renderer.py", line 197, in render
    self._normals_pass(scene, flags, env_idx=env_idx)
  File "/home/boris/Desktop/maniFM-proof-of-concept/Genesis/genesis/ext/pyrender/renderer.py", line 575, in _normals_pass
    program.set_uniform("normal_magnitude", 0.05 * primitive.scale)
  File "/home/boris/Desktop/maniFM-proof-of-concept/Genesis/genesis/ext/pyrender/shader_program.py", line 237, in set_uniform
    raise ValueError("Invalid data type")
```

Minimal reproduction for this error (after the GUI is launched, press `i` and `f` to see the error):

```python
import argparse
import os
os.environ["PYOPENGL_PLATFORM"] = "glx"

import torch
import numpy as np
import genesis as gs

from genesis.engine.solvers.rigid.rigid_solver_decomp import RigidSolver

def main():

    ########################## init ##########################
    gs.init(backend=gs.gpu)

    ########################## create a scene ##########################
    scene = gs.Scene(
        viewer_options=gs.options.ViewerOptions(
            camera_pos=(0, -3.5, 2.5),
            camera_lookat=(0.0, 0.0, 1.0),
            camera_fov=40,
            max_FPS=60,
        ),
        vis_options = gs.options.VisOptions(
            show_world_frame = True, # visualize the coordinate frame of `world` at its origin
            world_frame_size = 1.0, # length of the world frame in meter
            show_link_frame  = True, # do not visualize coordinate frames of entity links
            show_cameras     = False, # do not visualize mesh and frustum of the cameras added
            plane_reflection = True, # turn on plane reflection
            ambient_light    = (0.1, 0.1, 0.1), # ambient light setting
        ),
        sim_options=gs.options.SimOptions(
            dt=0.01,
        ),
        profiling_options=gs.options.ProfilingOptions(
            show_FPS=True,
        ),
        show_viewer=True,
    )

    ########################## entities ##########################
    plane = scene.add_entity(
        gs.morphs.Plane(),
    )
    cube = scene.add_entity(
        gs.morphs.Box(
            pos=(0, 0, 1.0),
            size=(0.2, 0.2, 0.2),
        ),
    )
    ########################## build ##########################
    scene.build(n_envs=16, env_spacing=(1.0, 1.0))
    
    link_idx = [1]
    rotation_direction = 1
    for i in range(2000):
        cube_pos = scene.sim.rigid_solver.get_links_pos(link_idx)
        cube_pos[:, :, 2] -= 1
        force = -100 * cube_pos
        scene.sim.rigid_solver.apply_links_external_force(force=force, links_idx=link_idx)

        torque = torch.tensor([[[0, 0, rotation_direction]]])
        torque = torque.repeat(16, 1, 1)
        scene.sim.rigid_solver.apply_links_external_torque(torque=torque, links_idx=link_idx)

        scene.step()

        if (i + 50) % 100 == 0:
            rotation_direction *= -1


if __name__ == "__main__":
    main()
```

The reason is that in the `shader_program.py`, the value is `np.float32` but there is no branch handling this scenario, causing a ValueError.

Now, this can be done:
![Screenshot from 2025-06-09 15-11-38](https://github.com/user-attachments/assets/db143ae3-e6a3-4ca0-b964-bac25fb19c60)


## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
