### PR TITLE
[MISC] Update default FEM damping 45.0 -> 0.0

### DIFF
--- a/examples/tutorials/advanced_muscle.py
+++ b/examples/tutorials/advanced_muscle.py
@@ -24,7 +24,6 @@ scene = gs.Scene(
     ),
     fem_options=gs.options.FEMOptions(
         dt=dt,
-        damping=45.0,
     ),
     vis_options=gs.options.VisOptions(
         show_world_frame=False,

--- a/genesis/options/solvers.py
+++ b/genesis/options/solvers.py
@@ -507,7 +507,7 @@ class FEMOptions(Options):
     gravity : tuple, optional
         Gravity force in N/kg. If none, it will inherit from `SimOptions`. Defaults to None.
     damping : float, optional
-        Damping factor. Defaults to 45.0.
+        Damping factor. Defaults to 0.0.
     floor_height : float, optional
         Height of the floor in meters. If none, it will inherit from `SimOptions`. Defaults to None.
     use_implicit_solver : bool, optional

--- a/tests/test_deformable_physics.py
+++ b/tests/test_deformable_physics.py
@@ -108,7 +108,7 @@ def test_deformable_parallel(show_viewer):
             upper_bound=(0.33, 0.33, 1.0),
         ),
         fem_options=gs.options.FEMOptions(
-            damping=45.0,
+            damping=0.0,
         ),
         mpm_options=gs.options.MPMOptions(
             lower_bound=(0.5, -0.1, -0.05),

--- a/tests/test_fem.py
+++ b/tests/test_fem.py
@@ -26,7 +26,7 @@ def test_multiple_fem_entities(fem_material, show_viewer):
             gravity=(0.0, 0.0, 0.0),
         ),
         fem_options=gs.options.FEMOptions(
-            damping=45.0,
+            damping=0.0,
         ),
         show_viewer=show_viewer,
     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
Change FEM options to show damping = 0.0, update some tests which used damping = 45.

## Related Issue
Resolves https://github.com/Genesis-Embodied-AI/Genesis/issues/1278

## Motivation and Context
Had some confusion because the docs set default damping to 45.

## How Has This Been / Can This Be Tested?
N/A

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
