### PR TITLE
[FEATURE] expose joint position query

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -2444,6 +2444,46 @@ class RigidEntity(Entity):
         return self._solver.get_qpos(qs_idx, envs_idx, unsafe=unsafe)
 
     @gs.assert_built
+    def get_joints_anchor_pos(self, joints_idx_local=None, envs_idx=None, *, unsafe=False):
+        """
+        Returns anchor position of the entity's joints. This is the position of the joint in the world frame.
+
+        Parameters
+        ----------
+        joints_idx_local : None | array_like, optional
+            The indices of the dofs to get. If None, all dofs will be returned. Note that here this uses the local `q_idx`, not the scene-level one. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+
+        Returns
+        -------
+        anchor_pos : torch.Tensor, shape (n_joints, 3) or (n_envs, n_joints, 3)
+            The anchor position of the entity's joints.
+        """
+        joints_idx = self._get_idx(joints_idx_local, self.n_joints, self._joint_start, unsafe=True)
+        return self._solver.get_joints_anchor_pos(joints_idx, envs_idx, unsafe=unsafe).squeeze(-2)
+
+    @gs.assert_built
+    def get_joints_anchor_axis(self, joints_idx_local=None, envs_idx=None, *, unsafe=False):
+        """
+        Returns anchor axis of the entity's joints represented as a unit vector.
+
+        Parameters
+        ----------
+        joints_idx_local : None | array_like, optional
+            The indices of the dofs to get. If None, all dofs will be returned. Note that here this uses the local `q_idx`, not the scene-level one. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+
+        Returns
+        -------
+        anchor_axis : torch.Tensor, shape (n_joints, 3) or (n_envs, n_joints, 3)
+            The anchor axis of the entity's joints.
+        """
+        joints_idx = self._get_idx(joints_idx_local, self.n_joints, self._joint_start, unsafe=True)
+        return self._solver.get_joints_anchor_axis(joints_idx, envs_idx, unsafe=unsafe).squeeze(-2)
+
+    @gs.assert_built
     def get_dofs_control_force(self, dofs_idx_local=None, envs_idx=None, *, unsafe=False):
         """
         Get the entity's dofs' internal control force, computed based on the position/velocity control command.

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -4708,6 +4708,14 @@ class RigidSolver(Solver):
         tensor = ti_field_to_torch(self.qpos, envs_idx, qs_idx, transpose=True, unsafe=unsafe)
         return tensor.squeeze(0) if self.n_envs == 0 else tensor
 
+    def get_joints_anchor_pos(self, joints_idx=None, envs_idx=None, *, unsafe=False):
+        tensor = ti_field_to_torch(self.joints_state.xanchor, envs_idx, joints_idx, transpose=True, unsafe=unsafe)
+        return tensor.squeeze(0) if self.n_envs == 0 else tensor
+
+    def get_joints_anchor_axis(self, joints_idx=None, envs_idx=None, *, unsafe=False):
+        tensor = ti_field_to_torch(self.joints_state.xaxis, envs_idx, joints_idx, transpose=True, unsafe=unsafe)
+        return tensor.squeeze(0) if self.n_envs == 0 else tensor
+
     def get_dofs_control_force(self, dofs_idx=None, envs_idx=None, *, unsafe=False):
         _tensor, dofs_idx, envs_idx = self._sanitize_1D_io_variables(
             None, dofs_idx, self.n_dofs, envs_idx, unsafe=unsafe


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->

Add two new API `get_joints_anchor_pos` and `get_joints_anchor_axis` that returns the joint position in world coordinate and the axis direction in unit vector. 

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
