### PR TITLE
[FEATURE] Environment-wise gravity

### DIFF
--- a/genesis/engine/coupler.py
+++ b/genesis/engine/coupler.py
@@ -200,7 +200,7 @@ class Coupler(RBC):
                 vel_mpm = (1 / self.mpm_solver.grid[f, I, i_b].mass) * self.mpm_solver.grid[f, I, i_b].vel_in
 
                 # gravity
-                vel_mpm += self.mpm_solver.substep_dt * self.mpm_solver._gravity[None]
+                vel_mpm += self.mpm_solver.substep_dt * self.mpm_solver._gravity[i_b]
 
                 pos = (I + self.mpm_solver.grid_offset) * self.mpm_solver.dx
                 mass_mpm = self.mpm_solver.grid[f, I, i_b].mass / self.mpm_solver._p_vol_scale

--- a/genesis/engine/simulator.py
+++ b/genesis/engine/simulator.py
@@ -196,10 +196,13 @@ class Simulator(RBC):
         self._g_ti = ti.Vector.field(3, gs.ti_float, shape=self._B)
         self._g_ti.from_numpy(g_np)
 
+        for solver in self._solvers:
+            solver._gravity = self._g_ti
+
         # solvers
         self._rigid_only = self.rigid_solver.is_active()
         for solver in self._solvers:
-            solver._finalize_batch(self._B)
+            # solver._finalize_batch(self._B)
             solver.build()
             if solver.is_active():
                 self._active_solvers.append(solver)

--- a/genesis/engine/simulator.py
+++ b/genesis/engine/simulator.py
@@ -202,7 +202,6 @@ class Simulator(RBC):
         # solvers
         self._rigid_only = self.rigid_solver.is_active()
         for solver in self._solvers:
-            # solver._finalize_batch(self._B)
             solver.build()
             if solver.is_active():
                 self._active_solvers.append(solver)

--- a/genesis/engine/simulator.py
+++ b/genesis/engine/simulator.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING
 import numpy as np
 import taichi as ti
-import torch
 
 import genesis as gs
 from genesis.engine.entities.base_entity import Entity
@@ -184,6 +183,7 @@ class Simulator(RBC):
             solver._add_force_field(force_field)
 
     def build(self):
+
         self.n_envs = self.scene.n_envs
         self._B = self.scene._B
         self._para_level = self.scene._para_level

--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -34,7 +34,7 @@ class Solver(RBC):
     def build(self):
         self._B = self._sim._B
         if self._init_gravity is not None:
-            g_np = np.asarray(self._init_gravity, dtype=np.float32)
+            g_np = np.asarray(self._init_gravity, dtype=gs.np_float)
             g_np = np.repeat(g_np[None], self._B, axis=0)
             self._gravity = ti.Vector.field(3, dtype=gs.ti_float, shape=self._B)
             self._gravity.from_numpy(g_np)
@@ -43,7 +43,7 @@ class Solver(RBC):
     def set_gravity(self, gravity, envs_idx=None):
         if self._gravity is None:
             return
-        g = np.asarray(gravity, dtype=np.float32)
+        g = np.asarray(gravity, dtype=gs.np_float)
         if envs_idx is None:
             if g.ndim == 1:
                 g = np.repeat(g[None], self._B, axis=0)

--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -17,8 +17,8 @@ class Solver(RBC):
         self._uid = gs.UID()
         self._sim = sim
         self._scene = scene
-        self._dt = options.dt
-        self._substep_dt = options.dt / sim.substeps
+        self._dt: float = options.dt
+        self._substep_dt: float = options.dt / sim.substeps
 
         self._gravity_cfg = np.asarray(options.gravity, gs.np_float) if hasattr(options, "gravity") else None
         self._gravity = None

--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -19,7 +19,7 @@ class Solver(RBC):
         self._scene = scene
         self._dt: float = options.dt
         self._substep_dt: float = options.dt / sim.substeps
-        self._gravity = sim.gravity
+        self._gravity = None
         self._entities: list[Entity] = gs.List()
 
         # force fields
@@ -27,6 +27,21 @@ class Solver(RBC):
 
     def _add_force_field(self, force_field):
         self._ffs.append(force_field)
+
+    def build(self, B: int):
+        self._B = B
+        g_np = np.asarray(self._sim._gravity)
+        g_np = np.repeat(g_np[None], B, axis=0)
+        self._gravity = ti.Vector.field(3, dtype=gs.ti_float, shape=B)
+        self._gravity.from_numpy(g_np)
+
+    def set_gravity(self, gravity, envs_idx=None):
+        if self._gravity is None:
+            return
+        if envs_idx is None:
+            self._gravity.copy_from(gravity)
+        else:
+            self._gravity[envs_idx] = gravity
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------

--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -31,14 +31,18 @@ class Solver(RBC):
 
     def build(self):
         self._B = self._sim._B
-        if self._init_gravity is not None:
-            g_np = np.asarray(self._init_gravity, dtype=gs.np_float)
-        else:
-            g_np = np.asarray(self._sim._gravity, dtype=gs.np_float)
+
+        g_np = np.asarray(
+            self._init_gravity if self._init_gravity is not None else self._sim._gravity,
+            dtype=np.float32,
+        )
         g_np = np.repeat(g_np[None], self._B, axis=0)
 
         self._gravity = ti.Vector.field(3, dtype=gs.ti_float, shape=self._B)
         self._gravity.from_numpy(g_np)
+
+        if self._B == 1:
+            self._gravity.to_numpy = lambda _orig=self._gravity.to_numpy: _orig().squeeze(0)  # noqa: E251
 
     def set_gravity(self, gravity, envs_idx=None):
         if self._gravity is None:

--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -19,9 +19,9 @@ class Solver(RBC):
         self._scene = scene
         self._dt: float = options.dt
         self._substep_dt: float = options.dt / sim.substeps
-
-        self._gravity_cfg = np.asarray(options.gravity, gs.np_float) if hasattr(options, "gravity") else None
-        self._gravity = None
+        self._gravity = sim.gravity
+        # self._gravity_cfg = np.asarray(options.gravity, gs.np_float) if hasattr(options, "gravity") else None
+        # self._gravity = None
 
         self._entities: list[Entity] = gs.List()
 
@@ -31,6 +31,7 @@ class Solver(RBC):
     def _add_force_field(self, force_field):
         self._ffs.append(force_field)
 
+    """
     def _finalize_batch(self, B: int):
         if self._gravity_cfg is None or self._gravity is not None:
             return
@@ -39,7 +40,7 @@ class Solver(RBC):
         if g.ndim == 1:
             g = np.tile(g[None, :], (B, 1))
         self._gravity.from_numpy(g[..., None])
-
+    """
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------
     # ------------------------------------------------------------------------------------

--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -20,9 +20,6 @@ class Solver(RBC):
         self._dt: float = options.dt
         self._substep_dt: float = options.dt / sim.substeps
         self._gravity = sim.gravity
-        # self._gravity_cfg = np.asarray(options.gravity, gs.np_float) if hasattr(options, "gravity") else None
-        # self._gravity = None
-
         self._entities: list[Entity] = gs.List()
 
         # force fields
@@ -31,16 +28,6 @@ class Solver(RBC):
     def _add_force_field(self, force_field):
         self._ffs.append(force_field)
 
-    """
-    def _finalize_batch(self, B: int):
-        if self._gravity_cfg is None or self._gravity is not None:
-            return
-        self._gravity = ti.field(dtype=gs.ti_vec3, shape=(B,))
-        g = self._gravity_cfg
-        if g.ndim == 1:
-            g = np.tile(g[None, :], (B, 1))
-        self._gravity.from_numpy(g[..., None])
-    """
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------
     # ------------------------------------------------------------------------------------

--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -38,8 +38,6 @@ class Solver(RBC):
             g_np = np.repeat(g_np[None], self._B, axis=0)
             self._gravity = ti.Vector.field(3, dtype=gs.ti_float, shape=self._B)
             self._gravity.from_numpy(g_np)
-        else:
-            self._gravity = None
 
     @gs.assert_built
     def set_gravity(self, gravity, envs_idx=None):

--- a/genesis/engine/solvers/fem_solver.py
+++ b/genesis/engine/solvers/fem_solver.py
@@ -276,9 +276,9 @@ class FEMSolver(Solver):
             entity.reset_grad()
 
     def build(self):
+        super().build()
         self.n_envs = self.sim.n_envs
         self._B = self.sim._B
-        super().build(self._B)
 
         # batch fields
         self.init_batch_fields()

--- a/genesis/engine/solvers/fem_solver.py
+++ b/genesis/engine/solvers/fem_solver.py
@@ -389,7 +389,7 @@ class FEMSolver(Solver):
             #       however, this inevitably damp the gravity.
             self.elements_v[f + 1, i_v, i_b].vel *= ti.exp(-dt * self.damping)
             # Add gravity (avoiding damping on gravity)
-            self.elements_v[f + 1, i_v, i_b].vel += dt * self._gravity[None]
+            self.elements_v[f + 1, i_v, i_b].vel += dt * self._gravity[i_b]
 
     @ti.kernel
     def compute_pos(self, f: ti.i32):
@@ -416,7 +416,7 @@ class FEMSolver(Solver):
         dt = self.substep_dt
         for i_v, i_b in ti.ndrange(self.n_vertices, self._B):
             self.elements_v_energy[i_b, i_v].inertia = (
-                self.elements_v[f, i_v, i_b].pos + self.elements_v[f, i_v, i_b].vel * dt + self._gravity[None] * dt**2
+                self.elements_v[f, i_v, i_b].pos + self.elements_v[f, i_v, i_b].vel * dt + self._gravity[i_b] * dt**2
             )
             self.elements_v[f + 1, i_v, i_b].pos = self.elements_v[f, i_v, i_b].pos
 

--- a/genesis/engine/solvers/fem_solver.py
+++ b/genesis/engine/solvers/fem_solver.py
@@ -278,6 +278,7 @@ class FEMSolver(Solver):
     def build(self):
         self.n_envs = self.sim.n_envs
         self._B = self.sim._B
+        super().build(self._B)
 
         # batch fields
         self.init_batch_fields()

--- a/genesis/engine/solvers/mpm_solver.py
+++ b/genesis/engine/solvers/mpm_solver.py
@@ -197,7 +197,6 @@ class MPMSolver(Solver):
 
     def build(self):
         super().build()
-
         # particles and entities
         self._B = self._sim._B
 

--- a/genesis/engine/solvers/mpm_solver.py
+++ b/genesis/engine/solvers/mpm_solver.py
@@ -198,6 +198,7 @@ class MPMSolver(Solver):
     def build(self):
         # particles and entities
         self._B = self._sim._B
+        super().build(self._B)
 
         self._n_particles = self.n_particles
         self._n_vverts = self.n_vverts

--- a/genesis/engine/solvers/mpm_solver.py
+++ b/genesis/engine/solvers/mpm_solver.py
@@ -196,9 +196,10 @@ class MPMSolver(Solver):
             entity.reset_grad()
 
     def build(self):
+        super().build()
+
         # particles and entities
         self._B = self._sim._B
-        super().build(self._B)
 
         self._n_particles = self.n_particles
         self._n_vverts = self.n_vverts

--- a/genesis/engine/solvers/pbd_solver.py
+++ b/genesis/engine/solvers/pbd_solver.py
@@ -371,7 +371,7 @@ class PBDSolver(Solver):
         for i_p, i_b in ti.ndrange(self._n_particles, self._B):
             if self.particles[i_p, i_b].free:
                 # gravity
-                self.particles[i_p, i_b].vel = self.particles[i_p, i_b].vel + self._gravity[None] * self._substep_dt
+                self.particles[i_p, i_b].vel = self.particles[i_p, i_b].vel + self._gravity[i_b] * self._substep_dt
 
                 # external force fields
                 acc = ti.Vector.zero(gs.ti_float, 3)

--- a/genesis/engine/solvers/pbd_solver.py
+++ b/genesis/engine/solvers/pbd_solver.py
@@ -209,6 +209,7 @@ class PBDSolver(Solver):
 
     def build(self):
         self._B = self._sim._B
+        super().build(self._B)
         self._n_particles = self.n_particles
         self._n_fluid_particles = self.n_fluid_particles
         self._n_edges = self.n_edges

--- a/genesis/engine/solvers/pbd_solver.py
+++ b/genesis/engine/solvers/pbd_solver.py
@@ -208,8 +208,8 @@ class PBDSolver(Solver):
         self._ckpt = dict()
 
     def build(self):
+        super().build()
         self._B = self._sim._B
-        super().build(self._B)
         self._n_particles = self.n_particles
         self._n_fluid_particles = self.n_fluid_particles
         self._n_edges = self.n_edges

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -2969,7 +2969,6 @@ class RigidSolver(Solver):
                     i_p = self.links_info[I_l].parent_idx
 
                     if i_p == -1:
-                        self.links_state[i_l, i_b].cdd_vel = -self._gravity[None] * (1 - e_info.gravity_compensation)
                         self.links_state[i_l, i_b].cdd_vel = -self._gravity[i_b] * (1 - e_info.gravity_compensation)
                         self.links_state[i_l, i_b].cdd_ang = ti.Vector.zero(gs.ti_float, 3)
                         if ti.static(update_cacc):

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -44,11 +44,12 @@ def _sanitize_sol_params(
     if (timeconst < gs.EPS).any():
         # We deliberately set timeconst to be zero for urdf and meshes so that it can fall back to 2*dt
         gs.logger.debug(f"Constraint solver time constant not specified. Using minimum value (`{min_timeconst:0.6g}`).")
-    if ((timeconst > gs.EPS) & (timeconst + gs.EPS < min_timeconst)).any():
+    invalid_mask = (timeconst > gs.EPS) & (timeconst + gs.EPS < min_timeconst)
+    if invalid_mask.any():
         gs.logger.warning(
-            "Constraint solver time constant was increased to avoid numerical instability (from "
-            f"`{timeconst.min():0.6g}` to `{min_timeconst:0.6g}`). Decrease simulation timestep to avoid "
-            "altering the original value."
+            "Constraint solver time constant should be greater than 2*substep_dt. timeconst is changed from "
+            f"`{min(timeconst[invalid_mask]):0.6g}` to `{min_timeconst:0.6g}`). Decrease simulation timestep or "
+            "increase timeconst to avoid altering the original value."
         )
     timeconst[:] = timeconst.clip(min_timeconst)
     dampratio[:] = dampratio.clip(0.0)
@@ -239,10 +240,11 @@ class RigidSolver(Solver):
             return
 
         # Compute mass matrix without any implicit damping terms
-        self._kernel_compute_mass_matrix()
+        self._kernel_compute_mass_matrix(decompose=True)
 
         # Define some proxies for convenience
-        mass_mat = self.mass_mat.to_numpy()[:, :, 0]
+        mass_mat_D_inv = self.mass_mat_D_inv.to_numpy()[:, 0]
+        mass_mat_L = self.mass_mat_L.to_numpy()[:, :, 0]
         offsets = self.links_state.i_pos.to_numpy()[:, 0]
         cdof_ang = self.dofs_state.cdof_ang.to_numpy()[:, 0]
         cdof_vel = self.dofs_state.cdof_vel.to_numpy()[:, 0]
@@ -265,6 +267,13 @@ class RigidSolver(Solver):
             joints_dof_start = joints_dof_start[:, 0]
             joints_n_dofs = joints_n_dofs[:, 0]
 
+        # Compute the inverted mass matrix efficiently
+        mass_mat_L_inv = np.eye(self.n_dofs_)
+        for i in range(self.n_dofs_):
+            for j in range(i):
+                mass_mat_L_inv[i] -= mass_mat_L[i, j] * mass_mat_L_inv[j]
+        mass_mat_inv = (mass_mat_L_inv * mass_mat_D_inv) @ mass_mat_L_inv.T
+
         # Compute links invweight
         links_invweight = np.zeros((self._n_links, 2), dtype=gs.np_float)
         for i_l in range(self._n_links):
@@ -283,7 +292,7 @@ class RigidSolver(Solver):
 
             jac = np.concatenate((jacp, jacr), axis=0)
 
-            A = jac @ np.linalg.inv(mass_mat) @ jac.T
+            A = jac @ mass_mat_inv @ jac.T
             A_diag = np.diag(A)
 
             links_invweight[i_l, 0] = A_diag[:3].mean()
@@ -303,7 +312,7 @@ class RigidSolver(Solver):
                 for i_d_ in range(n_dofs):
                     jac[i_d_, dof_start + i_d_] = 1.0
 
-                A = jac @ np.linalg.inv(mass_mat) @ jac.T
+                A = jac @ mass_mat_inv @ jac.T
                 A_diag = np.diag(A)
 
                 if joint_type == gs.JOINT_TYPE.FREE:
@@ -318,8 +327,10 @@ class RigidSolver(Solver):
         self._kernel_init_invweight(links_invweight, dofs_invweight)
 
     @ti.kernel
-    def _kernel_compute_mass_matrix(self):
+    def _kernel_compute_mass_matrix(self, decompose: ti.u1):
         self._func_compute_mass_matrix(implicit_damping=False)
+        if decompose:
+            self._func_factor_mass(implicit_damping=False)
 
     @ti.kernel
     def _kernel_init_invweight(
@@ -327,13 +338,11 @@ class RigidSolver(Solver):
         links_invweight: ti.types.ndarray(),
         dofs_invweight: ti.types.ndarray(),
     ):
-        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for I in ti.grouped(self.links_info):
             for j in ti.static(range(2)):
                 if self.links_info[I].invweight[j] < gs.EPS:
                     self.links_info[I].invweight[j] = links_invweight[I[0], j]
 
-        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for I in ti.grouped(self.dofs_info):
             if self.dofs_info[I].invweight < gs.EPS:
                 self.dofs_info[I].invweight = dofs_invweight[I[0]]
@@ -481,7 +490,6 @@ class RigidSolver(Solver):
         dofs_kv: ti.types.ndarray(),
         dofs_force_range: ti.types.ndarray(),
     ):
-        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for I in ti.grouped(self.dofs_info):
             i = I[0]  # batching (if any) will be the second dim
 
@@ -572,9 +580,9 @@ class RigidSolver(Solver):
             # COM-based total forces
             cfrc_ang=gs.ti_vec3,
             cfrc_vel=gs.ti_vec3,
-            # COM-based "true" external forces (i.e. user-specified and not resulting from any kind of constraints)
-            cfrc_ext_ang=gs.ti_vec3,
-            cfrc_ext_vel=gs.ti_vec3,
+            # COM-based external forces explictly applied by the user (i.e. not resulting from any kind of constraints)
+            cfrc_applied_ang=gs.ti_vec3,
+            cfrc_applied_vel=gs.ti_vec3,
             # net force from external contacts
             contact_force=gs.ti_vec3,
             # Flag for links that converge into a static state (hibernation)
@@ -693,7 +701,6 @@ class RigidSolver(Solver):
         links_inertial_mass: ti.types.ndarray(),
         links_entity_idx: ti.types.ndarray(),
     ):
-        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for I in ti.grouped(self.links_info):
             i = I[0]
 
@@ -725,7 +732,6 @@ class RigidSolver(Solver):
                 for j2 in ti.static(range(3)):
                     self.links_info[I].inertial_i[j1, j2] = links_inertial_i[i, j1, j2]
 
-        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for i, b in ti.ndrange(self.n_links, self._B):
             I = [i, b] if ti.static(self._options.batch_links_info) else i
 
@@ -762,7 +768,6 @@ class RigidSolver(Solver):
         joints_dof_end: ti.types.ndarray(),
         joints_pos: ti.types.ndarray(),
     ):
-        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for I in ti.grouped(self.joints_info):
             i = I[0]
 
@@ -964,7 +969,7 @@ class RigidSolver(Solver):
         self.geoms_state = struct_geom_state.field(
             shape=self._batch_shape(self.n_geoms_), needs_grad=False, layout=ti.Layout.SOA
         )
-        self._geoms_render_T = np.empty((self.n_geoms_, self._B, 4, 4), dtype=gs.np_float)
+        self._geoms_render_T = np.empty((self.n_geoms_, self._B, 4, 4), order="F", dtype=np.float32)
 
         if self.n_geoms > 0:
             # Make sure that the constraints parameters are valid
@@ -1147,7 +1152,7 @@ class RigidSolver(Solver):
         self.vgeoms_state = struct_vgeom_state.field(
             shape=self._batch_shape(self.n_vgeoms_), needs_grad=False, layout=ti.Layout.SOA
         )
-        self._vgeoms_render_T = np.empty((self.n_vgeoms_, self._B, 4, 4), dtype=gs.np_float)
+        self._vgeoms_render_T = np.empty((self.n_vgeoms_, self._B, 4, 4), order="F", dtype=np.float32)
 
         if self.n_vgeoms > 0:
             vgeoms = self.vgeoms
@@ -1316,7 +1321,6 @@ class RigidSolver(Solver):
         equalities_eq_type: ti.types.ndarray(),
         equalities_sol_params: ti.types.ndarray(),
     ):
-
         ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for i, b in ti.ndrange(self.n_equalities, self._B):
             self.equalities_info[i, b].eq_obj1id = equalities_eq_obj1id[i]
@@ -1695,7 +1699,9 @@ class RigidSolver(Solver):
         # self._func_actuation()
         self._func_bias_force()
         self._func_compute_qacc()
-        # FIXME: External forces should be cleared at the end of the step, not during substeps.
+
+    @ti.kernel
+    def _kernel_clear_external_force(self):
         self._func_clear_external_force()
 
     def substep(self):
@@ -1787,7 +1793,6 @@ class RigidSolver(Solver):
 
     @ti.kernel
     def _kernel_forward_kinematics_links_geoms(self, envs_idx: ti.types.ndarray()):
-        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.ALL)
         for i_b in envs_idx:
             self._func_forward_kinematics(i_b)
             self._func_COM_links(i_b)
@@ -2589,11 +2594,53 @@ class RigidSolver(Solver):
                 n_awake_links = ti.atomic_add(self.n_awake_links[i_b], 1)
                 self.awake_links[n_awake_links, i_b] = i_l
 
-    def apply_links_external_force(self, force, links_idx=None, envs_idx=None, *, unsafe=False):
+    def apply_links_external_force(
+        self,
+        force,
+        links_idx=None,
+        envs_idx=None,
+        *,
+        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        local: bool = False,
+        unsafe: bool = False,
+    ):
+        """
+        Apply some external linear force on a set of links.
+
+        Parameters
+        ----------
+        force : array_like
+            The force to apply.
+        links_idx : None | array_like, optional
+            The indices of the links on which to apply force. None to specify all links. Default to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+        ref: "link_origin" | "link_com" | "root_com", optional
+            The reference frame on which the linear force will be applied. "link_origin" refers to the origin of the
+            link, "link_com" refers to the center of mass of the link, and "root_com" refers to the center of mass of
+            the entire kinematic tree to which a link belong (see `get_links_root_COM` for details).
+        local: bool, optional
+            Whether the force is expressed in the local coordinates associated with the reference frame instead of
+            world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
+        """
         force, links_idx, envs_idx = self._sanitize_2D_io_variables(
             force, links_idx, self.n_links, 3, envs_idx, idx_name="links_idx", skip_allocation=True, unsafe=unsafe
         )
-        self._kernel_apply_links_external_force(force, links_idx, envs_idx)
+        if self.n_envs == 0:
+            force = force.unsqueeze(0)
+
+        if ref == "root_com":
+            if local:
+                raise ValueError("'local=True' not compatible with ref='root_com'.")
+            ref = 0
+        elif ref == "link_com":
+            ref = 1
+        elif ref == "link_origin":
+            ref = 2
+        else:
+            raise ValueError("'ref' must be either 'link_origin', 'link_com', or 'root_com'.")
+
+        self._kernel_apply_links_external_force(force, links_idx, envs_idx, ref, 1 if local else 0)
 
     @ti.kernel
     def _kernel_apply_links_external_force(
@@ -2601,17 +2648,60 @@ class RigidSolver(Solver):
         force: ti.types.ndarray(),
         links_idx: ti.types.ndarray(),
         envs_idx: ti.types.ndarray(),
+        ref: ti.template(),
+        local: ti.template(),
     ):
         ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for i_l_, i_b_ in ti.ndrange(links_idx.shape[0], envs_idx.shape[0]):
-            for i in ti.static(range(3)):
-                self.links_state[links_idx[i_l_], envs_idx[i_b_]].cfrc_ext_vel[i] -= force[i_b_, i_l_, i]
+            force_i = ti.Vector([force[i_b_, i_l_, 0], force[i_b_, i_l_, 1], force[i_b_, i_l_, 2]], dt=gs.ti_float)
+            self._func_apply_link_external_force(force_i, links_idx[i_l_], envs_idx[i_b_], ref, local)
 
-    def apply_links_external_torque(self, torque, links_idx=None, envs_idx=None, *, unsafe=False):
+    def apply_links_external_torque(
+        self,
+        torque,
+        links_idx=None,
+        envs_idx=None,
+        *,
+        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        local: bool = False,
+        unsafe=False,
+    ):
+        """
+        Apply some external torque on a set of links.
+
+        Parameters
+        ----------
+        torque : array_like
+            The torque to apply.
+        links_idx : None | array_like, optional
+            The indices of the links on which to apply torque. None to specify all links. Default to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+        ref: "link_origin" | "link_com" | "root_com", optional
+            The reference frame on which the torque will be applied. "link_origin" refers to the origin of the link,
+            "link_com" refers to the center of mass of the link, and "root_com" refers to the center of mass of
+            the entire kinematic tree to which a link belong (see `get_links_root_COM` for details). Note that this
+            argument has no effect unless `local=True`.
+        local: bool, optional
+            Whether the torque is expressed in the local coordinates associated with the reference frame instead of
+            world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
+        """
         torque, links_idx, envs_idx = self._sanitize_2D_io_variables(
             torque, links_idx, self.n_links, 3, envs_idx, idx_name="links_idx", skip_allocation=True, unsafe=unsafe
         )
-        self._kernel_apply_links_external_torque(torque, links_idx, envs_idx)
+
+        if ref == "root_com":
+            if local:
+                raise ValueError("'local=True' not compatible with ref='root_com'.")
+            ref = 0
+        elif ref == "link_com":
+            ref = 1
+        elif ref == "link_origin":
+            ref = 2
+        else:
+            raise ValueError("'ref' must be either 'link_origin', 'link_com', or 'root_com'.")
+
+        self._kernel_apply_links_external_torque(torque, links_idx, envs_idx, ref, 1 if local else 0)
 
     @ti.kernel
     def _kernel_apply_links_external_torque(
@@ -2619,49 +2709,47 @@ class RigidSolver(Solver):
         torque: ti.types.ndarray(),
         links_idx: ti.types.ndarray(),
         envs_idx: ti.types.ndarray(),
+        ref: ti.template(),
+        local: ti.template(),
     ):
         ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for i_l_, i_b_ in ti.ndrange(links_idx.shape[0], envs_idx.shape[0]):
-            for i in ti.static(range(3)):
-                self.links_state[links_idx[i_l_], envs_idx[i_b_]].cfrc_ext_ang[i] -= torque[i_b_, i_l_, i]
+            torque_i = ti.Vector([torque[i_b_, i_l_, 0], torque[i_b_, i_l_, 1], torque[i_b_, i_l_, 2]], dt=gs.ti_float)
+            self._func_apply_link_external_torque(torque_i, links_idx[i_l_], envs_idx[i_b_], ref, local)
 
     @ti.func
-    def _func_apply_external_force(self, pos, force, link_idx, batch_idx):
-        torque = (pos - self.links_state[link_idx, batch_idx].COM).cross(force)
-        self.links_state[link_idx, batch_idx].cfrc_ext_ang -= torque
-        self.links_state[link_idx, batch_idx].cfrc_ext_vel -= force
+    def _func_apply_external_force(self, pos, force, link_idx, env_idx):
+        torque = (pos - self.links_state[link_idx, env_idx].COM).cross(force)
+        self.links_state[link_idx, env_idx].cfrc_applied_ang -= torque
+        self.links_state[link_idx, env_idx].cfrc_applied_vel -= force
 
     @ti.func
-    def _func_apply_external_torque(self, torque, link_idx, batch_idx):
-        self.links_state[link_idx, batch_idx].cfrc_ext_ang -= torque
+    def _func_apply_link_external_force(self, force, link_idx, env_idx, ref: ti.template(), local: ti.template()):
+        torque = ti.Vector.zero(gs.ti_float, 3)
+        if ti.static(ref == 1):  # link's CoM
+            if ti.static(local == 1):
+                force = gu.ti_transform_by_quat(force, self.links_state[link_idx, env_idx].i_quat)
+            torque = self.links_state[link_idx, env_idx].i_pos.cross(force)
+        if ti.static(ref == 2):  # link's origin
+            if ti.static(local == 1):
+                force = gu.ti_transform_by_quat(force, self.links_state[link_idx, env_idx].quat)
+            torque = (self.links_state[link_idx, env_idx].pos - self.links_state[link_idx, env_idx].COM).cross(force)
+
+        self.links_state[link_idx, env_idx].cfrc_applied_vel -= force
+        self.links_state[link_idx, env_idx].cfrc_applied_ang -= torque
 
     @ti.func
-    def _func_apply_external_force_link_frame(self, pos, force, link_idx, batch_idx):
-        pos = gu.ti_transform_by_trans_quat(
-            pos, self.links_state[link_idx, batch_idx].pos, self.links_state[link_idx, batch_idx].quat
-        )
-        force = gu.ti_transform_by_quat(force, self.links_state[link_idx, batch_idx].quat)
-        self._func_apply_external_force(pos, force, link_idx, batch_idx)
+    def _func_apply_external_torque(self, torque, link_idx, env_idx):
+        self.links_state[link_idx, env_idx].cfrc_applied_ang -= torque
 
     @ti.func
-    def _func_apply_external_torque_link_frame(self, torque, link_idx, batch_idx):
-        torque = gu.ti_transform_by_quat(torque, self.links_state[link_idx, batch_idx].quat)
-        self._func_apply_external_torque(torque, link_idx, batch_idx)
+    def _func_apply_link_external_torque(self, torque, link_idx, env_idx, ref: ti.template(), local: ti.template()):
+        if ti.static(ref == 1 and local == 1):  # link's CoM
+            torque = gu.ti_transform_by_quat(torque, self.links_state[link_idx, env_idx].i_quat)
+        if ti.static(ref == 2 and local == 1):  # link's origin
+            torque = gu.ti_transform_by_quat(torque, self.links_state[link_idx, env_idx].quat)
 
-    @ti.func
-    def _func_apply_external_force_link_inertial_frame(self, pos, force, link_idx, batch_idx):
-        link_I = [link_idx, batch_idx] if ti.static(self._options.batch_links_info) else link_idx
-        pos = gu.ti_transform_by_trans_quat(
-            pos, self.links_info[link_I].inertial_pos, self.links_info[link_I].inertial_quat
-        )
-        force = gu.ti_transform_by_quat(force, self.links_info[link_I].inertial_quat)
-        self._func_apply_external_force_link_frame(pos, force, link_idx, batch_idx)
-
-    @ti.func
-    def _func_apply_external_torque_link_inertial_frame(self, torque, link_idx, batch_idx):
-        link_I = [link_idx, batch_idx] if ti.static(self._options.batch_links_info) else link_idx
-        torque = gu.ti_transform_by_quat(torque, self.links_info[link_I].inertial_quat)
-        self._func_apply_external_torque_link_frame(torque, link_idx, batch_idx)
+        self.links_state[link_idx, env_idx].cfrc_applied_ang -= torque
 
     @ti.func
     def _func_clear_external_force(self):
@@ -2670,13 +2758,13 @@ class RigidSolver(Solver):
             for i_b in range(self._B):
                 for i_l_ in range(self.n_awake_links[i_b]):
                     i_l = self.awake_links[i_l_, i_b]
-                    self.links_state[i_l, i_b].cfrc_ext_ang = ti.Vector.zero(gs.ti_float, 3)
-                    self.links_state[i_l, i_b].cfrc_ext_vel = ti.Vector.zero(gs.ti_float, 3)
+                    self.links_state[i_l, i_b].cfrc_applied_ang = ti.Vector.zero(gs.ti_float, 3)
+                    self.links_state[i_l, i_b].cfrc_applied_vel = ti.Vector.zero(gs.ti_float, 3)
         else:
             ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
             for i_l, i_b in ti.ndrange(self.n_links, self._B):
-                self.links_state[i_l, i_b].cfrc_ext_ang = ti.Vector.zero(gs.ti_float, 3)
-                self.links_state[i_l, i_b].cfrc_ext_vel = ti.Vector.zero(gs.ti_float, 3)
+                self.links_state[i_l, i_b].cfrc_applied_ang = ti.Vector.zero(gs.ti_float, 3)
+                self.links_state[i_l, i_b].cfrc_applied_vel = ti.Vector.zero(gs.ti_float, 3)
 
     @ti.func
     def _func_torque_and_passive_force(self):
@@ -2881,7 +2969,6 @@ class RigidSolver(Solver):
                     i_p = self.links_info[I_l].parent_idx
 
                     if i_p == -1:
-                        self.links_state[i_l, i_b].cdd_vel = -self._gravity[None] * (1 - e_info.gravity_compensation)
                         self.links_state[i_l, i_b].cdd_vel = -self._gravity[i_b] * (1 - e_info.gravity_compensation)
                         self.links_state[i_l, i_b].cdd_ang = ti.Vector.zero(gs.ti_float, 3)
                         if ti.static(update_cacc):
@@ -2938,8 +3025,8 @@ class RigidSolver(Solver):
                         self.links_state[i_l, i_b].cd_ang, self.links_state[i_l, i_b].cd_vel, f2_ang, f2_vel
                     )
 
-                    self.links_state[i_l, i_b].cfrc_vel = f1_vel + f2_vel + self.links_state[i_l, i_b].cfrc_ext_vel
-                    self.links_state[i_l, i_b].cfrc_ang = f1_ang + f2_ang + self.links_state[i_l, i_b].cfrc_ext_ang
+                    self.links_state[i_l, i_b].cfrc_vel = f1_vel + f2_vel + self.links_state[i_l, i_b].cfrc_applied_vel
+                    self.links_state[i_l, i_b].cfrc_ang = f1_ang + f2_ang + self.links_state[i_l, i_b].cfrc_applied_ang
 
             for i_b in range(self._B):
                 for i_e_ in range(self.n_awake_entities[i_b]):
@@ -2977,8 +3064,8 @@ class RigidSolver(Solver):
                     self.links_state[i_l, i_b].cd_ang, self.links_state[i_l, i_b].cd_vel, f2_ang, f2_vel
                 )
 
-                self.links_state[i_l, i_b].cfrc_vel = f1_vel + f2_vel + self.links_state[i_l, i_b].cfrc_ext_vel
-                self.links_state[i_l, i_b].cfrc_ang = f1_ang + f2_ang + self.links_state[i_l, i_b].cfrc_ext_ang
+                self.links_state[i_l, i_b].cfrc_vel = f1_vel + f2_vel + self.links_state[i_l, i_b].cfrc_applied_vel
+                self.links_state[i_l, i_b].cfrc_ang = f1_ang + f2_ang + self.links_state[i_l, i_b].cfrc_applied_ang
 
             ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.ALL)
             for i_e, i_b in ti.ndrange(self.n_entities, self._B):
@@ -3325,28 +3412,28 @@ class RigidSolver(Solver):
 
     @ti.kernel
     def _kernel_update_geoms_render_T(self, geoms_render_T: ti.types.ndarray()):
-        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
+        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.ALL)
         for i_g, i_b in ti.ndrange(self.n_geoms, self._B):
             geom_T = gu.ti_trans_quat_to_T(
                 self.geoms_state[i_g, i_b].pos + self.envs_offset[i_b],
                 self.geoms_state[i_g, i_b].quat,
             )
             for i, j in ti.static(ti.ndrange(4, 4)):
-                geoms_render_T[i_g, i_b, i, j] = geom_T[i, j]
+                geoms_render_T[i_g, i_b, i, j] = ti.cast(geom_T[i, j], ti.float32)
 
     def update_geoms_render_T(self):
         self._kernel_update_geoms_render_T(self._geoms_render_T)
 
     @ti.kernel
     def _kernel_update_vgeoms_render_T(self, vgeoms_render_T: ti.types.ndarray()):
-        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
+        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.ALL)
         for i_g, i_b in ti.ndrange(self.n_vgeoms, self._B):
             geom_T = gu.ti_trans_quat_to_T(
                 self.vgeoms_state[i_g, i_b].pos + self.envs_offset[i_b],
                 self.vgeoms_state[i_g, i_b].quat,
             )
             for i, j in ti.static(ti.ndrange(4, 4)):
-                vgeoms_render_T[i_g, i_b, i, j] = geom_T[i, j]
+                vgeoms_render_T[i_g, i_b, i, j] = ti.cast(geom_T[i, j], ti.float32)
 
     def update_vgeoms_render_T(self):
         self._kernel_update_vgeoms_render_T(self._vgeoms_render_T)
@@ -4451,21 +4538,21 @@ class RigidSolver(Solver):
         links_idx=None,
         envs_idx=None,
         *,
-        ref: Literal["link_origin", "link_com", "entity_com"] = "link_origin",
+        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
         unsafe: bool = False,
     ):
         _tensor, links_idx, envs_idx = self._sanitize_2D_io_variables(
             None, links_idx, self.n_links, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
         )
         tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
-        if ref == "entity_com":
+        if ref == "root_com":
             ref = 0
         elif ref == "link_com":
             ref = 1
         elif ref == "link_origin":
             ref = 2
         else:
-            raise ValueError("'ref' must be either 'link_origin', 'link_com', or 'entity_com'.")
+            raise ValueError("'ref' must be either 'link_origin', 'link_com', or 'root_com'.")
         self._kernel_get_links_vel(tensor, links_idx, envs_idx, ref)
         return _tensor
 
@@ -4544,6 +4631,12 @@ class RigidSolver(Solver):
         return tensor.squeeze(0) if self.n_envs == 0 else tensor
 
     def get_links_root_COM(self, links_idx=None, envs_idx=None, *, unsafe=False):
+        """
+        Returns the center of mass (COM) of the entire kinematic tree to which the specified links belong.
+
+        This corresponds to the global COM of each entity, assuming a single-rooted structure — that is, as long as no
+        two successive links are connected by a free-floating joint (ie a joint that allows all 6 degrees of freedom).
+        """
         tensor = ti_field_to_torch(self.links_state.COM, envs_idx, links_idx, transpose=True, unsafe=unsafe)
         return tensor.squeeze(0) if self.n_envs == 0 else tensor
 
@@ -4707,7 +4800,6 @@ class RigidSolver(Solver):
     def _kernel_set_drone_rpm(
         self,
         n_propellers: ti.i32,
-        COM_link_idx: ti.i32,
         propellers_link_idxs: ti.types.ndarray(),
         propellers_rpm: ti.types.ndarray(),
         propellers_spin: ti.types.ndarray(),
@@ -4717,21 +4809,22 @@ class RigidSolver(Solver):
     ):
         """
         Set the RPM of propellers of a drone entity.
-        Should only be called by drone entities.
+
+        This method should only be called by drone entities.
         """
-        for b in range(self._B):
-            torque = 0.0
-            for i in range(n_propellers):
-                force_i = propellers_rpm[i, b] ** 2 * KF
-                torque += propellers_rpm[i, b] ** 2 * KM * propellers_spin[i]
-                self._func_apply_external_force_link_inertial_frame(
-                    ti.Vector([0.0, 0.0, 0.0]), ti.Vector([0.0, 0.0, force_i]), propellers_link_idxs[i], b
+        for i_b in range(self._B):
+            for i_prop in range(n_propellers):
+                i_l = propellers_link_idxs[i_prop]
+
+                force = ti.Vector([0.0, 0.0, propellers_rpm[i_prop, i_b] ** 2 * KF], dt=gs.ti_float)
+                torque = ti.Vector(
+                    [0.0, 0.0, propellers_rpm[i_prop, i_b] ** 2 * KM * propellers_spin[i_prop]], dt=gs.ti_float
                 )
+                if invert:
+                    torque = -torque
 
-            if invert:
-                torque = -torque
-
-            self._func_apply_external_torque_link_inertial_frame(ti.Vector([0.0, 0.0, torque]), COM_link_idx, b)
+                self._func_apply_link_external_force(force, i_l, i_b, 1, 1)
+                self._func_apply_link_external_torque(torque, i_l, i_b, 1, 1)
 
     @ti.kernel
     def _update_drone_propeller_vgeoms(
@@ -4747,7 +4840,7 @@ class RigidSolver(Solver):
         for i, b in ti.ndrange(n_propellers, self._B):
             rad = propellers_revs[i, b] * propellers_spin[i] * self._substep_dt * np.pi / 30
             self.vgeoms_state[propellers_vgeom_idxs[i], b].quat = gu.ti_transform_quat_by_quat(
-                gu.ti_rotvec_to_quat(ti.Vector([0.0, 0.0, rad])),
+                gu.ti_rotvec_to_quat(ti.Vector([0.0, 0.0, rad], dt=gs.ti_float)),
                 self.vgeoms_state[propellers_vgeom_idxs[i], b].quat,
             )
 

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -2932,9 +2932,7 @@ class RigidSolver(Solver):
                         i_p = self.links_info[I_l].parent_idx
 
                         if i_p == -1:
-                            self.links_state[i_l, i_b].cdd_vel = -self._gravity[None] * (
-                                1 - e_info.gravity_compensation
-                            )
+                            self.links_state[i_l, i_b].cdd_vel = -self._gravity[i_b] * (1 - e_info.gravity_compensation)
                             self.links_state[i_l, i_b].cdd_ang = ti.Vector.zero(gs.ti_float, 3)
                             if ti.static(update_cacc):
                                 self.links_state[i_l, i_b].cacc_lin = ti.Vector.zero(gs.ti_float, 3)
@@ -2971,7 +2969,7 @@ class RigidSolver(Solver):
                     i_p = self.links_info[I_l].parent_idx
 
                     if i_p == -1:
-                        self.links_state[i_l, i_b].cdd_vel = -self._gravity[None] * (1 - e_info.gravity_compensation)
+                        self.links_state[i_l, i_b].cdd_vel = -self._gravity[i_b] * (1 - e_info.gravity_compensation)
                         self.links_state[i_l, i_b].cdd_ang = ti.Vector.zero(gs.ti_float, 3)
                         if ti.static(update_cacc):
                             self.links_state[i_l, i_b].cacc_lin = ti.Vector.zero(gs.ti_float, 3)
@@ -4620,7 +4618,7 @@ class RigidSolver(Solver):
             # Mimick IMU accelerometer signal if requested
             if mimick_imu:
                 # Subtract gravity
-                acc_classic_lin -= self._gravity[None]
+                acc_classic_lin -= self._gravity[i_b]
 
                 # Move the resulting linear acceleration in local links frame
                 acc_classic_lin = gu.ti_inv_transform_by_quat(acc_classic_lin, self.links_state[i_l, i_b].quat)

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -2969,6 +2969,7 @@ class RigidSolver(Solver):
                     i_p = self.links_info[I_l].parent_idx
 
                     if i_p == -1:
+                        self.links_state[i_l, i_b].cdd_vel = -self._gravity[None] * (1 - e_info.gravity_compensation)
                         self.links_state[i_l, i_b].cdd_vel = -self._gravity[i_b] * (1 - e_info.gravity_compensation)
                         self.links_state[i_l, i_b].cdd_ang = ti.Vector.zero(gs.ti_float, 3)
                         if ti.static(update_cacc):

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -158,6 +158,7 @@ class RigidSolver(Solver):
     def build(self):
         self.n_envs = self.sim.n_envs
         self._B = self.sim._B
+        super().build(self._B)
         self._para_level = self.sim._para_level
 
         for entity in self._entities:

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -156,9 +156,10 @@ class RigidSolver(Solver):
         return entity
 
     def build(self):
+        super().build()
+
         self.n_envs = self.sim.n_envs
         self._B = self.sim._B
-        super().build(self._B)
         self._para_level = self.sim._para_level
 
         for entity in self._entities:

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -44,12 +44,11 @@ def _sanitize_sol_params(
     if (timeconst < gs.EPS).any():
         # We deliberately set timeconst to be zero for urdf and meshes so that it can fall back to 2*dt
         gs.logger.debug(f"Constraint solver time constant not specified. Using minimum value (`{min_timeconst:0.6g}`).")
-    invalid_mask = (timeconst > gs.EPS) & (timeconst + gs.EPS < min_timeconst)
-    if invalid_mask.any():
+    if ((timeconst > gs.EPS) & (timeconst + gs.EPS < min_timeconst)).any():
         gs.logger.warning(
-            "Constraint solver time constant should be greater than 2*substep_dt. timeconst is changed from "
-            f"`{min(timeconst[invalid_mask]):0.6g}` to `{min_timeconst:0.6g}`). Decrease simulation timestep or "
-            "increase timeconst to avoid altering the original value."
+            "Constraint solver time constant was increased to avoid numerical instability (from "
+            f"`{timeconst.min():0.6g}` to `{min_timeconst:0.6g}`). Decrease simulation timestep to avoid "
+            "altering the original value."
         )
     timeconst[:] = timeconst.clip(min_timeconst)
     dampratio[:] = dampratio.clip(0.0)
@@ -240,11 +239,10 @@ class RigidSolver(Solver):
             return
 
         # Compute mass matrix without any implicit damping terms
-        self._kernel_compute_mass_matrix(decompose=True)
+        self._kernel_compute_mass_matrix()
 
         # Define some proxies for convenience
-        mass_mat_D_inv = self.mass_mat_D_inv.to_numpy()[:, 0]
-        mass_mat_L = self.mass_mat_L.to_numpy()[:, :, 0]
+        mass_mat = self.mass_mat.to_numpy()[:, :, 0]
         offsets = self.links_state.i_pos.to_numpy()[:, 0]
         cdof_ang = self.dofs_state.cdof_ang.to_numpy()[:, 0]
         cdof_vel = self.dofs_state.cdof_vel.to_numpy()[:, 0]
@@ -267,13 +265,6 @@ class RigidSolver(Solver):
             joints_dof_start = joints_dof_start[:, 0]
             joints_n_dofs = joints_n_dofs[:, 0]
 
-        # Compute the inverted mass matrix efficiently
-        mass_mat_L_inv = np.eye(self.n_dofs_)
-        for i in range(self.n_dofs_):
-            for j in range(i):
-                mass_mat_L_inv[i] -= mass_mat_L[i, j] * mass_mat_L_inv[j]
-        mass_mat_inv = (mass_mat_L_inv * mass_mat_D_inv) @ mass_mat_L_inv.T
-
         # Compute links invweight
         links_invweight = np.zeros((self._n_links, 2), dtype=gs.np_float)
         for i_l in range(self._n_links):
@@ -292,7 +283,7 @@ class RigidSolver(Solver):
 
             jac = np.concatenate((jacp, jacr), axis=0)
 
-            A = jac @ mass_mat_inv @ jac.T
+            A = jac @ np.linalg.inv(mass_mat) @ jac.T
             A_diag = np.diag(A)
 
             links_invweight[i_l, 0] = A_diag[:3].mean()
@@ -312,7 +303,7 @@ class RigidSolver(Solver):
                 for i_d_ in range(n_dofs):
                     jac[i_d_, dof_start + i_d_] = 1.0
 
-                A = jac @ mass_mat_inv @ jac.T
+                A = jac @ np.linalg.inv(mass_mat) @ jac.T
                 A_diag = np.diag(A)
 
                 if joint_type == gs.JOINT_TYPE.FREE:
@@ -327,10 +318,8 @@ class RigidSolver(Solver):
         self._kernel_init_invweight(links_invweight, dofs_invweight)
 
     @ti.kernel
-    def _kernel_compute_mass_matrix(self, decompose: ti.u1):
+    def _kernel_compute_mass_matrix(self):
         self._func_compute_mass_matrix(implicit_damping=False)
-        if decompose:
-            self._func_factor_mass(implicit_damping=False)
 
     @ti.kernel
     def _kernel_init_invweight(
@@ -338,11 +327,13 @@ class RigidSolver(Solver):
         links_invweight: ti.types.ndarray(),
         dofs_invweight: ti.types.ndarray(),
     ):
+        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for I in ti.grouped(self.links_info):
             for j in ti.static(range(2)):
                 if self.links_info[I].invweight[j] < gs.EPS:
                     self.links_info[I].invweight[j] = links_invweight[I[0], j]
 
+        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for I in ti.grouped(self.dofs_info):
             if self.dofs_info[I].invweight < gs.EPS:
                 self.dofs_info[I].invweight = dofs_invweight[I[0]]
@@ -490,6 +481,7 @@ class RigidSolver(Solver):
         dofs_kv: ti.types.ndarray(),
         dofs_force_range: ti.types.ndarray(),
     ):
+        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for I in ti.grouped(self.dofs_info):
             i = I[0]  # batching (if any) will be the second dim
 
@@ -580,9 +572,9 @@ class RigidSolver(Solver):
             # COM-based total forces
             cfrc_ang=gs.ti_vec3,
             cfrc_vel=gs.ti_vec3,
-            # COM-based external forces explictly applied by the user (i.e. not resulting from any kind of constraints)
-            cfrc_applied_ang=gs.ti_vec3,
-            cfrc_applied_vel=gs.ti_vec3,
+            # COM-based "true" external forces (i.e. user-specified and not resulting from any kind of constraints)
+            cfrc_ext_ang=gs.ti_vec3,
+            cfrc_ext_vel=gs.ti_vec3,
             # net force from external contacts
             contact_force=gs.ti_vec3,
             # Flag for links that converge into a static state (hibernation)
@@ -701,6 +693,7 @@ class RigidSolver(Solver):
         links_inertial_mass: ti.types.ndarray(),
         links_entity_idx: ti.types.ndarray(),
     ):
+        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for I in ti.grouped(self.links_info):
             i = I[0]
 
@@ -732,6 +725,7 @@ class RigidSolver(Solver):
                 for j2 in ti.static(range(3)):
                     self.links_info[I].inertial_i[j1, j2] = links_inertial_i[i, j1, j2]
 
+        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for i, b in ti.ndrange(self.n_links, self._B):
             I = [i, b] if ti.static(self._options.batch_links_info) else i
 
@@ -768,6 +762,7 @@ class RigidSolver(Solver):
         joints_dof_end: ti.types.ndarray(),
         joints_pos: ti.types.ndarray(),
     ):
+        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for I in ti.grouped(self.joints_info):
             i = I[0]
 
@@ -969,7 +964,7 @@ class RigidSolver(Solver):
         self.geoms_state = struct_geom_state.field(
             shape=self._batch_shape(self.n_geoms_), needs_grad=False, layout=ti.Layout.SOA
         )
-        self._geoms_render_T = np.empty((self.n_geoms_, self._B, 4, 4), order="F", dtype=np.float32)
+        self._geoms_render_T = np.empty((self.n_geoms_, self._B, 4, 4), dtype=gs.np_float)
 
         if self.n_geoms > 0:
             # Make sure that the constraints parameters are valid
@@ -1152,7 +1147,7 @@ class RigidSolver(Solver):
         self.vgeoms_state = struct_vgeom_state.field(
             shape=self._batch_shape(self.n_vgeoms_), needs_grad=False, layout=ti.Layout.SOA
         )
-        self._vgeoms_render_T = np.empty((self.n_vgeoms_, self._B, 4, 4), order="F", dtype=np.float32)
+        self._vgeoms_render_T = np.empty((self.n_vgeoms_, self._B, 4, 4), dtype=gs.np_float)
 
         if self.n_vgeoms > 0:
             vgeoms = self.vgeoms
@@ -1321,6 +1316,7 @@ class RigidSolver(Solver):
         equalities_eq_type: ti.types.ndarray(),
         equalities_sol_params: ti.types.ndarray(),
     ):
+
         ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for i, b in ti.ndrange(self.n_equalities, self._B):
             self.equalities_info[i, b].eq_obj1id = equalities_eq_obj1id[i]
@@ -1699,9 +1695,7 @@ class RigidSolver(Solver):
         # self._func_actuation()
         self._func_bias_force()
         self._func_compute_qacc()
-
-    @ti.kernel
-    def _kernel_clear_external_force(self):
+        # FIXME: External forces should be cleared at the end of the step, not during substeps.
         self._func_clear_external_force()
 
     def substep(self):
@@ -1793,6 +1787,7 @@ class RigidSolver(Solver):
 
     @ti.kernel
     def _kernel_forward_kinematics_links_geoms(self, envs_idx: ti.types.ndarray()):
+        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.ALL)
         for i_b in envs_idx:
             self._func_forward_kinematics(i_b)
             self._func_COM_links(i_b)
@@ -2594,53 +2589,11 @@ class RigidSolver(Solver):
                 n_awake_links = ti.atomic_add(self.n_awake_links[i_b], 1)
                 self.awake_links[n_awake_links, i_b] = i_l
 
-    def apply_links_external_force(
-        self,
-        force,
-        links_idx=None,
-        envs_idx=None,
-        *,
-        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
-        local: bool = False,
-        unsafe: bool = False,
-    ):
-        """
-        Apply some external linear force on a set of links.
-
-        Parameters
-        ----------
-        force : array_like
-            The force to apply.
-        links_idx : None | array_like, optional
-            The indices of the links on which to apply force. None to specify all links. Default to None.
-        envs_idx : None | array_like, optional
-            The indices of the environments. If None, all environments will be considered. Defaults to None.
-        ref: "link_origin" | "link_com" | "root_com", optional
-            The reference frame on which the linear force will be applied. "link_origin" refers to the origin of the
-            link, "link_com" refers to the center of mass of the link, and "root_com" refers to the center of mass of
-            the entire kinematic tree to which a link belong (see `get_links_root_COM` for details).
-        local: bool, optional
-            Whether the force is expressed in the local coordinates associated with the reference frame instead of
-            world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
-        """
+    def apply_links_external_force(self, force, links_idx=None, envs_idx=None, *, unsafe=False):
         force, links_idx, envs_idx = self._sanitize_2D_io_variables(
             force, links_idx, self.n_links, 3, envs_idx, idx_name="links_idx", skip_allocation=True, unsafe=unsafe
         )
-        if self.n_envs == 0:
-            force = force.unsqueeze(0)
-
-        if ref == "root_com":
-            if local:
-                raise ValueError("'local=True' not compatible with ref='root_com'.")
-            ref = 0
-        elif ref == "link_com":
-            ref = 1
-        elif ref == "link_origin":
-            ref = 2
-        else:
-            raise ValueError("'ref' must be either 'link_origin', 'link_com', or 'root_com'.")
-
-        self._kernel_apply_links_external_force(force, links_idx, envs_idx, ref, 1 if local else 0)
+        self._kernel_apply_links_external_force(force, links_idx, envs_idx)
 
     @ti.kernel
     def _kernel_apply_links_external_force(
@@ -2648,60 +2601,17 @@ class RigidSolver(Solver):
         force: ti.types.ndarray(),
         links_idx: ti.types.ndarray(),
         envs_idx: ti.types.ndarray(),
-        ref: ti.template(),
-        local: ti.template(),
     ):
         ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for i_l_, i_b_ in ti.ndrange(links_idx.shape[0], envs_idx.shape[0]):
-            force_i = ti.Vector([force[i_b_, i_l_, 0], force[i_b_, i_l_, 1], force[i_b_, i_l_, 2]], dt=gs.ti_float)
-            self._func_apply_link_external_force(force_i, links_idx[i_l_], envs_idx[i_b_], ref, local)
+            for i in ti.static(range(3)):
+                self.links_state[links_idx[i_l_], envs_idx[i_b_]].cfrc_ext_vel[i] -= force[i_b_, i_l_, i]
 
-    def apply_links_external_torque(
-        self,
-        torque,
-        links_idx=None,
-        envs_idx=None,
-        *,
-        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
-        local: bool = False,
-        unsafe=False,
-    ):
-        """
-        Apply some external torque on a set of links.
-
-        Parameters
-        ----------
-        torque : array_like
-            The torque to apply.
-        links_idx : None | array_like, optional
-            The indices of the links on which to apply torque. None to specify all links. Default to None.
-        envs_idx : None | array_like, optional
-            The indices of the environments. If None, all environments will be considered. Defaults to None.
-        ref: "link_origin" | "link_com" | "root_com", optional
-            The reference frame on which the torque will be applied. "link_origin" refers to the origin of the link,
-            "link_com" refers to the center of mass of the link, and "root_com" refers to the center of mass of
-            the entire kinematic tree to which a link belong (see `get_links_root_COM` for details). Note that this
-            argument has no effect unless `local=True`.
-        local: bool, optional
-            Whether the torque is expressed in the local coordinates associated with the reference frame instead of
-            world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
-        """
+    def apply_links_external_torque(self, torque, links_idx=None, envs_idx=None, *, unsafe=False):
         torque, links_idx, envs_idx = self._sanitize_2D_io_variables(
             torque, links_idx, self.n_links, 3, envs_idx, idx_name="links_idx", skip_allocation=True, unsafe=unsafe
         )
-
-        if ref == "root_com":
-            if local:
-                raise ValueError("'local=True' not compatible with ref='root_com'.")
-            ref = 0
-        elif ref == "link_com":
-            ref = 1
-        elif ref == "link_origin":
-            ref = 2
-        else:
-            raise ValueError("'ref' must be either 'link_origin', 'link_com', or 'root_com'.")
-
-        self._kernel_apply_links_external_torque(torque, links_idx, envs_idx, ref, 1 if local else 0)
+        self._kernel_apply_links_external_torque(torque, links_idx, envs_idx)
 
     @ti.kernel
     def _kernel_apply_links_external_torque(
@@ -2709,47 +2619,49 @@ class RigidSolver(Solver):
         torque: ti.types.ndarray(),
         links_idx: ti.types.ndarray(),
         envs_idx: ti.types.ndarray(),
-        ref: ti.template(),
-        local: ti.template(),
     ):
         ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for i_l_, i_b_ in ti.ndrange(links_idx.shape[0], envs_idx.shape[0]):
-            torque_i = ti.Vector([torque[i_b_, i_l_, 0], torque[i_b_, i_l_, 1], torque[i_b_, i_l_, 2]], dt=gs.ti_float)
-            self._func_apply_link_external_torque(torque_i, links_idx[i_l_], envs_idx[i_b_], ref, local)
+            for i in ti.static(range(3)):
+                self.links_state[links_idx[i_l_], envs_idx[i_b_]].cfrc_ext_ang[i] -= torque[i_b_, i_l_, i]
 
     @ti.func
-    def _func_apply_external_force(self, pos, force, link_idx, env_idx):
-        torque = (pos - self.links_state[link_idx, env_idx].COM).cross(force)
-        self.links_state[link_idx, env_idx].cfrc_applied_ang -= torque
-        self.links_state[link_idx, env_idx].cfrc_applied_vel -= force
+    def _func_apply_external_force(self, pos, force, link_idx, batch_idx):
+        torque = (pos - self.links_state[link_idx, batch_idx].COM).cross(force)
+        self.links_state[link_idx, batch_idx].cfrc_ext_ang -= torque
+        self.links_state[link_idx, batch_idx].cfrc_ext_vel -= force
 
     @ti.func
-    def _func_apply_link_external_force(self, force, link_idx, env_idx, ref: ti.template(), local: ti.template()):
-        torque = ti.Vector.zero(gs.ti_float, 3)
-        if ti.static(ref == 1):  # link's CoM
-            if ti.static(local == 1):
-                force = gu.ti_transform_by_quat(force, self.links_state[link_idx, env_idx].i_quat)
-            torque = self.links_state[link_idx, env_idx].i_pos.cross(force)
-        if ti.static(ref == 2):  # link's origin
-            if ti.static(local == 1):
-                force = gu.ti_transform_by_quat(force, self.links_state[link_idx, env_idx].quat)
-            torque = (self.links_state[link_idx, env_idx].pos - self.links_state[link_idx, env_idx].COM).cross(force)
-
-        self.links_state[link_idx, env_idx].cfrc_applied_vel -= force
-        self.links_state[link_idx, env_idx].cfrc_applied_ang -= torque
+    def _func_apply_external_torque(self, torque, link_idx, batch_idx):
+        self.links_state[link_idx, batch_idx].cfrc_ext_ang -= torque
 
     @ti.func
-    def _func_apply_external_torque(self, torque, link_idx, env_idx):
-        self.links_state[link_idx, env_idx].cfrc_applied_ang -= torque
+    def _func_apply_external_force_link_frame(self, pos, force, link_idx, batch_idx):
+        pos = gu.ti_transform_by_trans_quat(
+            pos, self.links_state[link_idx, batch_idx].pos, self.links_state[link_idx, batch_idx].quat
+        )
+        force = gu.ti_transform_by_quat(force, self.links_state[link_idx, batch_idx].quat)
+        self._func_apply_external_force(pos, force, link_idx, batch_idx)
 
     @ti.func
-    def _func_apply_link_external_torque(self, torque, link_idx, env_idx, ref: ti.template(), local: ti.template()):
-        if ti.static(ref == 1 and local == 1):  # link's CoM
-            torque = gu.ti_transform_by_quat(torque, self.links_state[link_idx, env_idx].i_quat)
-        if ti.static(ref == 2 and local == 1):  # link's origin
-            torque = gu.ti_transform_by_quat(torque, self.links_state[link_idx, env_idx].quat)
+    def _func_apply_external_torque_link_frame(self, torque, link_idx, batch_idx):
+        torque = gu.ti_transform_by_quat(torque, self.links_state[link_idx, batch_idx].quat)
+        self._func_apply_external_torque(torque, link_idx, batch_idx)
 
-        self.links_state[link_idx, env_idx].cfrc_applied_ang -= torque
+    @ti.func
+    def _func_apply_external_force_link_inertial_frame(self, pos, force, link_idx, batch_idx):
+        link_I = [link_idx, batch_idx] if ti.static(self._options.batch_links_info) else link_idx
+        pos = gu.ti_transform_by_trans_quat(
+            pos, self.links_info[link_I].inertial_pos, self.links_info[link_I].inertial_quat
+        )
+        force = gu.ti_transform_by_quat(force, self.links_info[link_I].inertial_quat)
+        self._func_apply_external_force_link_frame(pos, force, link_idx, batch_idx)
+
+    @ti.func
+    def _func_apply_external_torque_link_inertial_frame(self, torque, link_idx, batch_idx):
+        link_I = [link_idx, batch_idx] if ti.static(self._options.batch_links_info) else link_idx
+        torque = gu.ti_transform_by_quat(torque, self.links_info[link_I].inertial_quat)
+        self._func_apply_external_torque_link_frame(torque, link_idx, batch_idx)
 
     @ti.func
     def _func_clear_external_force(self):
@@ -2758,13 +2670,13 @@ class RigidSolver(Solver):
             for i_b in range(self._B):
                 for i_l_ in range(self.n_awake_links[i_b]):
                     i_l = self.awake_links[i_l_, i_b]
-                    self.links_state[i_l, i_b].cfrc_applied_ang = ti.Vector.zero(gs.ti_float, 3)
-                    self.links_state[i_l, i_b].cfrc_applied_vel = ti.Vector.zero(gs.ti_float, 3)
+                    self.links_state[i_l, i_b].cfrc_ext_ang = ti.Vector.zero(gs.ti_float, 3)
+                    self.links_state[i_l, i_b].cfrc_ext_vel = ti.Vector.zero(gs.ti_float, 3)
         else:
             ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
             for i_l, i_b in ti.ndrange(self.n_links, self._B):
-                self.links_state[i_l, i_b].cfrc_applied_ang = ti.Vector.zero(gs.ti_float, 3)
-                self.links_state[i_l, i_b].cfrc_applied_vel = ti.Vector.zero(gs.ti_float, 3)
+                self.links_state[i_l, i_b].cfrc_ext_ang = ti.Vector.zero(gs.ti_float, 3)
+                self.links_state[i_l, i_b].cfrc_ext_vel = ti.Vector.zero(gs.ti_float, 3)
 
     @ti.func
     def _func_torque_and_passive_force(self):
@@ -2969,6 +2881,7 @@ class RigidSolver(Solver):
                     i_p = self.links_info[I_l].parent_idx
 
                     if i_p == -1:
+                        self.links_state[i_l, i_b].cdd_vel = -self._gravity[None] * (1 - e_info.gravity_compensation)
                         self.links_state[i_l, i_b].cdd_vel = -self._gravity[i_b] * (1 - e_info.gravity_compensation)
                         self.links_state[i_l, i_b].cdd_ang = ti.Vector.zero(gs.ti_float, 3)
                         if ti.static(update_cacc):
@@ -3025,8 +2938,8 @@ class RigidSolver(Solver):
                         self.links_state[i_l, i_b].cd_ang, self.links_state[i_l, i_b].cd_vel, f2_ang, f2_vel
                     )
 
-                    self.links_state[i_l, i_b].cfrc_vel = f1_vel + f2_vel + self.links_state[i_l, i_b].cfrc_applied_vel
-                    self.links_state[i_l, i_b].cfrc_ang = f1_ang + f2_ang + self.links_state[i_l, i_b].cfrc_applied_ang
+                    self.links_state[i_l, i_b].cfrc_vel = f1_vel + f2_vel + self.links_state[i_l, i_b].cfrc_ext_vel
+                    self.links_state[i_l, i_b].cfrc_ang = f1_ang + f2_ang + self.links_state[i_l, i_b].cfrc_ext_ang
 
             for i_b in range(self._B):
                 for i_e_ in range(self.n_awake_entities[i_b]):
@@ -3064,8 +2977,8 @@ class RigidSolver(Solver):
                     self.links_state[i_l, i_b].cd_ang, self.links_state[i_l, i_b].cd_vel, f2_ang, f2_vel
                 )
 
-                self.links_state[i_l, i_b].cfrc_vel = f1_vel + f2_vel + self.links_state[i_l, i_b].cfrc_applied_vel
-                self.links_state[i_l, i_b].cfrc_ang = f1_ang + f2_ang + self.links_state[i_l, i_b].cfrc_applied_ang
+                self.links_state[i_l, i_b].cfrc_vel = f1_vel + f2_vel + self.links_state[i_l, i_b].cfrc_ext_vel
+                self.links_state[i_l, i_b].cfrc_ang = f1_ang + f2_ang + self.links_state[i_l, i_b].cfrc_ext_ang
 
             ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.ALL)
             for i_e, i_b in ti.ndrange(self.n_entities, self._B):
@@ -3412,28 +3325,28 @@ class RigidSolver(Solver):
 
     @ti.kernel
     def _kernel_update_geoms_render_T(self, geoms_render_T: ti.types.ndarray()):
-        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.ALL)
+        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for i_g, i_b in ti.ndrange(self.n_geoms, self._B):
             geom_T = gu.ti_trans_quat_to_T(
                 self.geoms_state[i_g, i_b].pos + self.envs_offset[i_b],
                 self.geoms_state[i_g, i_b].quat,
             )
             for i, j in ti.static(ti.ndrange(4, 4)):
-                geoms_render_T[i_g, i_b, i, j] = ti.cast(geom_T[i, j], ti.float32)
+                geoms_render_T[i_g, i_b, i, j] = geom_T[i, j]
 
     def update_geoms_render_T(self):
         self._kernel_update_geoms_render_T(self._geoms_render_T)
 
     @ti.kernel
     def _kernel_update_vgeoms_render_T(self, vgeoms_render_T: ti.types.ndarray()):
-        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.ALL)
+        ti.loop_config(serialize=self._para_level < gs.PARA_LEVEL.PARTIAL)
         for i_g, i_b in ti.ndrange(self.n_vgeoms, self._B):
             geom_T = gu.ti_trans_quat_to_T(
                 self.vgeoms_state[i_g, i_b].pos + self.envs_offset[i_b],
                 self.vgeoms_state[i_g, i_b].quat,
             )
             for i, j in ti.static(ti.ndrange(4, 4)):
-                vgeoms_render_T[i_g, i_b, i, j] = ti.cast(geom_T[i, j], ti.float32)
+                vgeoms_render_T[i_g, i_b, i, j] = geom_T[i, j]
 
     def update_vgeoms_render_T(self):
         self._kernel_update_vgeoms_render_T(self._vgeoms_render_T)
@@ -4538,21 +4451,21 @@ class RigidSolver(Solver):
         links_idx=None,
         envs_idx=None,
         *,
-        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        ref: Literal["link_origin", "link_com", "entity_com"] = "link_origin",
         unsafe: bool = False,
     ):
         _tensor, links_idx, envs_idx = self._sanitize_2D_io_variables(
             None, links_idx, self.n_links, 3, envs_idx, idx_name="links_idx", unsafe=unsafe
         )
         tensor = _tensor.unsqueeze(0) if self.n_envs == 0 else _tensor
-        if ref == "root_com":
+        if ref == "entity_com":
             ref = 0
         elif ref == "link_com":
             ref = 1
         elif ref == "link_origin":
             ref = 2
         else:
-            raise ValueError("'ref' must be either 'link_origin', 'link_com', or 'root_com'.")
+            raise ValueError("'ref' must be either 'link_origin', 'link_com', or 'entity_com'.")
         self._kernel_get_links_vel(tensor, links_idx, envs_idx, ref)
         return _tensor
 
@@ -4631,12 +4544,6 @@ class RigidSolver(Solver):
         return tensor.squeeze(0) if self.n_envs == 0 else tensor
 
     def get_links_root_COM(self, links_idx=None, envs_idx=None, *, unsafe=False):
-        """
-        Returns the center of mass (COM) of the entire kinematic tree to which the specified links belong.
-
-        This corresponds to the global COM of each entity, assuming a single-rooted structure — that is, as long as no
-        two successive links are connected by a free-floating joint (ie a joint that allows all 6 degrees of freedom).
-        """
         tensor = ti_field_to_torch(self.links_state.COM, envs_idx, links_idx, transpose=True, unsafe=unsafe)
         return tensor.squeeze(0) if self.n_envs == 0 else tensor
 
@@ -4800,6 +4707,7 @@ class RigidSolver(Solver):
     def _kernel_set_drone_rpm(
         self,
         n_propellers: ti.i32,
+        COM_link_idx: ti.i32,
         propellers_link_idxs: ti.types.ndarray(),
         propellers_rpm: ti.types.ndarray(),
         propellers_spin: ti.types.ndarray(),
@@ -4809,22 +4717,21 @@ class RigidSolver(Solver):
     ):
         """
         Set the RPM of propellers of a drone entity.
-
-        This method should only be called by drone entities.
+        Should only be called by drone entities.
         """
-        for i_b in range(self._B):
-            for i_prop in range(n_propellers):
-                i_l = propellers_link_idxs[i_prop]
-
-                force = ti.Vector([0.0, 0.0, propellers_rpm[i_prop, i_b] ** 2 * KF], dt=gs.ti_float)
-                torque = ti.Vector(
-                    [0.0, 0.0, propellers_rpm[i_prop, i_b] ** 2 * KM * propellers_spin[i_prop]], dt=gs.ti_float
+        for b in range(self._B):
+            torque = 0.0
+            for i in range(n_propellers):
+                force_i = propellers_rpm[i, b] ** 2 * KF
+                torque += propellers_rpm[i, b] ** 2 * KM * propellers_spin[i]
+                self._func_apply_external_force_link_inertial_frame(
+                    ti.Vector([0.0, 0.0, 0.0]), ti.Vector([0.0, 0.0, force_i]), propellers_link_idxs[i], b
                 )
-                if invert:
-                    torque = -torque
 
-                self._func_apply_link_external_force(force, i_l, i_b, 1, 1)
-                self._func_apply_link_external_torque(torque, i_l, i_b, 1, 1)
+            if invert:
+                torque = -torque
+
+            self._func_apply_external_torque_link_inertial_frame(ti.Vector([0.0, 0.0, torque]), COM_link_idx, b)
 
     @ti.kernel
     def _update_drone_propeller_vgeoms(
@@ -4840,7 +4747,7 @@ class RigidSolver(Solver):
         for i, b in ti.ndrange(n_propellers, self._B):
             rad = propellers_revs[i, b] * propellers_spin[i] * self._substep_dt * np.pi / 30
             self.vgeoms_state[propellers_vgeom_idxs[i], b].quat = gu.ti_transform_quat_by_quat(
-                gu.ti_rotvec_to_quat(ti.Vector([0.0, 0.0, rad], dt=gs.ti_float)),
+                gu.ti_rotvec_to_quat(ti.Vector([0.0, 0.0, rad])),
                 self.vgeoms_state[propellers_vgeom_idxs[i], b].quat,
             )
 

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -157,7 +157,6 @@ class RigidSolver(Solver):
 
     def build(self):
         super().build()
-
         self.n_envs = self.sim.n_envs
         self._B = self.sim._B
         self._para_level = self.sim._para_level

--- a/genesis/engine/solvers/sf_solver.py
+++ b/genesis/engine/solvers/sf_solver.py
@@ -41,7 +41,8 @@ class SFSolver(Solver):
         self.jets = jets
 
     def build(self):
-        super().build(self.sim._B)
+        super().build()
+
         if self.is_active():
             self.t = 0.0
             self.setup_fields()

--- a/genesis/engine/solvers/sf_solver.py
+++ b/genesis/engine/solvers/sf_solver.py
@@ -41,6 +41,7 @@ class SFSolver(Solver):
         self.jets = jets
 
     def build(self):
+        super().build(self.sim._B)
         if self.is_active():
             self.t = 0.0
             self.setup_fields()

--- a/genesis/engine/solvers/sf_solver.py
+++ b/genesis/engine/solvers/sf_solver.py
@@ -42,7 +42,6 @@ class SFSolver(Solver):
 
     def build(self):
         super().build()
-
         if self.is_active():
             self.t = 0.0
             self.setup_fields()

--- a/genesis/engine/solvers/sph_solver.py
+++ b/genesis/engine/solvers/sph_solver.py
@@ -129,6 +129,7 @@ class SPHSolver(Solver):
 
     def build(self):
         self._B = self._sim._B
+        super().build(self._B)
 
         # particles and entities
         self._n_particles = self.n_particles

--- a/genesis/engine/solvers/sph_solver.py
+++ b/genesis/engine/solvers/sph_solver.py
@@ -128,8 +128,9 @@ class SPHSolver(Solver):
         pass
 
     def build(self):
+        super().build()
+
         self._B = self._sim._B
-        super().build(self._B)
 
         # particles and entities
         self._n_particles = self.n_particles

--- a/genesis/engine/solvers/sph_solver.py
+++ b/genesis/engine/solvers/sph_solver.py
@@ -129,7 +129,6 @@ class SPHSolver(Solver):
 
     def build(self):
         super().build()
-
         self._B = self._sim._B
 
         # particles and entities

--- a/genesis/engine/solvers/sph_solver.py
+++ b/genesis/engine/solvers/sph_solver.py
@@ -275,7 +275,7 @@ class SPHSolver(Solver):
     def _kernel_compute_non_pressure_forces(self, f: ti.i32, t: ti.f32):
         for i_p, i_b in ti.ndrange(self._n_particles, self._B):
             if self.particles_ng_reordered[i_p, i_b].active:
-                acc = self._gravity[None]
+                acc = self._gravity[i_b]
                 self.sh.for_all_neighbors(
                     i_p,
                     self.particles_reordered.pos,

--- a/genesis/engine/solvers/tool_solver.py
+++ b/genesis/engine/solvers/tool_solver.py
@@ -32,7 +32,8 @@ class ToolSolver(Solver):
         self.setup_boundary()
 
     def build(self):
-        super().build(self.sim._B)
+        super().build()
+
         for entity in self._entities:
             entity.build()
 

--- a/genesis/engine/solvers/tool_solver.py
+++ b/genesis/engine/solvers/tool_solver.py
@@ -32,6 +32,7 @@ class ToolSolver(Solver):
         self.setup_boundary()
 
     def build(self):
+        super().build(self.sim._B)
         for entity in self._entities:
             entity.build()
 

--- a/genesis/engine/solvers/tool_solver.py
+++ b/genesis/engine/solvers/tool_solver.py
@@ -24,6 +24,7 @@ class ToolSolver(Solver):
 
     def __init__(self, scene, sim, options):
         super().__init__(scene, sim, options)
+
         # options
         self.floor_height = options.floor_height
 
@@ -32,7 +33,6 @@ class ToolSolver(Solver):
 
     def build(self):
         super().build()
-
         for entity in self._entities:
             entity.build()
 

--- a/genesis/engine/solvers/tool_solver.py
+++ b/genesis/engine/solvers/tool_solver.py
@@ -24,7 +24,6 @@ class ToolSolver(Solver):
 
     def __init__(self, scene, sim, options):
         super().__init__(scene, sim, options)
-
         # options
         self.floor_height = options.floor_height
 

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2229,7 +2229,7 @@ def test_gravity(show_viewer, tol):
 
     assert_allclose(first_pos * -1, second_pos, tol=tol)
 
-    
+
 @pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.cpu])
 def test_scene_saver_franka(show_viewer, tol):

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -577,7 +577,7 @@ def test_link_velocity(gs_sim, tol):
 @pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
 def test_pendulum_links_acc(gs_sim, tol):
     pendulum = gs_sim.entities[0]
-    g = gs_sim.rigid_solver._gravity.to_numpy()[2]
+    g = gs_sim.rigid_solver._gravity[0][2]
 
     # Make sure that the linear and angular acceleration matches expectation
     theta = np.random.rand()
@@ -1589,7 +1589,7 @@ def test_contact_forces(show_viewer, tol):
     )
     scene.build()
 
-    cube_weight = scene.rigid_solver._gravity.to_numpy()[2] * cube.get_mass()
+    cube_weight = scene.rigid_solver._gravity[0][2] * cube.get_mass()
     motors_dof = np.arange(7)
     fingers_dof = np.arange(7, 9)
     qpos = np.array([-1.0124, 1.5559, 1.3662, -1.6878, -1.5799, 1.7757, 1.4602, 0.04, 0.04])

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2202,32 +2202,27 @@ def test_urdf_mimic(show_viewer, tol):
 
 @pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.cpu])
-def test_gravity(show_viewer):
-    base_rpm = 14468.429183500699
+def test_gravity(show_viewer, tol):
     scene = gs.Scene(
         show_viewer=show_viewer,
         sim_options=gs.options.SimOptions(
             dt=0.01,
             substeps=1,
-            gravity=[(0.0, 0.0, -9.8), (0.0, 0.0, -10.00)],
+            gravity=[(0.0, 0.0, -9.8), (0.0, 0.0, 9.8)],
         ),
     )
 
-    drone = scene.add_entity(
-        gs.morphs.Drone(file="urdf/drones/cf2x.urdf", pos=(0, 0, 1.0)),
-    )
+    sphere = scene.add_entity(gs.morphs.Sphere())
 
     scene.build(n_envs=2)
 
-    for _ in range(500):
-        drone.set_propellels_rpm([[base_rpm, base_rpm, base_rpm, base_rpm], [base_rpm, base_rpm, base_rpm, base_rpm]])
+    for _ in range(200):
         scene.step()
 
-    first_pos = drone.get_dofs_position()[0, 2]
-    second_pos = drone.get_dofs_position()[1, 2]
-    assert_allclose(
-        second_pos, first_pos - 2.5, tol=scene.sim_options.dt
-    )  # Relax the tolerance due to time integration's error
+    first_pos = sphere.get_dofs_position()[0, 2]
+    second_pos = sphere.get_dofs_position()[1, 2]
+
+    assert_allclose(first_pos * -1, second_pos, tol=tol)
 
 
 @pytest.mark.required

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2208,13 +2208,15 @@ def test_gravity(show_viewer, tol):
         sim_options=gs.options.SimOptions(
             dt=0.01,
             substeps=1,
-            gravity=[(0.0, 0.0, -9.8), (0.0, 0.0, 9.8)],
+            gravity=(0.0, 0.0, -9.8),
         ),
     )
 
     sphere = scene.add_entity(gs.morphs.Sphere())
-
     scene.build(n_envs=2)
+
+    scene.sim.set_gravity(torch.tensor([0.0, 0.0, -9.8]), envs_idx=0)
+    scene.sim.set_gravity(torch.tensor([0.0, 0.0, 9.8]), envs_idx=1)
 
     for _ in range(200):
         scene.step()

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2205,11 +2205,6 @@ def test_urdf_mimic(show_viewer, tol):
 def test_gravity(show_viewer, tol):
     scene = gs.Scene(
         show_viewer=show_viewer,
-        sim_options=gs.options.SimOptions(
-            dt=0.01,
-            substeps=1,
-            gravity=(0.0, 0.0, -9.8),
-        ),
     )
 
     sphere = scene.add_entity(gs.morphs.Sphere())


### PR DESCRIPTION
This PR introduces support for environment-specific gravity settings. Different environments in the simulation can now have distinct gravity configurations, enabling more flexible and realistic physics behavior tailored to each context.

Example use case with two spheres: 

```
import torch
import genesis as gs

gs.init(backend=gs.cpu)

scene = gs.Scene(
    show_viewer=True,
    sim_options=gs.options.SimOptions(
        dt=0.01,
        substeps=1,
    ),
)

sphere = scene.add_entity(gs.morphs.Sphere())
scene.build(n_envs=2)

scene.sim.set_gravity(torch.tensor([0.0, 0.0, -9.8]), envs_idx=0)
scene.sim.set_gravity(torch.tensor([0.0, 0.0, 9.8]), envs_idx=1)

for _ in range(200):
    scene.step()
```

Addresses: #1113 

Below is a video demonstrating two parallel environments one with more negative gravity making the drone fall while the other hovers: 

https://github.com/user-attachments/assets/ac3c148f-ab3e-4d26-a47f-c56d67d48601





