### PR TITLE
[BUG FIX] Fix pickling of 'reward_cfg["reward_scales"]' in hover example

### DIFF
--- a/examples/drone/hover_env.py
+++ b/examples/drone/hover_env.py
@@ -1,5 +1,6 @@
 import torch
 import math
+import copy
 import genesis as gs
 from genesis.utils.geom import quat_to_xyz, transform_by_quat, inv_quat, transform_quat_by_quat
 
@@ -28,7 +29,7 @@ class HoverEnv:
         self.command_cfg = command_cfg
 
         self.obs_scales = obs_cfg["obs_scales"]
-        self.reward_scales = reward_cfg["reward_scales"]
+        self.reward_scales = copy.deepcopy(reward_cfg["reward_scales"])
 
         # create scene
         self.scene = gs.Scene(


### PR DESCRIPTION

## Description
Currently, `HoverEnv.reward_scales` is a shadow reference of `reward_cfg["reward_scales"]`, so later modification on `self.reward_scales` will affect `reward_cfg["reward_scales"]`, leading to wrong reward_cfg in `cfgs.pkl`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
