### PR TITLE
[BUGFIX] Made max_collision_pairs for broad phase larger

### DIFF
--- a/genesis/engine/solvers/rigid/array_class.py
+++ b/genesis/engine/solvers/rigid/array_class.py
@@ -59,17 +59,6 @@ class ConstraintState:
 
 
 @ti.data_oriented
-class ConstraintState:
-    """
-    Class to store the mutable constraint data, all of which type is [ti.fields].
-    """
-
-    def __init__(self, solver):
-        f_batch = solver._batch_shape
-        self.n_constraints = ti.field(dtype=gs.ti_int, shape=f_batch())
-
-
-@ti.data_oriented
 class ColliderState:
     """
     Class to store the MUTABLE collider data, all of which type is [ti.fields] (later we will support NDArrays).
@@ -89,6 +78,7 @@ class ColliderState:
         f_batch = solver._batch_shape
         n_geoms = solver.n_geoms_
         max_collision_pairs = min(solver._max_collision_pairs, n_possible_pairs)
+        max_collision_pairs_broad = max_collision_pairs * collider_static_config.max_collision_pairs_broad_k
         max_contact_pairs = max_collision_pairs * collider_static_config.n_contacts_per_pair
         use_hibernation = solver._static_rigid_sim_config.use_hibernation
         box_box_detection = solver._static_rigid_sim_config.box_box_detection
@@ -107,14 +97,11 @@ class ColliderState:
         # Whether or not this is the first time to run the broad phase for each batch
         self.first_time = ti.field(gs.ti_int, shape=_B)
 
-        # Number of possible pairs of collision, store them in a field to avoid recompilation
-        self._max_possible_pairs = ti.field(dtype=gs.ti_int, shape=())
-        self._max_collision_pairs = ti.field(dtype=gs.ti_int, shape=())
-        self._max_contact_pairs = ti.field(dtype=gs.ti_int, shape=())
-
         # Final results of the broad phase
         self.n_broad_pairs = ti.field(dtype=gs.ti_int, shape=_B)
-        self.broad_collision_pairs = ti.Vector.field(2, dtype=gs.ti_int, shape=f_batch(max(1, max_collision_pairs)))
+        self.broad_collision_pairs = ti.Vector.field(
+            2, dtype=gs.ti_int, shape=f_batch(max(1, max_collision_pairs_broad))
+        )
 
         ############## narrow phase ##############
         struct_contact_data = ti.types.struct(
@@ -196,6 +183,7 @@ class ColliderInfo:
         self._max_possible_pairs = ti.field(dtype=gs.ti_int, shape=())
         self._max_collision_pairs = ti.field(dtype=gs.ti_int, shape=())
         self._max_contact_pairs = ti.field(dtype=gs.ti_int, shape=())
+        self._max_collision_pairs_broad = ti.field(dtype=gs.ti_int, shape=())
 
         ########## Terrain contact detection ##########
         if collider_static_config.has_terrain:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->

This PR contains the following:

1. Made `max_collision_pairs_broad`, and set the value of it as 20x of `max_collision_pairs`. This is because we usually get much larger number of collision pairs during the broad phase than the narrow phase.
2. Removed duplicate `ConstraintState`.
3. Removed unnecessary fields in `ColliderState`.

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As shown in the video below, if we do not allow large `max_collisions_pair` for the broad phase, some of the collision pairs are ignored and are not detected, even when the number of final collision pairs after the narrow phase is small. In the video below, it ends up in falling objects error. 

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
[Screencast from 2025-07-14 17-09-04.webm](https://github.com/user-attachments/assets/cca85ab4-8673-478f-bda8-7d76ae84b487)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
