### PR TITLE
[BUG FIX] Fix errors in APIs that are used by rigid examples

### DIFF
--- a/examples/rigid/accelerometer_franka.py
+++ b/examples/rigid/accelerometer_franka.py
@@ -125,7 +125,6 @@ def main():
                 pos=link_pos.tolist(),
                 vec=link_acc.tolist(),
             )
-
             if last_link_vel is not None:
                 scene.draw_debug_arrow(
                     pos=link_pos.tolist(),

--- a/examples/rigid/closed_loop.py
+++ b/examples/rigid/closed_loop.py
@@ -3,7 +3,7 @@ import argparse
 import time
 
 
-def main_equality_connect():
+def main_equality_connect(args):
     gs.init(backend=gs.cpu)
 
     scene = gs.Scene(
@@ -12,6 +12,7 @@ def main_equality_connect():
             camera_lookat=(0.0, 0.0, 3),
             camera_fov=60,
         ),
+        show_viewer=args.vis,
     )
     franka = scene.add_entity(
         gs.morphs.MJCF(
@@ -23,10 +24,7 @@ def main_equality_connect():
         scene.step()
 
 
-def main_equality_weld():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-v", "--vis", action="store_true", default=False)
-    args = parser.parse_args()
+def main_equality_weld(args):
     ########################## init ##########################
     gs.init(backend=gs.cpu)
     scene = gs.Scene(
@@ -51,5 +49,8 @@ def main_equality_weld():
 
 
 if __name__ == "__main__":
-    main_equality_weld()
-    # main_equality_connect()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--vis", action="store_true", default=False)
+    args = parser.parse_args()
+    main_equality_weld(args)
+    # main_equality_connect(args)

--- a/examples/rigid/control_mesh.py
+++ b/examples/rigid/control_mesh.py
@@ -30,6 +30,7 @@ def main():
         vis_options=gs.options.VisOptions(
             show_link_frame=True,
         ),
+        show_viewer=args.vis,
     )
 
     ########################## entities ##########################

--- a/examples/rigid/diffik_controller.py
+++ b/examples/rigid/diffik_controller.py
@@ -32,12 +32,12 @@ def main():
             camera_fov=40,
             max_FPS=200,
         ),
-        show_viewer=args.vis,
         rigid_options=gs.options.RigidOptions(
             enable_joint_limit=False,
             enable_collision=False,
             gravity=(0, 0, -0),
         ),
+        show_viewer=args.vis,
         show_FPS=False,
     )
 

--- a/examples/rigid/domain_randomization.py
+++ b/examples/rigid/domain_randomization.py
@@ -66,6 +66,7 @@ def main():
         com_shift=-0.05 + 0.1 * torch.rand(scene.n_envs, robot.n_links, 3),
         links_idx_local=np.arange(0, robot.n_links),
     )
+    aabb = robot.get_AABB()
 
     joints_name = (
         "FR_hip_joint",
@@ -85,22 +86,7 @@ def main():
 
     robot.set_dofs_kp(np.full(12, 20), motors_dof_idx)
     robot.set_dofs_kv(np.full(12, 1), motors_dof_idx)
-    default_dof_pos = np.array(
-        [
-            0.0,
-            0.8,
-            -1.5,
-            0.0,
-            0.8,
-            -1.5,
-            0.0,
-            1.0,
-            -1.5,
-            0.0,
-            1.0,
-            -1.5,
-        ]
-    )
+    default_dof_pos = np.array([0.0, 0.8, -1.5, 0.0, 0.8, -1.5, 0.0, 1.0, -1.5, 0.0, 1.0, -1.5])
     # padding to n_env x n_dofs
     default_dof_pos = np.tile(default_dof_pos, (n_envs, 1))
     robot.control_dofs_position(default_dof_pos, motors_dof_idx)

--- a/examples/rigid/franka_cube.py
+++ b/examples/rigid/franka_cube.py
@@ -2,79 +2,89 @@ import numpy as np
 import time
 import genesis as gs
 
-########################## init ##########################
-gs.init(backend=gs.gpu, precision="32")
-########################## create a scene ##########################
-scene = gs.Scene(
-    viewer_options=gs.options.ViewerOptions(
-        camera_pos=(3, -1, 1.5),
-        camera_lookat=(0.0, 0.0, 0.5),
-        camera_fov=30,
-        res=(960, 640),
-        max_FPS=60,
-    ),
-    sim_options=gs.options.SimOptions(
-        dt=0.01,
-    ),
-    rigid_options=gs.options.RigidOptions(
-        box_box_detection=True,
-    ),
-    show_viewer=True,
-)
 
-########################## entities ##########################
-plane = scene.add_entity(
-    gs.morphs.Plane(),
-)
-franka = scene.add_entity(
-    gs.morphs.MJCF(file="xml/franka_emika_panda/panda.xml"),
-)
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--vis", action="store_true", default=False)
+    args = parser.parse_args()
 
-cube = scene.add_entity(
-    gs.morphs.Box(
-        size=(0.04, 0.04, 0.04),
-        pos=(0.65, 0.0, 0.02),
+    ########################## init ##########################
+    gs.init(backend=gs.gpu, precision="32")
+    ########################## create a scene ##########################
+    scene = gs.Scene(
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(3, -1, 1.5),
+            camera_lookat=(0.0, 0.0, 0.5),
+            camera_fov=30,
+            res=(960, 640),
+            max_FPS=60,
+        ),
+        sim_options=gs.options.SimOptions(
+            dt=0.01,
+        ),
+        rigid_options=gs.options.RigidOptions(
+            box_box_detection=True,
+        ),
+        show_viewer=args.vis,
     )
-)
-########################## build ##########################
-scene.build()
 
-motors_dof = np.arange(7)
-fingers_dof = np.arange(7, 9)
-qpos = np.array([-1.0124, 1.5559, 1.3662, -1.6878, -1.5799, 1.7757, 1.4602, 0.04, 0.04])
-franka.set_qpos(qpos)
-scene.step()
+    ########################## entities ##########################
+    plane = scene.add_entity(
+        gs.morphs.Plane(),
+    )
+    franka = scene.add_entity(
+        gs.morphs.MJCF(file="xml/franka_emika_panda/panda.xml"),
+    )
 
-end_effector = franka.get_link("hand")
-qpos = franka.inverse_kinematics(
-    link=end_effector,
-    pos=np.array([0.65, 0.0, 0.135]),
-    quat=np.array([0, 1, 0, 0]),
-)
+    cube = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.04, 0.04, 0.04),
+            pos=(0.65, 0.0, 0.02),
+        )
+    )
+    ########################## build ##########################
+    scene.build()
 
-franka.control_dofs_position(qpos[:-2], motors_dof)
-
-# hold
-for i in range(100):
-    print("hold", i)
+    motors_dof = np.arange(7)
+    fingers_dof = np.arange(7, 9)
+    qpos = np.array([-1.0124, 1.5559, 1.3662, -1.6878, -1.5799, 1.7757, 1.4602, 0.04, 0.04])
+    franka.set_qpos(qpos)
     scene.step()
 
-# grasp
-finder_pos = -0.0
-for i in range(100):
-    print("grasp", i)
+    end_effector = franka.get_link("hand")
+    qpos = franka.inverse_kinematics(
+        link=end_effector,
+        pos=np.array([0.65, 0.0, 0.135]),
+        quat=np.array([0, 1, 0, 0]),
+    )
+
     franka.control_dofs_position(qpos[:-2], motors_dof)
-    franka.control_dofs_position(np.array([finder_pos, finder_pos]), fingers_dof)
-    scene.step()
 
-# lift
-qpos = franka.inverse_kinematics(
-    link=end_effector,
-    pos=np.array([0.65, 0.0, 0.3]),
-    quat=np.array([0, 1, 0, 0]),
-)
-for i in range(200):
-    print("lift", i)
-    franka.control_dofs_position(qpos[:-2], motors_dof)
-    franka.control_dofs_position(np.array([finder_pos, finder_pos]), fingers_dof)
-    scene.step()
+    # hold
+    for i in range(100):
+        print("hold", i)
+        scene.step()
+
+    # grasp
+    finder_pos = -0.0
+    for i in range(100):
+        print("grasp", i)
+        franka.control_dofs_position(qpos[:-2], motors_dof)
+        franka.control_dofs_position(np.array([finder_pos, finder_pos]), fingers_dof)
+        scene.step()
+
+    # lift
+    qpos = franka.inverse_kinematics(
+        link=end_effector,
+        pos=np.array([0.65, 0.0, 0.3]),
+        quat=np.array([0, 1, 0, 0]),
+    )
+    for i in range(200):
+        print("lift", i)
+        franka.control_dofs_position(qpos[:-2], motors_dof)
+        franka.control_dofs_position(np.array([finder_pos, finder_pos]), fingers_dof)
+        scene.step()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rigid/ik_custom_chain.py
+++ b/examples/rigid/ik_custom_chain.py
@@ -20,12 +20,12 @@ def main():
             camera_lookat=(0.0, 0.0, 0.5),
             camera_fov=40,
         ),
-        show_viewer=args.vis,
         rigid_options=gs.options.RigidOptions(
             gravity=(0, 0, 0),
             enable_collision=False,
             enable_joint_limit=False,
         ),
+        show_viewer=args.vis,
     )
 
     target_1 = scene.add_entity(

--- a/examples/rigid/ik_duck.py
+++ b/examples/rigid/ik_duck.py
@@ -23,12 +23,12 @@ def main():
             camera_fov=40,
             max_FPS=200,
         ),
-        show_viewer=args.vis,
         rigid_options=gs.options.RigidOptions(
             enable_joint_limit=False,
             enable_collision=False,
             gravity=(0, 0, -0),
         ),
+        show_viewer=args.vis,
     )
 
     ########################## entities ##########################

--- a/examples/rigid/ik_franka.py
+++ b/examples/rigid/ik_franka.py
@@ -23,12 +23,12 @@ def main():
             camera_fov=40,
             max_FPS=200,
         ),
-        show_viewer=args.vis,
         rigid_options=gs.options.RigidOptions(
             enable_joint_limit=False,
             enable_collision=False,
             gravity=(0, 0, -0),
         ),
+        show_viewer=args.vis,
     )
 
     ########################## entities ##########################

--- a/examples/rigid/ik_franka_batched.py
+++ b/examples/rigid/ik_franka_batched.py
@@ -23,12 +23,12 @@ def main():
             camera_fov=40,
             max_FPS=200,
         ),
-        show_viewer=args.vis,
         rigid_options=gs.options.RigidOptions(
             enable_joint_limit=False,
             enable_collision=False,
             gravity=(0, 0, -0),
         ),
+        show_viewer=args.vis,
     )
 
     ########################## entities ##########################

--- a/examples/rigid/ik_shadow_hand.py
+++ b/examples/rigid/ik_shadow_hand.py
@@ -20,12 +20,12 @@ def main():
             camera_lookat=(0.0, 0.0, 0.5),
             camera_fov=40,
         ),
-        show_viewer=args.vis,
         rigid_options=gs.options.RigidOptions(
             gravity=(0, 0, 0),
             enable_collision=False,
             enable_joint_limit=False,
         ),
+        show_viewer=args.vis,
     )
 
     target_1 = scene.add_entity(
@@ -66,24 +66,27 @@ def main():
     target_quat = np.array([1, 0, 0, 0])
     index_finger_distal = robot.get_link("index_finger_distal")
     middle_finger_distal = robot.get_link("middle_finger_distal")
-    forearm = robot.get_link("forearm")
+    wrist = robot.get_link("wrist")  # there is no link named "forearm"
 
     center = np.array([0.5, 0.5, 0.2])
     r1 = 0.1
     r2 = 0.13
+    # FIXME: we have this Debug info and the simulation runs very slow
+    # [DEBUG] Tensor had to be re-allocated because of incorrect dtype/device or non-contiguous memory.
+    # #This may impede performance if it occurs in the critical path of your application
 
-    for i in range(2000):
+    for i in range(3):
         index_finger_pos = center + np.array([np.cos(i / 90 * np.pi), np.sin(i / 90 * np.pi), 0]) * r1
         middle_finger_pos = center + np.array([np.cos(i / 90 * np.pi), np.sin(i / 90 * np.pi), 0]) * r2
-        forearm_pos = index_finger_pos - np.array([0, 0, 0.40])
+        wrist_pos = index_finger_pos - np.array([0, 0, 0.40])
 
         target_1.set_qpos(np.concatenate([index_finger_pos, target_quat]))
         target_2.set_qpos(np.concatenate([middle_finger_pos, target_quat]))
-        target_3.set_qpos(np.concatenate([forearm_pos, target_quat]))
+        target_3.set_qpos(np.concatenate([wrist_pos, target_quat]))
 
         qpos = robot.inverse_kinematics_multilink(
-            links=[index_finger_distal, middle_finger_distal, forearm],
-            poss=[index_finger_pos, middle_finger_pos, forearm_pos],
+            links=[index_finger_distal, middle_finger_distal, wrist],
+            poss=[index_finger_pos, middle_finger_pos, wrist_pos],
         )
 
         robot.set_qpos(qpos)

--- a/examples/rigid/merge_entities.py
+++ b/examples/rigid/merge_entities.py
@@ -101,7 +101,7 @@ def main():
         "finger_joint1",
         "finger_joint2",
     )
-    gripper_dofs_idx = [franka.get_joint(name).dofs_idx_local[0] for name in gripper_joints_name]
+    gripper_dofs_idx = [hand.get_joint(name).dofs_idx_local[0] for name in gripper_joints_name]
 
     # Optional: set control gains
     hand.set_dofs_kp(

--- a/examples/rigid/single_franka.py
+++ b/examples/rigid/single_franka.py
@@ -20,10 +20,10 @@ def main():
             camera_lookat=(0.0, 0.0, 0.5),
             camera_fov=40,
         ),
-        show_viewer=args.vis,
         rigid_options=gs.options.RigidOptions(
             # constraint_solver=gs.constraint_solver.Newton,
         ),
+        show_viewer=args.vis,
     )
 
     ########################## entities ##########################

--- a/examples/rigid/single_franka_envs.py
+++ b/examples/rigid/single_franka_envs.py
@@ -31,10 +31,10 @@ def main():
             camera_lookat=(0.0, 0.0, 0.5),
             camera_fov=40,
         ),
-        show_viewer=args.vis,
         rigid_options=gs.options.RigidOptions(
             # constraint_solver=gs.constraint_solver.Newton,
         ),
+        show_viewer=args.vis,
     )
 
     ########################## entities ##########################

--- a/examples/rigid/terrain_height_field.py
+++ b/examples/rigid/terrain_height_field.py
@@ -25,14 +25,11 @@ def main():
             camera_lookat=(5.0, 5.0, 0.0),
             camera_fov=40,
         ),
-        show_viewer=args.vis,
         rigid_options=gs.options.RigidOptions(
             dt=0.01,
             constraint_solver=gs.constraint_solver.Newton,
         ),
-        vis_options=gs.options.VisOptions(
-            # geom_type='sdf',
-        ),
+        show_viewer=args.vis,
     )
 
     horizontal_scale = 0.25

--- a/examples/rigid/terrain_subterrain.py
+++ b/examples/rigid/terrain_subterrain.py
@@ -64,8 +64,8 @@ def main():
     ).unsqueeze(-1)
     cols = horizontal_scale * torch.range(0, height_field.shape[1] - 1, 1).unsqueeze(0).repeat(
         height_field.shape[0], 1
-    ).unsqueeze(-1)
-    heights = vertical_scale * torch.tensor(height_field).unsqueeze(-1)
+    ).unsqueeze(-1).to(rows.device)
+    heights = vertical_scale * torch.tensor(height_field).unsqueeze(-1).to(rows.device)
 
     poss = torch.cat([rows, cols, heights], dim=-1).reshape(-1, 3)
     scene.draw_debug_spheres(poss=poss, radius=0.05, color=(0, 0, 1, 0.7))

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1879,6 +1879,7 @@ class RigidEntity(Entity):
             The vertices of the entity (using collision geoms).
         """
 
+        self._update_verts_for_geom()
         if self.is_free:
             tensor = torch.empty(
                 self._solver._batch_shape((self.n_verts, 3), True), dtype=gs.tc_float, device=gs.device
@@ -1891,22 +1892,20 @@ class RigidEntity(Entity):
             self._kernel_get_fixed_verts(tensor)
         return tensor
 
+    @gs.assert_built
+    def _update_verts_for_geom(self):
+        for i_g_ in range(self.n_geoms):
+            i_g = i_g_ + self._geom_start
+            self._solver.update_verts_for_geom(i_g)
+
     @ti.kernel
     def _kernel_get_free_verts(self, tensor: ti.types.ndarray()):
-        for i_g_, i_b in ti.ndrange(self.n_geoms, self._solver._B):
-            i_g = i_g_ + self._geom_start
-            self._solver._func_update_verts_for_geom(i_g, i_b)
-
         for i, j, b in ti.ndrange(self.n_verts, 3, self._solver._B):
             idx_vert = i + self._verts_state_start
             tensor[b, i, j] = self._solver.free_verts_state.pos[idx_vert, b][j]
 
     @ti.kernel
     def _kernel_get_fixed_verts(self, tensor: ti.types.ndarray()):
-        for i_g_ in range(self.n_geoms):
-            i_g = i_g_ + self._geom_start
-            self._solver._func_update_verts_for_geom(i_g, 0)
-
         for i, j in ti.ndrange(self.n_verts, 3):
             idx_vert = i + self._verts_state_start
             tensor[i, j] = self._solver.fixed_verts_state.pos[idx_vert][j]

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -294,6 +294,7 @@ class RigidLink(RBC):
         """
         Get the vertices of the link's collision body (concatenation of all `link.geoms`) in the world frame.
         """
+        self._update_verts_for_geom()
         if self.is_free:
             tensor = torch.empty(
                 self._solver._batch_shape((self.n_verts, 3), True), dtype=gs.tc_float, device=gs.device
@@ -306,22 +307,20 @@ class RigidLink(RBC):
             self._kernel_get_fixed_verts(tensor)
         return tensor
 
+    @gs.assert_built
+    def _update_verts_for_geom(self):
+        for i_g_ in range(self.n_geoms):
+            i_g = i_g_ + self._geom_start
+            self._solver.update_verts_for_geom(i_g)
+
     @ti.kernel
     def _kernel_get_free_verts(self, tensor: ti.types.ndarray()):
-        for i_g_, i_b in ti.ndrange(self.n_geoms, self._solver._B):
-            i_g = i_g_ + self._geom_start
-            self._solver._func_update_verts_for_geom(i_g, i_b)
-
         for i, j, b in ti.ndrange(self.n_verts, 3, self._solver._B):
             idx_vert = i + self._verts_state_start
             tensor[b, i, j] = self._solver.free_verts_state.pos[idx_vert, b][j]
 
     @ti.kernel
     def _kernel_get_fixed_verts(self, tensor: ti.types.ndarray()):
-        for i_g_ in range(self.n_geoms):
-            i_g = i_g_ + self._geom_start
-            self._solver._func_update_verts_for_geom(i_g, 0)
-
         for i, j in ti.ndrange(self.n_verts, 3):
             idx_vert = i + self._verts_state_start
             tensor[i, j] = self._solver.fixed_verts_state.pos[idx_vert][j]

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -4778,21 +4778,34 @@ def kernel_update_verts_for_geom(
 ):
     _B = geoms_state.verts_updated.shape[1]
     for i_b in range(_B):
-        if not geoms_state.verts_updated[i_g, i_b]:
-            if geoms_info.is_free[i_g]:
-                for i_v in range(geoms_info.vert_start[i_g], geoms_info.vert_end[i_g]):
-                    verts_state_idx = verts_info.verts_state_idx[i_v]
-                    free_verts_state.pos[verts_state_idx, i_b] = gu.ti_transform_by_trans_quat(
-                        verts_info.init_pos[i_v], geoms_state.pos[i_g, i_b], geoms_state.quat[i_g, i_b]
-                    )
-                geoms_state.verts_updated[i_g, i_b] = 1
-            elif i_b == 0:
-                for i_v in range(geoms_info.vert_start[i_g], geoms_info.vert_end[i_g]):
-                    verts_state_idx = verts_info.verts_state_idx[i_v]
-                    fixed_verts_state.pos[verts_state_idx] = gu.ti_transform_by_trans_quat(
-                        verts_info.init_pos[i_v], geoms_state.pos[i_g, i_b], geoms_state.quat[i_g, i_b]
-                    )
-                geoms_state.verts_updated[i_g, 0] = 1
+        func_update_verts_for_geom(i_g, i_b, geoms_state, geoms_info, verts_info, free_verts_state, fixed_verts_state)
+
+
+@ti.func
+def func_update_verts_for_geom(
+    i_g: ti.i32,
+    i_b: ti.i32,
+    geoms_state: array_class.GeomsState,
+    geoms_info: array_class.GeomsInfo,
+    verts_info: array_class.VertsInfo,
+    free_verts_state: array_class.FreeVertsState,
+    fixed_verts_state: array_class.FixedVertsState,
+):
+    if not geoms_state.verts_updated[i_g, i_b]:
+        if geoms_info.is_free[i_g]:
+            for i_v in range(geoms_info.vert_start[i_g], geoms_info.vert_end[i_g]):
+                verts_state_idx = verts_info.verts_state_idx[i_v]
+                free_verts_state.pos[verts_state_idx, i_b] = gu.ti_transform_by_trans_quat(
+                    verts_info.init_pos[i_v], geoms_state.pos[i_g, i_b], geoms_state.quat[i_g, i_b]
+                )
+            geoms_state.verts_updated[i_g, i_b] = 1
+        elif i_b == 0:
+            for i_v in range(geoms_info.vert_start[i_g], geoms_info.vert_end[i_g]):
+                verts_state_idx = verts_info.verts_state_idx[i_v]
+                fixed_verts_state.pos[verts_state_idx] = gu.ti_transform_by_trans_quat(
+                    verts_info.init_pos[i_v], geoms_state.pos[i_g, i_b], geoms_state.quat[i_g, i_b]
+                )
+            geoms_state.verts_updated[i_g, 0] = 1
 
 
 @ti.func

--- a/genesis/ext/pyrender/mesh.py
+++ b/genesis/ext/pyrender/mesh.py
@@ -266,7 +266,7 @@ class Mesh(object):
                     else:
                         colors = vc[mesh.faces].reshape((3 * len(mesh.faces), vc.shape[1]))
                 material = MetallicRoughnessMaterial(
-                    alphaMode="OPAQUE" if (colors[..., 3] == 255).all() else "BLEND",
+                    alphaMode="OPAQUE" if colors.shape[-1] < 4 or (colors[..., 3] == 255).all() else "BLEND",
                     baseColorFactor=[1.0, 1.0, 1.0, 1.0],
                     metallicFactor=0.2,
                     roughnessFactor=0.8,
@@ -277,9 +277,8 @@ class Mesh(object):
                     raise ValueError("Cannot use face colors with a smooth mesh")
                 else:
                     colors = np.repeat(mesh.visual.face_colors, 3, axis=0)
-
                 material = MetallicRoughnessMaterial(
-                    alphaMode="OPAQUE" if (colors[..., 3] == 255).all() else "BLEND",
+                    alphaMode="OPAQUE" if colors.shape[-1] < 4 or (colors[..., 3] == 255).all() else "BLEND",
                     baseColorFactor=[1.0, 1.0, 1.0, 1.0],
                     metallicFactor=0.2,
                     roughnessFactor=0.8,

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2807,6 +2807,8 @@ def test_api_domain_randomization(show_viewer, tol):
         com_shift=-0.05 + 0.1 * torch.rand(scene.n_envs, robot.n_links, 3),
         links_idx_local=np.arange(0, robot.n_links),
     )
+    # test aabb api
+    aabb = robot.get_AABB()
 
     joints_name = (
         "FR_hip_joint",

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2754,7 +2754,7 @@ def test_contype_conaffinity(show_viewer, tol):
 
 
 @pytest.mark.parametrize("backend", [gs.cpu])
-def test_api_domain_randomization(show_viewer, tol):
+def test_examples_api(show_viewer, tol):
 
     scene = gs.Scene(
         viewer_options=gs.options.ViewerOptions(
@@ -2834,3 +2834,18 @@ def test_api_domain_randomization(show_viewer, tol):
     robot.control_dofs_position(default_dof_pos, motors_dof_idx)
 
     scene.step()
+    # test the api for drawing debug objects
+    scene.draw_debug_arrow(
+        pos=(0, 0, 0),
+        vec=(0, 0, 1),
+        color=(0, 1, 0),
+    )
+    scene.draw_debug_line(start=(0.5, -0.25, 0.5), end=(0.5, 0.25, 0.5), radius=0.01, color=(1, 0, 0, 1))
+    scene.draw_debug_sphere(
+        pos=(0, 0, 0),
+        radius=1,
+        color=(0, 1, 0),
+    )
+    scene.draw_debug_frame(T=np.eye(4), axis_length=0.5, origin_size=0.03, axis_radius=0.02)
+    scene.step()
+    scene.clear_debug_objects()

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2828,22 +2828,7 @@ def test_api_domain_randomization(show_viewer, tol):
 
     robot.set_dofs_kp(np.full(12, 20), motors_dof_idx)
     robot.set_dofs_kv(np.full(12, 1), motors_dof_idx)
-    default_dof_pos = np.array(
-        [
-            0.0,
-            0.8,
-            -1.5,
-            0.0,
-            0.8,
-            -1.5,
-            0.0,
-            1.0,
-            -1.5,
-            0.0,
-            1.0,
-            -1.5,
-        ]
-    )
+    default_dof_pos = np.array([0.0, 0.8, -1.5, 0.0, 0.8, -1.5, 0.0, 1.0, -1.5, 0.0, 1.0, -1.5])
     # padding to n_env x n_dofs
     default_dof_pos = np.tile(default_dof_pos, (n_envs, 1))
     robot.control_dofs_position(default_dof_pos, motors_dof_idx)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->

When calling `entity.get_AABB()` for a rigid entity, following error occured:
```
AttributeError: 'RigidSolver' object has no attribute '_func_update_verts_for_geom'
```

To reproduce the code, run:

```
import genesis as gs
gs.init(backend=gs.gpu, logging_level='debug')
options_mapping = {
	'sim_options': gs.options.SimOptions,
	'vis_options': gs.options.VisOptions,
	'coupler_options': gs.options.BaseCouplerOptions,
	'rigid_options': gs.options.RigidOptions,
	'mpm_options': gs.options.MPMOptions,
	'profiling_options': gs.options.ProfilingOptions,
	'viewer_options': gs.options.ViewerOptions,
}
scene_args = {'show_viewer': False, 'vis_options': {'shadow': True, 'background_color': [0.04, 0.08, 0.12]}, 'profiling_options': {'show_FPS': True}, 'sim_options': {'dt': 0.01, 'substeps': 5, 'gravity': [0, 0, -9.81]}}

for key, value in scene_args.items():
	if isinstance(value, dict):
		scene_args[key] = options_mapping[key](**value)
	else:
		scene_args[key] = value
scene = gs.Scene(**scene_args)

# Code Block: checkerboard_plane
plane = scene.add_entity(
    morph=gs.morphs.Box(pos=(0, 0, 0), euler=(0, 0, 0), size=(4.0, 4.0, 0.05), fixed=True),
    material=gs.materials.Rigid(),
    surface=gs.surfaces.Reflective(color=(0.5, 0.5, 0.5), double_sided=True)
)

scene.build() # Ensure the scene is built before accessing entity properties
print(plane.get_AABB().cpu().numpy().tolist())
```

This is because we did not refactor the code correctly during migration. 

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

The suggested code runs correctly now.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
