### PR TITLE
[FEATURE] URDF-GLB import: support non-uint8 + 1/2-channel textures

### DIFF
--- a/genesis/options/textures.py
+++ b/genesis/options/textures.py
@@ -141,33 +141,33 @@ class ImageTexture(Texture):
         elif self.image_array is not None:
             if not isinstance(self.image_array, np.ndarray):
                 gs.raise_exception("`image_array` needs to be a numpy array.")
-            if self.image_array.dtype == np.uint8:
-                pass
-            elif np.issubdtype(self.image_array.dtype, np.floating):
-                if self.image_array.max() <= 1.0:
-                    self.image_array = (self.image_array * 255.0).round()
-                self.image_array = np.clip(self.image_array, 0.0, 255.0).astype(np.uint8)
-            elif self.image_array.dtype == np.bool_:
-                self.image_array = self.image_array.astype(np.uint8) * 255
-            elif np.issubdtype(self.image_array.dtype, np.integer):
-                self.image_array = np.clip(self.image_array, 0, 255).astype(np.uint8)
-            else:
-                gs.raise_exception(
-                    f"Unsupported image dtype {self.image_array.dtype}. "
-                    "Only uint8, integer, floating-point, or bool types are supported."
-                )
-
-            if self.image_array.ndim == 2:
-                self.image_array = np.stack([self.image_array] * 3, axis=-1)
-            elif self.image_array.shape[2] == 1:
-                self.image_array = np.repeat(self.image_array, 3, axis=2)
-            elif self.image_array.shape[2] == 2:
-                L = self.image_array[..., 0]
-                A = self.image_array[..., 1]
-                self.image_array = np.stack([L, L, L, A], axis=-1)
+            arr = self.image_array
+            if arr.dtype != np.uint8:
+                if np.issubdtype(arr.dtype, np.floating):
+                    if arr.max() <= 1.0:
+                        arr = (arr * 255.0).round()
+                    arr = np.clip(arr, 0.0, 255.0).astype(np.uint8)
+                elif arr.dtype == np.bool_:
+                    arr = arr.astype(np.uint8) * 255
+                elif np.issubdtype(arr.dtype, np.integer):
+                    arr = np.clip(arr, 0, 255).astype(np.uint8)
+                else:
+                    gs.raise_exception(
+                        f"Unsupported image dtype {arr.dtype}. "
+                        "Only uint8, integer, floating-point, or bool types are supported."
+                    )
+            self.image_array = arr
 
         # calculate channel
         if self.image_array is None:
+            if isinstance(self.resolution, (tuple, list)):
+                H, W = self.resolution
+            else:
+                H = W = self.resolution
+
+            # Default to 3-channel RGB
+            white = np.array([255, 255, 255], dtype=np.uint8)
+            self.image_array = np.full((H, W, 3), white, dtype=np.uint8)
             self._mean_color = np.array([1.0, 1.0, 1.0], dtype=np.float16)
             self._channel = 3
         else:

--- a/genesis/options/textures.py
+++ b/genesis/options/textures.py
@@ -141,6 +141,30 @@ class ImageTexture(Texture):
         elif self.image_array is not None:
             if not isinstance(self.image_array, np.ndarray):
                 gs.raise_exception("`image_array` needs to be an numpy array.")
+            if self.image_array.dtype != np.uint8:
+                if self.image_array.dtype in (np.float32, np.float64):
+                    if self.image_array.max() <= 1.0:
+                        self.image_array = (self.image_array * 255.0).round()
+                    self.image_array = np.clip(self.image_array, 0.0, 255.0).astype(np.uint8)
+                elif self.image_array.dtype == np.bool_:
+                    self.image_array = self.image_array.astype(np.uint8) * 255
+
+                elif np.issubdtype(self.image_array.dtype, np.integer):
+                    self.image_array = np.clip(self.image_array, 0, 255).astype(np.uint8)
+                else:
+                    gs.raise_exception(
+                        f"Unsupported image dtype {self.image_array.dtype}. Only uint8 or float32/64 are supported."
+                    )
+            if self.image_array.ndim == 2:
+                self.image_array = np.stack([self.image_array] * 3, axis=-1)
+
+            elif self.image_array.shape[2] == 1:
+                self.image_array = np.repeat(self.image_array, 3, axis=2)
+
+            elif self.image_array.shape[2] == 2:
+                L = self.image_array[..., 0]
+                A = self.image_array[..., 1]
+                self.image_array = np.stack([L, L, L, A], axis=-1)
 
         # calculate channel
         if self.image_array is None:
@@ -162,8 +186,6 @@ class ImageTexture(Texture):
         self.encoding = self.encoding.lower()
         if self.encoding not in ["srgb", "linear"]:
             gs.raise_exception(f"Invalid image encoding: {self.encoding}.")
-
-        assert self.image_array is None or self.image_array.dtype == np.uint8
 
     def check_dim(self, dim):
         if self.image_array is not None:

--- a/genesis/options/textures.py
+++ b/genesis/options/textures.py
@@ -140,27 +140,27 @@ class ImageTexture(Texture):
 
         elif self.image_array is not None:
             if not isinstance(self.image_array, np.ndarray):
-                gs.raise_exception("`image_array` needs to be an numpy array.")
-            if self.image_array.dtype != np.uint8:
-                if self.image_array.dtype in (np.float32, np.float64):
-                    if self.image_array.max() <= 1.0:
-                        self.image_array = (self.image_array * 255.0).round()
-                    self.image_array = np.clip(self.image_array, 0.0, 255.0).astype(np.uint8)
-                elif self.image_array.dtype == np.bool_:
-                    self.image_array = self.image_array.astype(np.uint8) * 255
+                gs.raise_exception("`image_array` needs to be a numpy array.")
+            if self.image_array.dtype == np.uint8:
+                pass
+            elif np.issubdtype(self.image_array.dtype, np.floating):
+                if self.image_array.max() <= 1.0:
+                    self.image_array = (self.image_array * 255.0).round()
+                self.image_array = np.clip(self.image_array, 0.0, 255.0).astype(np.uint8)
+            elif self.image_array.dtype == np.bool_:
+                self.image_array = self.image_array.astype(np.uint8) * 255
+            elif np.issubdtype(self.image_array.dtype, np.integer):
+                self.image_array = np.clip(self.image_array, 0, 255).astype(np.uint8)
+            else:
+                gs.raise_exception(
+                    f"Unsupported image dtype {self.image_array.dtype}. "
+                    "Only uint8, integer, floating-point, or bool types are supported."
+                )
 
-                elif np.issubdtype(self.image_array.dtype, np.integer):
-                    self.image_array = np.clip(self.image_array, 0, 255).astype(np.uint8)
-                else:
-                    gs.raise_exception(
-                        f"Unsupported image dtype {self.image_array.dtype}. Only uint8 or float32/64 are supported."
-                    )
             if self.image_array.ndim == 2:
                 self.image_array = np.stack([self.image_array] * 3, axis=-1)
-
             elif self.image_array.shape[2] == 1:
                 self.image_array = np.repeat(self.image_array, 3, axis=2)
-
             elif self.image_array.shape[2] == 2:
                 L = self.image_array[..., 0]
                 A = self.image_array[..., 1]

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -296,11 +296,9 @@ def test_usd_parse(usd_filename):
 
 
 @pytest.mark.required
-def test_urdf_with_existing_glb():
+def test_urdf_with_existing_glb(tmp_path, show_viewer):
     assets = Path(gs.utils.get_assets_dir())
     glb_path = assets / "usd" / "sneaker_airforce.glb"
-
-    tmp_path = Path(__file__).parent
     urdf_path = tmp_path / "model.urdf"
     urdf_path.write_text(
         f"""<robot name="shoe">
@@ -309,8 +307,81 @@ def test_urdf_with_existing_glb():
                    <geometry><mesh filename="{glb_path}"/></geometry>
                  </visual>
                </link>
-             </robot>"""
+             </robot>
+          """
     )
-    scene = gs.Scene(show_viewer=False)
+    scene = gs.Scene(
+        show_viewer=show_viewer,
+        show_fps=False,
+    )
+    scene.build()
+    scene.step()
+
+
+@pytest.mark.required
+def test_urdf_with_float32_grayscale_glb(tmp_path, show_viewer):
+    glb_path = tmp_path / "gray.glb"
+    img = np.random.rand(16, 16).astype(np.float32)
+    vertices = np.array(
+        [[-0.5, -0.5, 0.0], [0.5, -0.5, 0.0], [0.5, 0.5, 0.0], [-0.5, 0.5, 0.0]],
+        dtype=np.float32,
+    )
+    faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.uint32)
+    mesh = trimesh.Trimesh(vertices, faces, process=False)
+    mesh.visual = trimesh.visual.texture.TextureVisuals(
+        uv=np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float32),
+        material=trimesh.visual.material.SimpleMaterial(image=img),
+    )
+    trimesh.Scene([mesh]).export(glb_path)
+    urdf_path = tmp_path / "model_gray.urdf"
+    urdf_path.write_text(
+        f"""<robot name="gray">
+               <link name="base">
+                 <visual>
+                   <geometry><mesh filename="{glb_path}"/></geometry>
+                 </visual>
+               </link>
+             </robot>
+          """
+    )
+    scene = gs.Scene(
+        show_viewer=show_viewer,
+        show_fps=False,
+    )
+    scene.build()
+    scene.step()
+
+
+@pytest.mark.required
+def test_urdf_with_float64_two_channel_glb(tmp_path, show_viewer):
+    glb_path = tmp_path / "rg.glb"
+    img = np.random.rand(16, 16, 2).astype(np.float64)
+    vertices = np.array(
+        [[-0.5, -0.5, 0.0], [0.5, -0.5, 0.0], [0.5, 0.5, 0.0], [-0.5, 0.5, 0.0]],
+        dtype=np.float32,
+    )
+    faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.uint32)
+    mesh = trimesh.Trimesh(vertices, faces, process=False)
+    mesh.visual = trimesh.visual.texture.TextureVisuals(
+        uv=np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float32),
+        material=trimesh.visual.material.SimpleMaterial(image=img),
+    )
+    trimesh.Scene([mesh]).export(glb_path)
+
+    urdf_path = tmp_path / "model_rg.urdf"
+    urdf_path.write_text(
+        f"""<robot name="rg">
+               <link name="base">
+                 <visual>
+                   <geometry><mesh filename="{glb_path}"/></geometry>
+                 </visual>
+               </link>
+             </robot>
+          """
+    )
+    scene = gs.Scene(
+        show_viewer=show_viewer,
+        show_fps=False,
+    )
     scene.build()
     scene.step()

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -3,6 +3,7 @@ import trimesh
 import numpy as np
 import os
 from huggingface_hub import snapshot_download
+from pathlib import Path
 
 import genesis as gs
 import genesis.utils.mesh as mu
@@ -292,3 +293,24 @@ def test_usd_parse(usd_filename):
         check_gs_textures(
             gs_glb_material.emissive_texture, gs_usd_material.emissive_texture, 0.0, material_name, "emissive"
         )
+
+
+@pytest.mark.required
+def test_urdf_with_existing_glb():
+    assets = Path(gs.utils.get_assets_dir())
+    glb_path = assets / "usd" / "sneaker_airforce.glb"
+
+    tmp_path = Path(__file__).parent
+    urdf_path = tmp_path / "model.urdf"
+    urdf_path.write_text(
+        f"""<robot name="shoe">
+               <link name="base">
+                 <visual>
+                   <geometry><mesh filename="{glb_path}"/></geometry>
+                 </visual>
+               </link>
+             </robot>"""
+    )
+    scene = gs.Scene(show_viewer=False)
+    scene.build()
+    scene.step()

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,16 +1,15 @@
+import os
+from pathlib import Path
+import numpy as np
 import pytest
 import trimesh
-import numpy as np
-import os
-from huggingface_hub import snapshot_download
-from pathlib import Path
 
 import genesis as gs
-import genesis.utils.mesh as mu
 import genesis.utils.gltf as gltf_utils
+import genesis.utils.mesh as mu
 import genesis.utils.usda as usda_utils
 
-from .utils import get_hf_assets, assert_allclose, assert_array_equal
+from .utils import assert_allclose, assert_array_equal, get_hf_assets
 
 VERTICES_TOL = 1e-05  # Transformation loses a little precision in vertices
 NORMALS_TOL = 1e-02  # Conversion from .usd to .glb loses a little precision in normals
@@ -302,86 +301,64 @@ def test_urdf_with_existing_glb(tmp_path, show_viewer):
     urdf_path = tmp_path / "model.urdf"
     urdf_path.write_text(
         f"""<robot name="shoe">
-               <link name="base">
-                 <visual>
-                   <geometry><mesh filename="{glb_path}"/></geometry>
-                 </visual>
-               </link>
-             </robot>
-          """
+              <link name="base">
+                <visual>
+                  <geometry><mesh filename="{glb_path}"/></geometry>
+                </visual>
+              </link>
+            </robot>
+         """
     )
     scene = gs.Scene(
         show_viewer=show_viewer,
-        show_fps=False,
+        show_FPS=False,
     )
     scene.build()
     scene.step()
 
 
 @pytest.mark.required
-def test_urdf_with_float32_grayscale_glb(tmp_path, show_viewer):
-    glb_path = tmp_path / "gray.glb"
-    img = np.random.rand(16, 16).astype(np.float32)
+@pytest.mark.parametrize(
+    "n_channels, float_type",
+    [
+        (1, np.float32),  # grayscale → H×W
+        (2, np.float64),  # L+A       → H×W×2
+    ],
+)
+def test_urdf_with_float_texture_glb(tmp_path, show_viewer, n_channels, float_type):
     vertices = np.array(
         [[-0.5, -0.5, 0.0], [0.5, -0.5, 0.0], [0.5, 0.5, 0.0], [-0.5, 0.5, 0.0]],
         dtype=np.float32,
     )
     faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.uint32)
+
     mesh = trimesh.Trimesh(vertices, faces, process=False)
+
+    H = W = 16
+    if n_channels == 1:
+        img = np.random.rand(H, W).astype(float_type)
+    else:
+        img = np.random.rand(H, W, n_channels).astype(float_type)
+
     mesh.visual = trimesh.visual.texture.TextureVisuals(
         uv=np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float32),
         material=trimesh.visual.material.SimpleMaterial(image=img),
     )
-    trimesh.Scene([mesh]).export(glb_path)
-    urdf_path = tmp_path / "model_gray.urdf"
-    urdf_path.write_text(
-        f"""<robot name="gray">
-               <link name="base">
-                 <visual>
-                   <geometry><mesh filename="{glb_path}"/></geometry>
-                 </visual>
-               </link>
-             </robot>
-          """
-    )
-    scene = gs.Scene(
-        show_viewer=show_viewer,
-        show_fps=False,
-    )
-    scene.build()
-    scene.step()
 
-
-@pytest.mark.required
-def test_urdf_with_float64_two_channel_glb(tmp_path, show_viewer):
-    glb_path = tmp_path / "rg.glb"
-    img = np.random.rand(16, 16, 2).astype(np.float64)
-    vertices = np.array(
-        [[-0.5, -0.5, 0.0], [0.5, -0.5, 0.0], [0.5, 0.5, 0.0], [-0.5, 0.5, 0.0]],
-        dtype=np.float32,
-    )
-    faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.uint32)
-    mesh = trimesh.Trimesh(vertices, faces, process=False)
-    mesh.visual = trimesh.visual.texture.TextureVisuals(
-        uv=np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float32),
-        material=trimesh.visual.material.SimpleMaterial(image=img),
-    )
+    glb_path = tmp_path / f"tex_{n_channels}c.glb"
+    urdf_path = tmp_path / f"tex_{n_channels}c.urdf"
     trimesh.Scene([mesh]).export(glb_path)
 
-    urdf_path = tmp_path / "model_rg.urdf"
     urdf_path.write_text(
-        f"""<robot name="rg">
-               <link name="base">
-                 <visual>
-                   <geometry><mesh filename="{glb_path}"/></geometry>
-                 </visual>
-               </link>
-             </robot>
-          """
+        f"""<robot name="tex{n_channels}c">
+              <link name="base">
+                <visual>
+                  <geometry><mesh filename="{glb_path}"/></geometry>
+                </visual>
+              </link>
+            </robot>
+         """
     )
-    scene = gs.Scene(
-        show_viewer=show_viewer,
-        show_fps=False,
-    )
+    scene = gs.Scene(show_viewer=show_viewer, show_FPS=False)
     scene.build()
     scene.step()


### PR DESCRIPTION
Auto-converts all float / bool / ≥9-bit integer images to uint8.

Expands grayscale (H,W) / (H,W,1) → RGB and L+A (H,W,2) → RGBA

Addresses: #1322 