### PR TITLE
[BUG FIX] dim error in pos_lookat_up_to_T()

### DIFF
--- a/genesis/utils/geom.py
+++ b/genesis/utils/geom.py
@@ -1,11 +1,10 @@
 import math
 
-import numpy as np
 import numba as nb
+import numpy as np
+import taichi as ti
 import torch
 import torch.nn.functional as F
-
-import taichi as ti
 
 import genesis as gs
 
@@ -1142,7 +1141,7 @@ def z_up_to_R(z, up=None, out=None):
     if out is None:
         out_ = np.empty((*B, 3, 3), dtype=z.dtype)
     else:
-        assert out.shape == (*B, 3, 3)
+        assert out.shape == (*B, 3, 3), f"out.shape: {out.shape} != {(*B, 3, 3)}"
         out_ = out
 
     z_norm = np.sqrt(np.sum(np.square(z.reshape((-1, 3))), -1)).reshape(B)
@@ -1187,6 +1186,8 @@ def pos_lookat_up_to_T(pos, lookat, up, *, dtype=np.float32):
     z_norm = np.linalg.norm(z)
     if z_norm < gs.EPS:
         z = np.array([0.0, 1.0, 0.0], dtype=dtype)
+    if z.ndim == 2:
+        z = z[0]
     z_up_to_R(z, up=up, out=T[:3, :3])
 
     return T


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

There was dim bug in geom.py

```
File "/home/kashu/research/Genesis/genesis/vis/camera.py", line 457, in set_pose
    self._transform = gu.pos_lookat_up_to_T(self._pos, self._lookat, self._up)
  File "/home/kashu/research/Genesis/genesis/utils/geom.py", line 1190, in pos_lookat_up_to_T
    z_up_to_R(z, up=up, out=T[:3, :3])
  File "/home/kashu/miniconda3/envs/genesis/lib/python3.10/site-packages/numba/core/dispatcher.py", line 424, in _compile_for_args
    error_rewrite(e, 'typing')
  File "/home/kashu/miniconda3/envs/genesis/lib/python3.10/site-packages/numba/core/dispatcher.py", line 365, in error_rewrite
    raise e.with_traceback(None)
numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
Cannot unify array(float32, 3d, C) and array(float32, 2d, A) for 'out_.2', defined at /home/kashu/research/Genesis/genesis/utils/geom.py (1148)

File "../../../Genesis/genesis/utils/geom.py", line 1148:
def z_up_to_R(z, up=None, out=None):
    <source elided>

    z_norm = np.sqrt(np.sum(np.square(z.reshape((-1, 3))), -1)).reshape(B)
    ^

During: typing of assignment at /home/kashu/research/Genesis/genesis/utils/geom.py (1148)

File "../../../Genesis/genesis/utils/geom.py", line 1148:
def z_up_to_R(z, up=None, out=None):
    <source elided>

    z_norm = np.sqrt(np.sum(np.square(z.reshape((-1, 3))), -1)).reshape(B)
    ^

During: Pass nopython_type_inference

[Genesis] [14:22:00] [ERROR] TypingError: Failed in nopython mode pipeline (step: nopython frontend)
Cannot unify array(float32, 3d, C) and array(float32, 2d, A) for 'out_.2', defined at /home/kashu/research/Genesis/genesis/utils/geom.py (1148)

File "../../../Genesis/genesis/utils/geom.py", line 1148:
def z_up_to_R(z, up=None, out=None):
    <source elided>

    z_norm = np.sqrt(np.sum(np.square(z.reshape((-1, 3))), -1)).reshape(B)
    ^

During: typing of assignment at /home/kashu/research/Genesis/genesis/utils/geom.py (1148)

File "../../../Genesis/genesis/utils/geom.py", line 1148:
def z_up_to_R(z, up=None, out=None):
    <source elided>

    z_norm = np.sqrt(np.sum(np.square(z.reshape((-1, 3))), -1)).reshape(B)
    ^

During: Pass nopython_type_inference
```

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
