### PR TITLE
[BUG FIX] Timers did not call ti.sync on create/reset

### DIFF
--- a/genesis/utils/tools.py
+++ b/genesis/utils/tools.py
@@ -65,6 +65,8 @@ class Timer:
         self.just_reset = True
         if self.level == 0 and not self.skip:
             print("─" * os.get_terminal_size()[0])
+        if self.ti_sync:
+            ti.sync()
         self.prev_time = self.init_time = time.perf_counter()
 
     def _stamp(self, msg="", _ratio=1.0):


### PR DESCRIPTION
Timers did not call ti.sync on create/reset when created with ti_sync=True parameter.
This caused invalid timings on the first call to timer.stamp().

## Description
Added ti.sync() call to Timer.reset()

## Related Issue

## Motivation and Context
Detailed profiling of sim on GPU

## How Has This Been / Can This Be Tested?

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
