### PR TITLE
[BUG FIX] Fix broken interactive viewer.

### DIFF
--- a/genesis/ext/pyrender/jit_render.py
+++ b/genesis/ext/pyrender/jit_render.py
@@ -826,6 +826,10 @@ class JITRenderer:
             return self._update_normal_flat(vertices.reshape((-1, 3, 3)))
 
     def update_buffer(self, buffer_updates):
+        # Early return if nothing to do
+        if not buffer_updates:
+            return
+
         updates = np.zeros((len(buffer_updates), 3), dtype=np.int64)
         buffers = []
         for idx, (id, data) in enumerate(buffer_updates.items()):

--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -400,8 +400,6 @@ class Viewer(pyglet.window.Window):
         self.pending_offscreen_camera = None
         self.offscreen_result = None
 
-        self.pending_buffer_updates = {}
-
         # Starting the viewer would raise an exception if the OpenGL context is invalid for some reason. This exception
         # must be caught in order to implement some fallback mechanism. One may want to start the viewer from the main
         # thread while the running loop would be running on a background thread. However, this approach is not possible
@@ -655,10 +653,6 @@ class Viewer(pyglet.window.Window):
             self.render_flags["depth"] = False
         return self.offscreen_result
 
-    def update_buffers(self):
-        self._renderer.jit.update_buffer(self.pending_buffer_updates)
-        self.pending_buffer_updates.clear()
-
     def wait_until_initialized(self):
         self._initialized_event.wait()
 
@@ -671,7 +665,10 @@ class Viewer(pyglet.window.Window):
 
         # Make OpenGL context current
         self.switch_to()
-        self.update_buffers()
+
+        # Update the context if not already done before
+        self._renderer.jit.update_buffer(self.gs_context.buffer)
+        self.gs_context.buffer.clear()
 
         self.offscreen_results = []
         self.render_flags["offscreen"] = True
@@ -696,7 +693,10 @@ class Viewer(pyglet.window.Window):
 
         # Make OpenGL context current
         self.switch_to()
-        self.update_buffers()
+
+        # Update the context if not already done before
+        self._renderer.jit.update_buffer(self.gs_context.buffer)
+        self.gs_context.buffer.clear()
 
         # Render the scene
         self.clear()

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -875,7 +875,7 @@ class RasterizerContext:
             self.seg_node_map[seg_node] = self.seg_idxc_to_idxc_rgb(seg_idxc)
 
     def remove_node_seg(self, seg_node):
-        self.seg_node_map.pop(seg_node)
+        self.seg_node_map.pop(seg_node, None)
 
     def generate_seg_vars(self):
         # seg_key: same as entity/link/geom's idx

--- a/genesis/vis/viewer.py
+++ b/genesis/vis/viewer.py
@@ -144,7 +144,8 @@ class Viewer(RBC):
             self.update_following()
 
         with self.lock:
-            self._pyrender_viewer.pending_buffer_updates |= self.context.update()
+            # Update context
+            self.context.update()
 
             # Refresh viewer by default if and if this is possible
             if auto_refresh is None:
@@ -157,6 +158,9 @@ class Viewer(RBC):
         # lock FPS
         if self._max_FPS is not None:
             self.rate.sleep()
+
+    def render_offscreen(self, camera_node, render_target, depth=False, seg=False, normal=False):
+        return self._pyrender_viewer.render_offscreen(camera_node, render_target, depth, seg, normal)
 
     def set_camera_pose(self, pose=None, pos=None, lookat=None):
         """


### PR DESCRIPTION
## Description

* Fix segmentation node removal.
* Cleanup rendering context state update.

## Motivation and Context

Having all rendering backend managing their own context update state induces additional boilerplate without any advantage. It should be centralised in the context itself. Moreover, the viewer initialisation logic is overly complicated and should be simplified. 

## How Has This Been / Can This Be Tested?

`python examples/rigid/single_franka.py --vis`

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.