### PR TITLE
[Feature] Terrain texture user option

### DIFF
--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -893,6 +893,8 @@ class Terrain(Morph):
         The size of each cell in the subterrain in meters. Defaults to 0.25.
     vertical_scale : float, optional
         The height of each step in the subterrain in meters. Defaults to 0.005.
+    uv_scale : float, optional
+        The scale of the UV mapping for the terrain. Defaults to 1.0.
     subterrain_types : str or 2D list of str, optional
         The types of subterrains to generate. If a string, it will be repeated for all subterrains. If a 2D list, it should have the same shape as `n_subterrains`.
     height_field : array-like, optional
@@ -911,6 +913,7 @@ class Terrain(Morph):
     subterrain_size: Tuple[float, float] = (12.0, 12.0)  # meter
     horizontal_scale: float = 0.25  # meter size of each cell in the subterrain
     vertical_scale: float = 0.005  # meter height of each step in the subterrain
+    uv_scale: float = 1.0
     subterrain_types: Any = [
         ["flat_terrain", "random_uniform_terrain", "stepping_stones_terrain"],
         ["pyramid_sloped_terrain", "discrete_obstacles_terrain", "wave_terrain"],

--- a/genesis/utils/terrain.py
+++ b/genesis/utils/terrain.py
@@ -364,6 +364,9 @@ def convert_heightfield_to_watertight_trimesh(
 
     sdf_mesh = trimesh.Trimesh(vertices, triangles, process=False, visual=visual)
 
+    # This is the mesh used for non-sdf purposes.
+    # It's losslessly simplified from the full mesh, to save memory cost for storing verts and faces.
+
     v_simp, f_simp = fast_simplification.simplify(
         sdf_mesh.vertices,
         sdf_mesh.faces,
@@ -378,9 +381,6 @@ def convert_heightfield_to_watertight_trimesh(
             idx_map[i] = np.argmin(dists)
 
         uv_simp = uvs[idx_map]
-
-        # This is the mesh used for non-sdf purposes.
-        # It's losslessly simplified from the full mesh, to save memory cost for storing verts and faces.
 
         mesh = trimesh.Trimesh(
             v_simp,

--- a/genesis/utils/terrain.py
+++ b/genesis/utils/terrain.py
@@ -150,11 +150,12 @@ def parse_terrain(morph: Terrain, surface):
                         i * subterrain_rows : (i + 1) * subterrain_rows, j * subterrain_cols : (j + 1) * subterrain_cols
                     ] = subterrain_height_field
 
+        need_uvs = getattr(surface, "diffuse_texture", None) is not None
         tmesh, sdf_tmesh = convert_heightfield_to_watertight_trimesh(
             heightfield,
             horizontal_scale=morph.horizontal_scale,
             vertical_scale=morph.vertical_scale,
-            uv_scale=morph.uv_scale,
+            uv_scale=morph.uv_scale if need_uvs else None,
         )
 
         terrain_dir = os.path.join(get_assets_dir(), f"terrain/{morph.name}")
@@ -213,7 +214,7 @@ def fractal_terrain(terrain, levels=8, scale=1.0):
 
 
 def convert_heightfield_to_watertight_trimesh(
-    height_field_raw, horizontal_scale, vertical_scale, slope_threshold=None, uv_scale=1.0
+    height_field_raw, horizontal_scale, vertical_scale, slope_threshold=None, uv_scale=None
 ):
     """
     Adapted from Issac Gym's `convert_heightfield_to_trimesh` function.
@@ -266,12 +267,9 @@ def convert_heightfield_to_watertight_trimesh(
 
     # create triangle mesh vertices and triangles from the heightfield grid
     vertices_top = np.zeros((num_rows * num_cols, 3), dtype=np.float32)
-    vertices_top[:, 0] = xx.flatten()
-    vertices_top[:, 1] = yy.flatten()
+    vertices_top[:, 0] = xx.flat
+    vertices_top[:, 1] = yy.flat
     vertices_top[:, 2] = hf.flatten() * vertical_scale
-    uv_top = np.zeros((num_rows * num_cols, 2), dtype=np.float32)
-    uv_top[:, 0] = (xx.flatten() - xx.min()) / (xx.max() - xx.min()) * uv_scale
-    uv_top[:, 1] = (yy.flatten() - yy.min()) / (yy.max() - yy.min()) * uv_scale
     triangles_top = -np.ones((2 * (num_rows - 1) * (num_cols - 1), 3), dtype=np.uint32)
     for i in range(num_rows - 1):
         ind0 = np.arange(0, num_cols - 1) + i * num_cols
@@ -291,8 +289,8 @@ def convert_heightfield_to_watertight_trimesh(
     z_min = np.min(vertices_top[:, 2]) - 1.0
 
     vertices_bottom = np.zeros((num_rows * num_cols, 3), dtype=np.float32)
-    vertices_bottom[:, 0] = xx.flatten()
-    vertices_bottom[:, 1] = yy.flatten()
+    vertices_bottom[:, 0] = xx.flat
+    vertices_bottom[:, 1] = yy.flat
     vertices_bottom[:, 2] = z_min
     triangles_bottom = -np.ones((2 * (num_rows - 1) * (num_cols - 1), 3), dtype=np.uint32)
     for i in range(num_rows - 1):
@@ -352,18 +350,45 @@ def convert_heightfield_to_watertight_trimesh(
         [triangles_top, triangles_bottom, triangles_side_0, triangles_side_1, triangles_side_2, triangles_side_3],
         axis=0,
     )
-    uvs = np.concatenate(
-        [uv_top, uv_top],
-        axis=0,
-    )
-    visual = trimesh.visual.TextureVisuals(uv=uvs)
-    # This a uniformly-distributed full mesh, which gives faster sdf generation
+
+    if uv_scale is not None:
+        uv_top = np.zeros((num_rows * num_cols, 2), dtype=np.float32)
+        uv_top[:, 0] = (xx.flat - xx.min()) / (xx.max() - xx.min()) * uv_scale
+        uv_top[:, 1] = (yy.flat - yy.min()) / (yy.max() - yy.min()) * uv_scale
+
+        uvs = np.concatenate([uv_top, uv_top], axis=0)
+        visual = trimesh.visual.TextureVisuals(uv=uvs)
+    else:
+        uvs = None
+        visual = None
+
     sdf_mesh = trimesh.Trimesh(vertices, triangles, process=False, visual=visual)
 
-    # This is the mesh used for non-sdf purposes.
-    # It's losslessly simplified from the full mesh, to save memory cost for storing verts and faces.
+    v_simp, f_simp = fast_simplification.simplify(
+        sdf_mesh.vertices,
+        sdf_mesh.faces,
+        target_count=0,
+        lossless=True,
+    )
 
-    mesh = sdf_mesh.copy()
+    if uvs is not None:
+        idx_map = np.empty(len(v_simp), dtype=np.int64)
+        for i, v in enumerate(v_simp):
+            dists = np.square(vertices - v).sum(axis=1)
+            idx_map[i] = np.argmin(dists)
+
+        uv_simp = uvs[idx_map]
+
+        # This is the mesh used for non-sdf purposes.
+        # It's losslessly simplified from the full mesh, to save memory cost for storing verts and faces.
+
+        mesh = trimesh.Trimesh(
+            v_simp,
+            f_simp,
+            visual=trimesh.visual.TextureVisuals(uv=uv_simp),
+        )
+    else:
+        mesh = trimesh.Trimesh(v_simp, f_simp)
 
     return mesh, sdf_mesh
 


### PR DESCRIPTION
Added feature that allows user to upload a scalable texture "uv_scale" to the terrain instead of always being the default white one. 

Resolves #1252 

Without pattern:
<img width="603" alt="Screenshot 2025-06-24 at 11 16 52 AM" src="https://github.com/user-attachments/assets/960a00cd-4486-4477-b8df-6664550820ab" />

With pattern:
<img width="667" alt="Screenshot 2025-06-24 at 11 19 08 AM" src="https://github.com/user-attachments/assets/3b5554ac-90cc-40af-bc5c-ebbed99917a6" />

Code to reproduce: 

```
from genesis import gs

gs.init(backend=gs.cpu)

scene = gs.Scene(show_viewer=True)

scene.add_entity(
    surfaces.Rough(
        roughness=0.3,
        diffuse_texture=gs.textures.ImageTexture(image_path="genesis/assets/textures/checker.png"),
    ),
    morph=gs.morphs.Terrain(
        n_subterrains=(3, 3),
        horizontal_scale=0.25
        subterrain_types="wave_terrain",
        uv_scale=9.0,
        subterrain_parameters={"wave_terrain": {"amplitude": 0.2}},
    ),
)

scene.build()

for _ in range(500):
    scene.step()
```