### PR TITLE
[BUG FIX] Fixed apply_links_external_torque() crashing for n_envs == 0

### DIFF
--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -2723,6 +2723,8 @@ class RigidSolver(Solver):
         torque, links_idx, envs_idx = self._sanitize_2D_io_variables(
             torque, links_idx, self.n_links, 3, envs_idx, idx_name="links_idx", skip_allocation=True, unsafe=unsafe
         )
+        if self.n_envs == 0:
+            torque = torque.unsqueeze(0)
 
         if ref == "root_com":
             if local:


### PR DESCRIPTION
## Description
Fixed apply_links_external_torque() to behave analogically to apply_links_external_force()
The former was not unsqueezing the input torque tensor when running a single environment.

## How Has This Been / Can This Be Tested?
Only run test locally for single env, calling both:
apply_links_external_force() and
apply_links_external_toruqe()
with the same parameter.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
