### PR TITLE
[BUG FIX] Fix shadows and plane reflection for offscreen rendering.

### DIFF
--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -964,7 +964,7 @@ class RigidSolver(Solver):
         self.geoms_state = struct_geom_state.field(
             shape=self._batch_shape(self.n_geoms_), needs_grad=False, layout=ti.Layout.SOA
         )
-        self._geoms_render_T = np.empty((self.n_geoms_, self._B, 4, 4), dtype=gs.np_float)
+        self._geoms_render_T = np.empty((self.n_geoms_, self._B, 4, 4), order="F", dtype=np.float32)
 
         if self.n_geoms > 0:
             # Make sure that the constraints parameters are valid
@@ -1147,7 +1147,7 @@ class RigidSolver(Solver):
         self.vgeoms_state = struct_vgeom_state.field(
             shape=self._batch_shape(self.n_vgeoms_), needs_grad=False, layout=ti.Layout.SOA
         )
-        self._vgeoms_render_T = np.empty((self.n_vgeoms_, self._B, 4, 4), dtype=gs.np_float)
+        self._vgeoms_render_T = np.empty((self.n_vgeoms_, self._B, 4, 4), order="F", dtype=np.float32)
 
         if self.n_vgeoms > 0:
             vgeoms = self.vgeoms

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -4545,6 +4545,12 @@ class RigidSolver(Solver):
         return tensor.squeeze(0) if self.n_envs == 0 else tensor
 
     def get_links_root_COM(self, links_idx=None, envs_idx=None, *, unsafe=False):
+        """
+        Returns the center of mass (COM) of the entire kinematic tree to which the specified links belong.
+
+        This corresponds to the global COM of each entity, assuming a single-rooted structure — that is, as long as no
+        two successive links are connected by a free-floating joint (ie a joint that allows all 6 degrees of freedom).
+        """
         tensor = ti_field_to_torch(self.links_state.COM, envs_idx, links_idx, transpose=True, unsafe=unsafe)
         return tensor.squeeze(0) if self.n_envs == 0 else tensor
 

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -3333,7 +3333,7 @@ class RigidSolver(Solver):
                 self.geoms_state[i_g, i_b].quat,
             )
             for i, j in ti.static(ti.ndrange(4, 4)):
-                geoms_render_T[i_g, i_b, i, j] = geom_T[i, j]
+                geoms_render_T[i_g, i_b, i, j] = ti.cast(geom_T[i, j], ti.float32)
 
     def update_geoms_render_T(self):
         self._kernel_update_geoms_render_T(self._geoms_render_T)
@@ -3347,7 +3347,7 @@ class RigidSolver(Solver):
                 self.vgeoms_state[i_g, i_b].quat,
             )
             for i, j in ti.static(ti.ndrange(4, 4)):
-                vgeoms_render_T[i_g, i_b, i, j] = geom_T[i, j]
+                vgeoms_render_T[i_g, i_b, i, j] = ti.cast(geom_T[i, j], ti.float32)
 
     def update_vgeoms_render_T(self):
         self._kernel_update_vgeoms_render_T(self._vgeoms_render_T)

--- a/genesis/ext/pyrender/jit_render.py
+++ b/genesis/ext/pyrender/jit_render.py
@@ -832,14 +832,14 @@ class JITRenderer:
 
     def update_buffer(self, buffer_updates):
         updates = np.zeros((len(buffer_updates), 3), dtype=np.int64)
-        flattened_list = []
+        buffers = []
         for idx, (id, data) in enumerate(buffer_updates.items()):
-            flattened = data.astype(np.float32, order="C", copy=False).reshape((-1,))
-            flattened_list.append(flattened)
+            buffer = data.astype(np.float32, order="C", copy=False)
+            buffers.append(buffer)
 
             updates[idx, 0] = id
-            updates[idx, 1] = 4 * len(flattened)
-            updates[idx, 2] = flattened.ctypes.data
+            updates[idx, 1] = 4 * buffer.size
+            updates[idx, 2] = buffer.ctypes.data
 
         if self._update_buffer is None:
             self.gen_func_ptr()

--- a/genesis/ext/pyrender/numba_gl_wrapper.py
+++ b/genesis/ext/pyrender/numba_gl_wrapper.py
@@ -84,7 +84,7 @@ class GLWrapper:
             except AttributeError:
                 # OpenGL function not available, probably because the installed version does not support it (too old).
                 # Moving to the next one without raising an exception since it is not blocking at this point.
-                gs.logger.info(f"OpenGL function '{name}' not available on this machine.")
+                gs.logger.debug(f"OpenGL function '{name}' not available on this machine.")
 
         funcs = self.gl_funcs
         func_types = {}

--- a/genesis/ext/pyrender/platforms/egl.py
+++ b/genesis/ext/pyrender/platforms/egl.py
@@ -152,6 +152,7 @@ class EGLPlatform(Platform):
             eglChooseConfig,
             eglBindAPI,
             eglCreateContext,
+            eglMakeCurrent,
             EGLConfig,
             EGLError,
         )

--- a/genesis/ext/pyrender/platforms/egl.py
+++ b/genesis/ext/pyrender/platforms/egl.py
@@ -129,6 +129,7 @@ class EGLPlatform(Platform):
         _ensure_egl_loaded()
         from OpenGL.EGL import (
             EGL_SURFACE_TYPE,
+            EGL_NO_SURFACE,
             EGL_PBUFFER_BIT,
             EGL_BLUE_SIZE,
             EGL_RED_SIZE,
@@ -231,6 +232,9 @@ class EGLPlatform(Platform):
 
                 # Create an EGL context
                 egl_context = eglCreateContext(egl_display, configs[0], EGL_NO_CONTEXT, context_attributes)
+
+                # Select EGL context
+                assert eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, egl_context)
 
                 break
             except (AssertionError, EGLError) as e:

--- a/genesis/ext/pyrender/primitive.py
+++ b/genesis/ext/pyrender/primitive.py
@@ -342,7 +342,6 @@ class Primitive(object):
         #######################################################################
 
         # Generate and bind vertex buffer
-
         if self.stream_positions:
             posbuffer = glGenBuffers(1)
             self._buffers["pos"] = posbuffer

--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -644,7 +644,7 @@ class Viewer(pyglet.window.Window):
 
     def update_buffers(self):
         self._renderer.jit.update_buffer(self.pending_buffer_updates)
-        self.pending_buffer_updates = {}
+        self.pending_buffer_updates.clear()
 
     def wait_until_initialized(self):
         self._initialized_event.wait()

--- a/genesis/vis/rasterizer.py
+++ b/genesis/vis/rasterizer.py
@@ -64,6 +64,8 @@ class Rasterizer(RBC):
                     camera_node=self._camera_nodes[camera.uid],
                     env_separate_rigid=self._context.env_separate_rigid,
                     ret_depth=depth,
+                    plane_reflection=rgb and self._context.plane_reflection,
+                    shadow=rgb and self._context.shadow,
                     normal=normal,
                     seg=False,
                 )
@@ -75,6 +77,8 @@ class Rasterizer(RBC):
                     camera_node=self._camera_nodes[camera.uid],
                     env_separate_rigid=self._context.env_separate_rigid,
                     ret_depth=False,
+                    plane_reflection=False,
+                    shadow=False,
                     normal=False,
                     seg=True,
                 )

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -231,12 +231,8 @@ class RasterizerContext:
 
                 for link in links:
                     link_T = gu.trans_quat_to_T(links_pos[link.idx], links_quat[link.idx])
-                    buffer_updates[
-                        self._scene.get_buffer_id(
-                            self.link_frame_nodes[link.uid],
-                            "model",
-                        )
-                    ] = link_T.transpose([0, 2, 1])
+                    node = self._scene.get_buffer_id(self.link_frame_nodes[link.uid], "model")
+                    buffer_updates[node] = link_T.transpose((0, 2, 1))
 
     def on_tool(self):
         if self.sim.tool_solver.is_active():
@@ -320,9 +316,8 @@ class RasterizerContext:
 
                 for geom in geoms:
                     geom_T = geoms_T[geom.idx][self.rendered_envs_idx]
-                    buffer_updates[self._scene.get_buffer_id(self.rigid_nodes[geom.uid], "model")] = geom_T.transpose(
-                        [0, 2, 1]
-                    )
+                    node = self.rigid_nodes[geom.uid]
+                    buffer_updates[self._scene.get_buffer_id(node, "model")] = geom_T.transpose((0, 2, 1))
                     if isinstance(rigid_entity._morph, gs.morphs.Plane):
                         self.set_reflection_mat(geom_T)
 
@@ -389,9 +384,8 @@ class RasterizerContext:
 
                 for geom in geoms:
                     geom_T = geoms_T[geom.idx]
-                    buffer_updates[self._scene.get_buffer_id(self.rigid_nodes[geom.uid], "model")] = geom_T.transpose(
-                        [0, 2, 1]
-                    )
+                    node = self._scene.get_buffer_id(self.rigid_nodes[geom.uid], "model")
+                    buffer_updates[node] = geom_T.transpose((0, 2, 1))
 
     def on_mpm(self):
         if self.sim.mpm_solver.is_active():
@@ -420,12 +414,7 @@ class RasterizerContext:
                 self.add_node(
                     pyrender.Mesh.from_trimesh(
                         mu.create_box(
-                            bounds=np.array(
-                                [
-                                    self.sim.mpm_solver.boundary.lower,
-                                    self.sim.mpm_solver.boundary.upper,
-                                ]
-                            ),
+                            bounds=np.array([self.sim.mpm_solver.boundary.lower, self.sim.mpm_solver.boundary.upper]),
                             wireframe=True,
                             color=(1.0, 1.0, 0.0, 1.0),
                         ),
@@ -456,12 +445,8 @@ class RasterizerContext:
                     tfs = np.tile(np.eye(4), (mpm_entity.n_particles, 1, 1))
                     tfs[:, :3, 3] = particles_all[mpm_entity.particle_start : mpm_entity.particle_end]
 
-                    buffer_updates[
-                        self._scene.get_buffer_id(
-                            self.static_nodes[mpm_entity.uid],
-                            "model",
-                        )
-                    ] = tfs.transpose([0, 2, 1])
+                    node = self._scene.get_buffer_id(self.static_nodes[mpm_entity.uid], "model")
+                    buffer_updates[node] = tfs.transpose((0, 2, 1))
 
                 elif mpm_entity.surface.vis_mode == "visual":
                     mpm_entity._vmesh.verts = vverts_all[mpm_entity.vvert_start : mpm_entity.vvert_end]
@@ -490,12 +475,7 @@ class RasterizerContext:
                 self.add_node(
                     pyrender.Mesh.from_trimesh(
                         mu.create_box(
-                            bounds=np.array(
-                                [
-                                    self.sim.sph_solver.boundary.lower,
-                                    self.sim.sph_solver.boundary.upper,
-                                ]
-                            ),
+                            bounds=np.array([self.sim.sph_solver.boundary.lower, self.sim.sph_solver.boundary.upper]),
                             wireframe=True,
                             color=(0.0, 1.0, 1.0, 1.0),
                         ),
@@ -526,12 +506,8 @@ class RasterizerContext:
                     tfs = np.tile(np.eye(4), (sph_entity.n_particles, 1, 1))
                     tfs[:, :3, 3] = particles_all[sph_entity.particle_start : sph_entity.particle_end]
 
-                    buffer_updates[
-                        self._scene.get_buffer_id(
-                            self.static_nodes[sph_entity.uid],
-                            "model",
-                        )
-                    ] = tfs.transpose([0, 2, 1])
+                    node = self._scene.get_buffer_id(self.static_nodes[sph_entity.uid], "model")
+                    buffer_updates[node] = tfs.transpose((0, 2, 1))
 
     def on_pbd(self):
         if self.sim.pbd_solver.is_active():
@@ -572,12 +548,7 @@ class RasterizerContext:
                 self.add_node(
                     pyrender.Mesh.from_trimesh(
                         mu.create_box(
-                            bounds=np.array(
-                                [
-                                    self.sim.pbd_solver.boundary.lower,
-                                    self.sim.pbd_solver.boundary.upper,
-                                ]
-                            ),
+                            bounds=np.array([self.sim.pbd_solver.boundary.lower, self.sim.pbd_solver.boundary.upper]),
                             wireframe=True,
                             color=(0.0, 1.0, 1.0, 1.0),
                         ),
@@ -610,12 +581,8 @@ class RasterizerContext:
                         tfs = np.tile(np.eye(4), (pbd_entity.n_particles, 1, 1))
                         tfs[:, :3, 3] = particles_all[pbd_entity.particle_start : pbd_entity.particle_end]
 
-                        buffer_updates[
-                            self._scene.get_buffer_id(
-                                self.static_nodes[pbd_entity.uid],
-                                "model",
-                            )
-                        ] = tfs.transpose([0, 2, 1])
+                        node = self._scene.get_buffer_id(self.static_nodes[pbd_entity.uid], "model")
+                        buffer_updates[node] = tfs.transpose((0, 2, 1))
 
                     elif self.render_particle_as == "tet":
                         new_verts = mu.transform_tets_mesh_verts(

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -317,6 +317,9 @@ class RasterizerContext:
                 for geom in geoms:
                     geom_T = geoms_T[geom.idx][self.rendered_envs_idx]
                     node = self.rigid_nodes[geom.uid]
+                    node.mesh._bounds = None
+                    for primitive in node.mesh.primitives:
+                        primitive.poses = geom_T
                     buffer_updates[self._scene.get_buffer_id(node, "model")] = geom_T.transpose((0, 2, 1))
                     if isinstance(rigid_entity._morph, gs.morphs.Plane):
                         self.set_reflection_mat(geom_T)
@@ -385,6 +388,9 @@ class RasterizerContext:
                 for geom in geoms:
                     geom_T = geoms_T[geom.idx]
                     node = self._scene.get_buffer_id(self.rigid_nodes[geom.uid], "model")
+                    node.mesh._bounds = None
+                    for primitive in node.mesh.primitives:
+                        primitive.poses = geom_T
                     buffer_updates[node] = geom_T.transpose((0, 2, 1))
 
     def on_mpm(self):
@@ -775,6 +781,7 @@ class RasterizerContext:
         # update variables not used in simulation
         self.visualizer.update_visual_states()
 
+        self._scene._bounds = None
         self.update_link_frame(buffer_updates)
         self.update_tool(buffer_updates)
         self.update_rigid(buffer_updates)

--- a/genesis/vis/viewer.py
+++ b/genesis/vis/viewer.py
@@ -140,9 +140,7 @@ class Viewer(RBC):
             self.update_following()
 
         with self.lock:
-            buffer_updates = self.context.update()
-            for buffer_id, buffer_data in buffer_updates.items():
-                self._pyrender_viewer.pending_buffer_updates[buffer_id] = buffer_data
+            self._pyrender_viewer.pending_buffer_updates |= self.context.update()
 
             # Refresh viewer by default if and if this is possible
             if auto_refresh is None:

--- a/genesis/vis/visualizer.py
+++ b/genesis/vis/visualizer.py
@@ -123,15 +123,11 @@ class Visualizer(RBC):
 
         self._context.reset()
 
-        # temp fix for cam.render() segfault
+        # Need to update viewer once here, because otherwise camera will update scene if render is called right after
+        # build, which will lead to segfault.
         if self._viewer is not None:
-            # need to update viewer once here, because otherwise camera will update scene if render is called right
-            # after build, which will lead to segfault.
-            # TODO: this slows down visualizer.update(). Needs to remove this once the bug is fixed.
-            try:
+            if self._viewer.is_alive():
                 self._viewer.update(auto_refresh=True)
-            except:
-                pass
 
         if self._raytracer is not None:
             self._raytracer.reset()


### PR DESCRIPTION
## Description

* Pass `shadow` and `plane_reflection` optional argument to low-level Pyrender offscreen rasterizer.
* Dynamically update scene bounds to fix shadow clipping issues 

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/1264
Resolves Genesis-Embodied-AI/Genesis/issues/1279

## Motivation and Context

Shadows and plane reflections were forcibly disabled by mistake in a previous PR of myself intended to make rendering fully deterministic. Besides, shadow clipping area is currently only computed once at init of the simulation, this leads to shadow clipping issues, especially when rendering floating base entities that are spanning a small area (e.g. a single ball).

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] All new and existing tests passed.
