### PR TITLE
[BUG FIX] Various minor bug fixes.

### DIFF
--- a/genesis/_main.py
+++ b/genesis/_main.py
@@ -144,6 +144,7 @@ def view(filename, collision, rotate, scale=1.0, show_link_frame=False):
         vis_options=gs.options.VisOptions(
             show_link_frame=show_link_frame,
         ),
+        show_viewer=True,
     )
 
     if filename.endswith(".urdf"):

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -407,7 +407,7 @@ class RigidEntity(Entity):
 
             # Shift root idx for all child links
             for l_info in l_infos[idx:]:
-                if l_info["root_idx"] == idx + 1:
+                if "root_idx" in l_info and l_info["root_idx"] == idx + 1:
                     l_info["root_idx"] = idx
 
             # Must invalidate invweight for all child links and joints because the root joint was fixed when it was

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -2177,7 +2177,10 @@ class RigidEntity(Entity):
         elif isinstance(idx_local, int):
             idx_global = idx_local + idx_global_start
         elif isinstance(idx_local, (list, tuple)):
-            idx_global = [i + idx_global_start for i in idx_local]
+            try:
+                idx_global = [i + idx_global_start for i in idx_local]
+            except TypeError:
+                gs.raise_exception("Expecting a sequence of integers for `idx_local`.")
         else:
             # Increment may be slow when dealing with heterogenuous data, so it must be avoided if possible
             if idx_global_start > 0:

--- a/genesis/ext/pyrender/shader_program.py
+++ b/genesis/ext/pyrender/shader_program.py
@@ -221,14 +221,9 @@ class ShaderProgram(object):
                 func1(loc, 1, GL_TRUE, value)
 
         # Call correct uniform function
-        elif isinstance(value, float):
-            glUniform1f(loc, value)
-        elif isinstance(value, int):
-            if unsigned:
-                glUniform1ui(loc, value)
-            else:
-                glUniform1i(loc, value)
-        elif isinstance(value, bool):
+        elif isinstance(value, (numbers.Real, np.floating)):
+            glUniform1f(loc, float(value))
+        elif isinstance(value, (numbers.Integer, np.integer)):
             if unsigned:
                 glUniform1ui(loc, int(value))
             else:

--- a/genesis/options/textures.py
+++ b/genesis/options/textures.py
@@ -36,11 +36,17 @@ class ColorTexture(Texture):
 
     Parameters
     ----------
-    color : tuple, shape (3,)
+    color : tuple, shape (N,)
         RGB color value.
     """
 
-    color: tuple = (1.0, 1.0, 1.0)
+    color: tuple[float, ...] = (1.0, 1.0, 1.0)
+
+    def __init__(self, **data):
+        super().__init__(**data)
+
+        # Make sure that all color channel values are floating point
+        self.color = tuple(map(float, self.color))
 
     def check_dim(self, dim):
         if len(self.color) > dim:
@@ -51,7 +57,7 @@ class ColorTexture(Texture):
     def apply_cutoff(self, cutoff):
         if cutoff is None:
             return
-        self.color = tuple([1.0 if c >= cutoff else 0.0 for c in self.color])
+        self.color = tuple(1.0 if c >= cutoff else 0.0 for c in self.color)
 
 
 class ImageTexture(Texture):


### PR DESCRIPTION
## Description

* Clearer exception traceback in case of invalid mask for nested data accessor.
* Fix support of numpy scalar types for pyrender shader.
* Fix weird bug caused by passing int color dtype.
* Fix 'gs view' utility.
* Fix URDF parsing legacy fallback

## Related Issue

Supersedes https://github.com/Genesis-Embodied-AI/Genesis/pull/1255
Resolves Genesis-Embodied-AI/Genesis/issues/1236
Related to Genesis-Embodied-AI/Genesis/discussions/1250

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

