### PR TITLE
[MISC] Update pre-commit to use ruff formatting and auto-organize import instead of black

### DIFF
--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -95,11 +95,12 @@ jobs:
           pip install --upgrade pip setuptools pkg-info wheel
           pip install torch
 
-      - name: Black Format Check
+      - name: Ruff Format Check
         if: matrix.OS == 'ubuntu-22.04' && matrix.PYTHON_VERSION == '3.12'
         run: |
-          pip install black
-          black --line-length 120 --check .
+          pip install ruff
+          ruff format --check .
+          ruff check --select I .
 
       - name: Install Genesis
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,7 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.7
     hooks:
-      - id: black
+      - id: ruff-check
+        args: [--select, I, --fix]
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,6 @@ requires = ["setuptools", "wheel", "cython>=3.0.0", "numpy>=1.26.4"]
 build-backend = "setuptools.build_meta"
 
 [project]
-# name = "genesis-world-nightly"
-# version = "0.0.3"
 name = "genesis-world"
 version = "0.2.1"
 description = "A universal and generative physics engine"
@@ -18,6 +16,8 @@ dependencies = [
     "trimesh",
     "scipy >= 1.14",
     "libigl",
+    "ompl>=1.7.0; platform_system != 'Windows'",
+    "torch>=2.7.1",
     # Cross-platform library to get various kind of CPU information such as model name
     "py-cpuinfo",
     # * Mujoco 3.3 made Native CCD an opt-out option instead of opt-in,
@@ -60,7 +60,6 @@ dependencies = [
     # Motion Planning library
     # * 1.7.0: First version distributed on PyPI (no pre-compiled binaries for Windows OS).
     #          Fix OMPL DLL search directory.
-    "ompl>=1.7.0; platform_system != 'Windows'"
 ]
 
 [tool.setuptools.packages.find]
@@ -75,13 +74,9 @@ genesis = [
     "ext/VolumeSampling",
 ]
 
-[tool.black]
+[tool.ruff]
 line-length = 120
-force-exclude = '''
-/(
-    genesis/ext
-)/
-'''
+extend-exclude = ["genesis/ext"]
 
 [tool.pytest.ini_options]
 addopts = [
@@ -112,7 +107,7 @@ gs = "genesis._main:main"
 
 [project.optional-dependencies]
 dev = [
-    "black",
+    "ruff>=0.12.7",
     "pytest",
     "pytest-xdist",
     "pytest-forked",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,6 @@ dependencies = [
     "trimesh",
     "scipy >= 1.14",
     "libigl",
-    "ompl>=1.7.0; platform_system != 'Windows'",
-    "torch>=2.7.1",
     # Cross-platform library to get various kind of CPU information such as model name
     "py-cpuinfo",
     # * Mujoco 3.3 made Native CCD an opt-out option instead of opt-in,


### PR DESCRIPTION
## Description
Updates pre-commit hook and pyproject.toml. I also added torch to the pyproject because it was missing.

## Motivation and Context
We still have unorganized imports merged into main; we should update the pre-commit hook to mitigate this.

## How Has This Been / Can This Be Tested?
I tested with trying to commit an ugly file on my repo.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I tested my changes and added instructions on how to test it for reviewers.