### PR TITLE
[MISC] Add viewer code to handle moving objects

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -55,24 +55,24 @@ class RigidLink(RBC):
         self._entity_idx_in_solver = entity.idx
 
         self._uid = gs.UID()
-        self._idx = idx
-        self._parent_idx = parent_idx
-        self._root_idx = root_idx
-        self._child_idxs = list()
-        self._invweight = invweight
+        self._idx: int = idx
+        self._parent_idx: int = parent_idx  # -1 if no parent
+        self._root_idx: int | None = root_idx  # None if no root
+        self._child_idxs: list[int] = list()
+        self._invweight: float | None = invweight
 
-        self._joint_start = joint_start
-        self._n_joints = n_joints
+        self._joint_start: int = joint_start
+        self._n_joints: int = n_joints
 
-        self._geom_start = geom_start
-        self._cell_start = cell_start
-        self._vert_start = vert_start
-        self._face_start = face_start
-        self._edge_start = edge_start
-        self._verts_state_start = verts_state_start
-        self._vgeom_start = vgeom_start
-        self._vvert_start = vvert_start
-        self._vface_start = vface_start
+        self._geom_start: int = geom_start
+        self._cell_start: int = cell_start
+        self._vert_start: int = vert_start
+        self._face_start: int = face_start
+        self._edge_start: int = edge_start
+        self._verts_state_start: int = verts_state_start
+        self._vgeom_start: int = vgeom_start
+        self._vvert_start: int = vvert_start
+        self._vface_start: int = vface_start
 
         # Link position & rotation at creation time:
         self._pos: ArrayLike = pos

--- a/genesis/ext/pyrender/interaction/aabb.py
+++ b/genesis/ext/pyrender/interaction/aabb.py
@@ -54,7 +54,7 @@ class AABB:
         hit_pos = ray.origin + ray.direction * enter
         return RayHit(enter, hit_pos, normal)
 
-    def raycast_oobb(self, pose: Pose, ray: Ray) -> RayHit:
+    def raycast_obb(self, pose: Pose, ray: Ray) -> RayHit:
         inv_pose = pose.get_inverse()
         origin2 = inv_pose.transform_point(ray.origin)
         direction2 = inv_pose.transform_direction(ray.direction)

--- a/genesis/ext/pyrender/interaction/vec3.py
+++ b/genesis/ext/pyrender/interaction/vec3.py
@@ -35,6 +35,9 @@ class Vec3:
     def __rmul__(self, other: float) -> 'Vec3':
         return Vec3(self.v * np.float32(other))
 
+    def __neg__(self) -> 'Vec3':
+        return Vec3(-self.v)
+
     def dot(self, other: 'Vec3') -> float:
         return np.dot(self.v, other.v).item()
 
@@ -43,6 +46,9 @@ class Vec3:
 
     def normalized(self) -> 'Vec3':
         return Vec3(self.v / (np.linalg.norm(self.v) + 1e-24))
+
+    def magnitude(self) -> float:
+        return np.linalg.norm(self.v)
 
     def copy(self) -> 'Vec3':
         return Vec3(self.v.copy())

--- a/genesis/ext/pyrender/interaction/vec3.py
+++ b/genesis/ext/pyrender/interaction/vec3.py
@@ -10,16 +10,12 @@ from genesis.utils.misc import tensor_to_array
 # Vec3 = Annotated[npt.NDArray[np.float32], (3,)]
 # Aabb = Annotated[npt.NDArray[np.float32], (2, 3)]
 
-_is_torch_imported: bool = False
 
 def _ensure_torch_imported() -> None:
-    global _is_torch_imported
-    if not _is_torch_imported:
-        _is_torch_imported = True
-        global gs
-        import genesis as gs
-        global torch
-        import torch
+    global gs
+    import genesis as gs
+    global torch
+    import torch
 
 
 class Vec3:
@@ -69,6 +65,10 @@ class Vec3:
     def __repr__(self) -> str:
         return f"Vec3({self.v[0]}, {self.v[1]}, {self.v[2]})"
 
+    def as_tensor(self) -> 'torch.Tensor':
+        _ensure_torch_imported()
+        return torch.tensor(self.v, dtype=gs.tc_float) 
+
     @property
     def x(self) -> float:
         return self.v[0]
@@ -80,11 +80,6 @@ class Vec3:
     @property
     def z(self) -> float:
         return self.v[2]
-
-    @property
-    def as_tensor(self) -> 'torch.Tensor':
-        _ensure_torch_imported()
-        return torch.tensor(self.v, dtype=gs.tc_float) 
 
     @classmethod
     def from_xyz(cls, x: float, y: float, z: float) -> 'Vec3':
@@ -150,6 +145,10 @@ class Quat:
     def __repr__(self) -> str:
         return f"Quat({self.v[0]}, {self.v[1]}, {self.v[2]}, {self.v[3]})"
 
+    def as_tensor(self) -> 'torch.Tensor':
+        _ensure_torch_imported()
+        return torch.tensor(self.v, dtype=gs.tc_float) 
+
     @property
     def w(self) -> float:
         return self.v[0]
@@ -166,11 +165,6 @@ class Quat:
     def z(self) -> float:
         return self.v[3]
 
-    @property
-    def as_tensor(self) -> 'torch.Tensor':
-        _ensure_torch_imported()
-        return torch.tensor(self.v, dtype=gs.tc_float) 
-
     @classmethod
     def from_wxyz(cls, w: float, x: float, y: float, z: float) -> 'Quat':
         return cls(np.array([w, x, y, z], dtype=np.float32))
@@ -185,7 +179,6 @@ class Quat:
         _ensure_torch_imported()
         array: np.ndarray = tensor_to_array(v)
         return cls.from_array(array)
-
 
 
 @dataclass

--- a/genesis/ext/pyrender/interaction/viewer_interaction.py
+++ b/genesis/ext/pyrender/interaction/viewer_interaction.py
@@ -71,7 +71,7 @@ class ViewerInteraction(ViewerInteractionBase):
                     #apply displacement
                     pos = Vec3.from_tensor(self.picked_entity.get_pos())
                     pos = pos + delta_3d_pos
-                    self.picked_entity.set_pos(pos.as_tensor)
+                    self.picked_entity.set_pos(pos.as_tensor())
 
             return EVENT_HANDLED
 

--- a/genesis/ext/pyrender/interaction/viewer_interaction_base.py
+++ b/genesis/ext/pyrender/interaction/viewer_interaction_base.py
@@ -4,6 +4,7 @@ import genesis as gs
 
 
 EVENT_HANDLE_STATE = Union[Literal[True], None]
+EVENT_HANDLED = True
 
 # Note: Viewer window is based on pyglet.window.Window, mouse events are defined in pyglet.window.BaseWindow
 

--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -56,7 +56,7 @@ from .constants import (
     TextAlign,
 )
 from .interaction.viewer_interaction import ViewerInteraction
-from .interaction.viewer_interaction_base import ViewerInteractionBase, EVENT_HANDLE_STATE
+from .interaction.viewer_interaction_base import ViewerInteractionBase, EVENT_HANDLE_STATE, EVENT_HANDLED
 from .light import DirectionalLight
 from .node import Node
 from .renderer import Renderer
@@ -793,8 +793,10 @@ class Viewer(pyglet.window.Window):
 
     def on_mouse_drag(self, x: int, y: int, dx: int, dy: int, buttons: int, modifiers: int) -> EVENT_HANDLE_STATE:
         """The mouse was moved with one or more buttons held down."""
-        self._trackball.drag(np.array([x, y]))
-        return self.viewer_interaction.on_mouse_drag(x, y, dx, dy, buttons, modifiers)
+        result = self.viewer_interaction.on_mouse_drag(x, y, dx, dy, buttons, modifiers)
+        if result is not EVENT_HANDLED:
+            result = self._trackball.drag(np.array([x, y]))
+        return result
 
     def on_mouse_release(self, x: int, y: int, button: int, modifiers: int) -> EVENT_HANDLE_STATE:
         """Record a mouse release."""


### PR DESCRIPTION
## Description
Objects can be held with LMB. 
When objects are held, camera rotation (via mouse-drag) is suspended.

Temporary implementation of object movement is added, where only position is updated, not velocities, so that causes interpenetrations of objects.

* Add simple box-moving interaction.
* Lazy load tensor in vec3.py, add Vec3/Quat.from_tensor/from_array.
* Rename oobb to obb.
* Vec3/Quat.as_tensor() is now a method.

## Motivation and Context

Allow moving of objects and kinematic chains by using external user force.

## How Has This Been / Can This Be Tested?

Manual testing only

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/255a969f-c908-486b-93a8-430287660800)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
