### PR TITLE
Do not consider markers as physical objects for rendering.

### DIFF
--- a/examples/rigid/single_franka_envs.py
+++ b/examples/rigid/single_franka_envs.py
@@ -20,11 +20,11 @@ def main():
     ########################## create a scene ##########################
     scene = gs.Scene(
         vis_options=gs.options.VisOptions(
-            plane_reflection=False,
+            plane_reflection=True,
             rendered_envs_idx=list(range(args.num_env)),
             env_separate_rigid=args.sep,
-            show_world_frame=False,
-            show_link_frame=False,
+            show_world_frame=True,
+            show_link_frame=True,
         ),
         viewer_options=gs.options.ViewerOptions(
             camera_pos=(3.5, 0.0, 2.5),

--- a/genesis/ext/pyrender/interaction/viewer_interaction_base.py
+++ b/genesis/ext/pyrender/interaction/viewer_interaction_base.py
@@ -4,7 +4,7 @@ import genesis as gs
 
 
 EVENT_HANDLE_STATE = Union[Literal[True], None]
-EVENT_HANDLED = True
+EVENT_HANDLED: Literal[True] = True
 
 # Note: Viewer window is based on pyglet.window.Window, mouse events are defined in pyglet.window.BaseWindow
 

--- a/genesis/ext/pyrender/jit_render.py
+++ b/genesis/ext/pyrender/jit_render.py
@@ -57,6 +57,7 @@ RenderFlags_SKIP_CULL_FACES = RenderFlags.SKIP_CULL_FACES
 RenderFlags_SHADOWS_DIRECTIONAL = RenderFlags.SHADOWS_DIRECTIONAL
 RenderFlags_SHADOWS_POINT = RenderFlags.SHADOWS_POINT
 RenderFlags_SKIP_FLOOR = RenderFlags.SKIP_FLOOR
+RenderFlags_OFFSCREEN = RenderFlags.OFFSCREEN
 RenderFlags_REFLECTIVE_FLOOR = RenderFlags.REFLECTIVE_FLOOR
 RenderFlags_FLAT = RenderFlags.FLAT
 
@@ -492,7 +493,7 @@ class JITRenderer:
                     wf = render_flags[id, 1]
                     if flags & RenderFlags_FLIP_WIREFRAME:
                         wf = not wf
-                    if (flags & RenderFlags_ALL_WIREFRAME) or wf:
+                    if wf or flags & RenderFlags_ALL_WIREFRAME:
                         gl.glPolygonMode(GL_FRONT_AND_BACK, GL_LINE)
                     else:
                         gl.glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)

--- a/genesis/ext/pyrender/jit_render.py
+++ b/genesis/ext/pyrender/jit_render.py
@@ -290,8 +290,8 @@ class JITRenderer:
         self.pbr_mat = np.zeros((n, 9), np.float32)  # base_color <- 4, metallic <- 1, roughness <- 1, emissive <- 3
         self.spec_mat = np.zeros((n, 11), np.float32)  # diffuse <- 4, specular <- 3, glossiness <- 1, emissive <- 3
         self.render_flags = np.zeros(
-            (n, 7), np.int8
-        )  # (blend, wireframe, double sided, pbr texture, reflective floor, transparent, env shared)
+            (n, 8), np.int8
+        )  # (blend, wireframe, double sided, pbr texture, reflective floor, transparent, marker, env shared)
         self.mode = np.zeros(n, np.int32)
         self.n_instances = np.zeros(n, np.int32)
         self.n_indices = np.zeros(n, np.int32)  # positive: indices, negative: positions
@@ -337,7 +337,8 @@ class JITRenderer:
             self.render_flags[i, 3] = isinstance(material, MetallicRoughnessMaterial)
             self.render_flags[i, 4] = primitive.is_floor and not floor_existed
             self.render_flags[i, 5] = node_list[i].mesh.is_transparent
-            self.render_flags[i, 6] = primitive.env_shared
+            self.render_flags[i, 6] = node_list[i].mesh.is_marker
+            self.render_flags[i, 7] = primitive.env_shared
 
             if primitive.is_floor:
                 floor_existed = True
@@ -415,6 +416,8 @@ class JITRenderer:
             env_idx,
             gl,
         ):
+            is_rgba = not (flags & RenderFlags_DEPTH_ONLY or flags & RenderFlags_SEG)
+
             det_reflection = np.linalg.det(reflection_mat)
             last_pid = -1
             lighting_texture = 0
@@ -422,12 +425,16 @@ class JITRenderer:
             trans_idx = [i for i in range(len(vao_id)) if render_flags[i, 5]]
             idx = solid_idx + trans_idx
             for id in idx:
-                if render_flags[id, 4] and (flags & RenderFlags_SKIP_FLOOR):
+                # Only render markers on the main graphical window, while skipping plane-reflection
+                if ((render_flags[id, 4] or render_flags[id, 6]) and flags & RenderFlags_SKIP_FLOOR) or (
+                    render_flags[id, 6] and (not is_rgba or flags & RenderFlags_OFFSCREEN)
+                ):
                     continue
+
                 pid = program_id[id]
                 if pid != last_pid:
                     gl.glUseProgram(pid)
-                    if not (flags & RenderFlags_DEPTH_ONLY or flags & RenderFlags_SEG or flags & RenderFlags_FLAT):
+                    if is_rgba and not flags & RenderFlags_FLAT:
                         lighting_texture = bind_lighting(pid, flags, light, shadow_map, light_matrix, ambient_light, gl)
                         set_uniform_3fv(pid, "cam_pos", cam_pos, gl)
                         set_uniform_matrix_4fv(pid, "reflection_mat", reflection_mat, gl)
@@ -439,21 +446,22 @@ class JITRenderer:
 
                 active_texture = lighting_texture
 
-                if render_flags[id, 4] and (flags & RenderFlags_REFLECTIVE_FLOOR):
-                    gl.glActiveTexture(GL_TEXTURE0 + active_texture)
-                    gl.glBindTexture(GL_TEXTURE_2D, floor_tex)
-                    set_uniform_1i(pid, "floor_tex", active_texture, gl)
-                    set_uniform_1i(pid, "floor_flag", 1, gl)
-                    set_uniform_2f(pid, "screen_size", screen_size[0], screen_size[1], gl)
-                    active_texture += 1
-                elif flags & RenderFlags_REFLECTIVE_FLOOR:
-                    set_uniform_1i(pid, "floor_tex", 0, gl)
-                    set_uniform_1i(pid, "floor_flag", 0, gl)
+                if flags & RenderFlags_REFLECTIVE_FLOOR:
+                    if render_flags[id, 4]:
+                        gl.glActiveTexture(GL_TEXTURE0 + active_texture)
+                        gl.glBindTexture(GL_TEXTURE_2D, floor_tex)
+                        set_uniform_1i(pid, "floor_tex", active_texture, gl)
+                        set_uniform_1i(pid, "floor_flag", 1, gl)
+                        set_uniform_2f(pid, "screen_size", screen_size[0], screen_size[1], gl)
+                        active_texture += 1
+                    else:
+                        set_uniform_1i(pid, "floor_tex", 0, gl)
+                        set_uniform_1i(pid, "floor_flag", 0, gl)
 
                 set_uniform_matrix_4fv(pid, "M", pose[id], gl)
                 gl.glBindVertexArray(vao_id[id])
 
-                if not (flags & RenderFlags_DEPTH_ONLY or flags & RenderFlags_SEG or flags & RenderFlags_FLAT):
+                if is_rgba and not flags & RenderFlags_FLAT:
                     tf = textures[id, 0]
                     texture_list = [
                         "normal_texture",
@@ -517,7 +525,7 @@ class JITRenderer:
                         continue
                     set_uniform_3fv(pid, "color", color_list[id], gl)
 
-                if render_flags[id, 6] or env_idx == -1:
+                if render_flags[id, 7] or env_idx == -1:
                     if n_indices[id] > 0:
                         gl.glDrawElementsInstanced(
                             mode[id], n_indices[id], GL_UNSIGNED_INT, address_to_ptr(0), n_instances[id]
@@ -559,8 +567,10 @@ class JITRenderer:
         ):
             last_pid = -1
             for id in range(len(vao_id)):
-                if render_flags[id, 5]:
+                # Do not render shadows for markers and transparent objects
+                if render_flags[id, 5] or render_flags[id, 6]:
                     continue
+
                 pid = program_id[id]
                 if pid != last_pid:
                     gl.glUseProgram(pid)
@@ -580,7 +590,7 @@ class JITRenderer:
 
                 gl.glDisable(GL_PROGRAM_POINT_SIZE)
 
-                if render_flags[id, 6] or env_idx == -1:
+                if render_flags[id, 7] or env_idx == -1:
                     if n_indices[id] > 0:
                         gl.glDrawElementsInstanced(
                             mode[id], n_indices[id], GL_UNSIGNED_INT, address_to_ptr(0), n_instances[id]
@@ -622,8 +632,10 @@ class JITRenderer:
         ):
             last_pid = -1
             for id in range(len(vao_id)):
-                if render_flags[id, 5]:
+                # Do not render shadows for markers and transparent objects
+                if render_flags[id, 5] or render_flags[id, 6]:
                     continue
+
                 pid = program_id[id]
                 if pid != last_pid:
                     gl.glUseProgram(pid)
@@ -644,7 +656,7 @@ class JITRenderer:
 
                 gl.glDisable(GL_PROGRAM_POINT_SIZE)
 
-                if render_flags[id, 6] or env_idx == -1:
+                if render_flags[id, 7] or env_idx == -1:
                     if n_indices[id] > 0:
                         gl.glDrawElementsInstanced(
                             mode[id], n_indices[id], GL_UNSIGNED_INT, address_to_ptr(0), n_instances[id]

--- a/genesis/ext/pyrender/mesh.py
+++ b/genesis/ext/pyrender/mesh.py
@@ -49,35 +49,6 @@ class Mesh(object):
         self._name = value
 
     @property
-    def primitives(self):
-        """list of :class:`Primitive` : The primitives associated
-        with this mesh.
-        """
-        return self._primitives
-
-    @primitives.setter
-    def primitives(self, value):
-        self._primitives = value
-
-    @property
-    def weights(self):
-        """(k,) float : Weights to be applied to morph targets."""
-        return self._weights
-
-    @weights.setter
-    def weights(self, value):
-        self._weights = value
-
-    @property
-    def is_visible(self):
-        """bool : Whether the mesh is visible."""
-        return self._is_visible
-
-    @is_visible.setter
-    def is_visible(self, value):
-        self._is_visible = value
-
-    @property
     def bounds(self):
         """(2,3) float : The axis-aligned bounds of the mesh."""
         if self._bounds is None:

--- a/genesis/ext/pyrender/mesh.py
+++ b/genesis/ext/pyrender/mesh.py
@@ -29,11 +29,12 @@ class Mesh(object):
         If False, the mesh will not be rendered.
     """
 
-    def __init__(self, primitives, name=None, weights=None, is_visible=True):
+    def __init__(self, primitives, name=None, weights=None, is_visible=True, is_marker=False):
         self.primitives = primitives
         self.name = name
         self.weights = weights
         self.is_visible = is_visible
+        self.is_marker = is_marker
 
         self._bounds = None
 
@@ -90,7 +91,7 @@ class Mesh(object):
         return False
 
     @staticmethod
-    def from_points(points, name=None, colors=None, normals=None, is_visible=True, poses=None):
+    def from_points(points, name=None, colors=None, normals=None, is_visible=True, poses=None, is_marker=False):
         """Create a Mesh from a set of points.
 
         Parameters
@@ -114,7 +115,7 @@ class Mesh(object):
             The created mesh.
         """
         primitive = Primitive(positions=points, normals=normals, color_0=colors, mode=GLTF.POINTS, poses=poses)
-        mesh = Mesh(primitives=[primitive], name=name, is_visible=is_visible)
+        mesh = Mesh(primitives=[primitive], name=name, is_visible=is_visible, is_marker=is_marker)
         return mesh
 
     @staticmethod
@@ -123,6 +124,7 @@ class Mesh(object):
         name=None,
         material=None,
         is_visible=True,
+        is_marker=False,
         poses=None,
         wireframe=False,
         smooth=False,
@@ -216,7 +218,7 @@ class Mesh(object):
                 )
             )
 
-        return Mesh(primitives=primitives, name=name, is_visible=is_visible)
+        return Mesh(primitives=primitives, name=name, is_visible=is_visible, is_marker=is_marker)
 
     @staticmethod
     def _get_trimesh_props(mesh, smooth=False, material=None):

--- a/genesis/ext/pyrender/renderer.py
+++ b/genesis/ext/pyrender/renderer.py
@@ -144,10 +144,10 @@ class Renderer(object):
             self._update_context(scene, flags)
             self.jit.update(scene)
 
-        if bool(flags & RenderFlags.DEPTH_ONLY or flags & RenderFlags.SEG or flags & RenderFlags.FLAT):
+        if flags & RenderFlags.DEPTH_ONLY or flags & RenderFlags.SEG or flags & RenderFlags.FLAT:
             flags &= ~RenderFlags.REFLECTIVE_FLOOR
 
-        if bool(flags & RenderFlags.ENV_SEPARATE) and bool(flags & RenderFlags.OFFSCREEN):
+        if flags & RenderFlags.ENV_SEPARATE and flags & RenderFlags.OFFSCREEN:
             n_envs = scene.n_envs
             use_env_idx = True
         else:
@@ -159,14 +159,14 @@ class Renderer(object):
             env_idx = i if use_env_idx else -1
 
             # Render necessary shadow maps
-            if not bool(flags & RenderFlags.DEPTH_ONLY or flags & RenderFlags.SEG):
+            if not (flags & RenderFlags.DEPTH_ONLY or flags & RenderFlags.SEG):
                 for ln in scene.light_nodes:
                     take_pass = False
-                    if isinstance(ln.light, DirectionalLight) and bool(flags & RenderFlags.SHADOWS_DIRECTIONAL):
+                    if isinstance(ln.light, DirectionalLight) and flags & RenderFlags.SHADOWS_DIRECTIONAL:
                         take_pass = True
-                    elif isinstance(ln.light, SpotLight) and bool(flags & RenderFlags.SHADOWS_SPOT):
+                    elif isinstance(ln.light, SpotLight) and flags & RenderFlags.SHADOWS_SPOT:
                         take_pass = False
-                    elif isinstance(ln.light, PointLight) and bool(flags & RenderFlags.SHADOWS_POINT):
+                    elif isinstance(ln.light, PointLight) and flags & RenderFlags.SHADOWS_POINT:
                         take_pass = True
                     if take_pass:
                         if isinstance(ln.light, PointLight):
@@ -496,7 +496,7 @@ class Renderer(object):
         self._configure_forward_pass_viewport(flags)
 
         # Clear it
-        if bool(flags & RenderFlags.SEG):
+        if flags & RenderFlags.SEG:
             glClearColor(0.0, 0.0, 0.0, 1.0)
             if seg_node_map is None:
                 seg_node_map = {}
@@ -505,10 +505,10 @@ class Renderer(object):
 
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
 
-        if not bool(flags & RenderFlags.SEG):
-            glEnable(GL_MULTISAMPLE)
-        else:
+        if flags & RenderFlags.SEG:
             glDisable(GL_MULTISAMPLE)
+        else:
+            glEnable(GL_MULTISAMPLE)
 
         # Set up camera matrices
         V, P = self._get_camera_matrices(scene)
@@ -539,8 +539,6 @@ class Renderer(object):
             self.jit.forward_pass(
                 self, V, P, cam_pos, flags, ProgramFlags.USE_MATERIAL, screen_size, floor_tex=floor_tex, env_idx=env_idx
             )
-            # self.jit.forward_pass(self, V, P, cam_pos, flags, ProgramFlags.USE_MATERIAL,
-            #                       reflection_mat=np.diag(np.array([1.0, 1.0, -1.0, 1.0], dtype=np.float32)))
 
         # If doing offscreen render, copy result from framebuffer and return
         if flags & RenderFlags.OFFSCREEN:
@@ -570,11 +568,6 @@ class Renderer(object):
         V, P = self._get_light_cam_matrices(scene, light_node, flags)
 
         self.jit.shadow_mapping_pass(self, V, P, flags, ProgramFlags.NONE, env_idx=env_idx)
-
-        # dep = self.get_depth_image(light.shadow_texture._texid)
-        # plt.imshow(dep)
-        # plt.show()
-        # plt.savefig('tmp/tmp_dep.jpg')
 
     def _normals_pass(self, scene, flags, env_idx=-1):
         # Set up viewport for render
@@ -610,7 +603,7 @@ class Renderer(object):
                 program.set_uniform("V", V)
                 program.set_uniform("P", P)
                 program.set_uniform("normal_magnitude", 0.05 * primitive.scale)
-                program.set_uniform("normal_color", np.array([0.1, 0.1, 1.0, 1.0]))
+                program.set_uniform("normal_color", np.array((0.1, 0.1, 1.0, 1.0)))
 
                 # Finally, bind and draw the primitive
                 self._bind_and_draw_primitive(
@@ -682,7 +675,7 @@ class Renderer(object):
             wf = material.wireframe
             if flags & RenderFlags.FLIP_WIREFRAME:
                 wf = not wf
-            if (flags & RenderFlags.ALL_WIREFRAME) or wf:
+            if wf or flags & RenderFlags.ALL_WIREFRAME:
                 glPolygonMode(GL_FRONT_AND_BACK, GL_LINE)
             else:
                 glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
@@ -727,84 +720,6 @@ class Renderer(object):
 
         # Unbind mesh buffers
         primitive._unbind()
-
-    def _bind_lighting(self, scene, program, node, flags):
-        """Bind all lighting uniform values for a scene."""
-        max_n_lights = self._compute_max_n_lights(flags)
-
-        n_d = min(len(scene.directional_light_nodes), max_n_lights[0])
-        n_s = min(len(scene.spot_light_nodes), max_n_lights[1])
-        n_p = min(len(scene.point_light_nodes), max_n_lights[2])
-        program.set_uniform("ambient_light", scene.ambient_light)
-        program.set_uniform("n_directional_lights", n_d)
-        program.set_uniform("n_spot_lights", n_s)
-        program.set_uniform("n_point_lights", n_p)
-        plc = 0
-        slc = 0
-        dlc = 0
-
-        light_nodes = scene.light_nodes
-        if (
-            len(scene.directional_light_nodes) > max_n_lights[0]
-            or len(scene.spot_light_nodes) > max_n_lights[1]
-            or len(scene.point_light_nodes) > max_n_lights[2]
-        ):
-            light_nodes = self._sorted_nodes_by_distance(scene, scene.light_nodes, node)
-
-        for n in light_nodes:
-            light = n.light
-            pose = scene.get_pose(n)
-            position = pose[:3, 3]
-            direction = -pose[:3, 2]
-
-            if isinstance(light, PointLight):
-                if plc == max_n_lights[2]:
-                    continue
-                b = "point_lights[{}].".format(plc)
-                plc += 1
-                shadow = bool(flags & RenderFlags.SHADOWS_POINT)
-                program.set_uniform(b + "position", position)
-            elif isinstance(light, SpotLight):
-                if slc == max_n_lights[1]:
-                    continue
-                b = "spot_lights[{}].".format(slc)
-                slc += 1
-                shadow = bool(flags & RenderFlags.SHADOWS_SPOT)
-                las = 1.0 / max(0.001, np.cos(light.innerConeAngle) - np.cos(light.outerConeAngle))
-                lao = -np.cos(light.outerConeAngle) * las
-                program.set_uniform(b + "direction", direction)
-                program.set_uniform(b + "position", position)
-                program.set_uniform(b + "light_angle_scale", las)
-                program.set_uniform(b + "light_angle_offset", lao)
-            else:
-                if dlc == max_n_lights[0]:
-                    continue
-                b = "directional_lights[{}].".format(dlc)
-                dlc += 1
-                shadow = bool(flags & RenderFlags.SHADOWS_DIRECTIONAL)
-                program.set_uniform(b + "direction", direction)
-
-            program.set_uniform(b + "color", light.color)
-            program.set_uniform(b + "intensity", light.intensity)
-            # if light.range is not None:
-            #     program.set_uniform(b + 'range', light.range)
-            # else:
-            #     program.set_uniform(b + 'range', 0)
-
-            if shadow:
-                self._bind_texture(light.shadow_texture, b + "shadow_map", program)
-                if not isinstance(light, PointLight):
-                    V, P = self._get_light_cam_matrices(scene, n, flags)
-                    program.set_uniform(b + "light_matrix", P.dot(V))
-                else:
-                    raise NotImplementedError("Point light shadows not implemented")
-
-    def _sorted_nodes_by_distance(self, scene, nodes, compare_node):
-        nodes = list(nodes)
-        if compare_node is not None:
-            compare_posn = scene.get_pose(compare_node)[:3, 3]
-            nodes.sort(key=lambda n: np.linalg.norm(scene.get_pose(n)[:3, 3] - compare_posn))
-        return nodes
 
     ###########################################################################
     # Context Management
@@ -1232,9 +1147,9 @@ class Renderer(object):
         self._main_fb_dims = (None, None)
 
     def _read_main_framebuffer(self, scene, flags):
-        width, height = self._main_fb_dims[0], self._main_fb_dims[1]
+        width, height = self._main_fb_dims
 
-        if not (flags & RenderFlags.SEG):
+        if not flags & RenderFlags.SEG:
             # Bind framebuffer and blit buffers
             glBindFramebuffer(GL_READ_FRAMEBUFFER, self._main_fb_ms)
             glBindFramebuffer(GL_DRAW_FRAMEBUFFER, self._main_fb)
@@ -1250,9 +1165,8 @@ class Renderer(object):
                 z_far = -1.0
             depth_im = self.jit.read_depth_buf(width, height, z_near, z_far)
 
-            # Resize for macos if needed
-            if sys.platform == "darwin":
-                depth_im = self._resize_image(depth_im)
+            # Resize
+            depth_im = self._resize_image(depth_im, antialias=False)
         else:
             depth_im = None
 
@@ -1262,125 +1176,21 @@ class Renderer(object):
         # Read color
         color_im = self.jit.read_color_buf(width, height, flags & RenderFlags.RGBA)
 
-        # Resize for macos if needed
-        if sys.platform == "darwin":
-            color_im = self._resize_image(color_im, not (flags & RenderFlags.SEG))
+        # Resize
+        color_im = self._resize_image(color_im, antialias=not flags & RenderFlags.SEG)
 
         return color_im, depth_im
 
-    def _resize_image(self, value, antialias=False):
-        """If needed, rescale the render for MacOS."""
+    def _resize_image(self, value, antialias):
+        """Rescale the generated image if necessary."""
+        if self.dpscale == 1:
+            return value
+
         img = PIL.Image.fromarray(value)
-        resample = PIL.Image.NEAREST
-        if antialias:
-            resample = PIL.Image.BILINEAR
         size = (self.viewport_width // self.dpscale, self.viewport_height // self.dpscale)
+        resample = PIL.Image.BILINEAR if antialias else PIL.Image.NEAREST
         img = img.resize(size, resample=resample)
-        return np.array(img)
-
-    ###########################################################################
-    # Shadowmap Debugging
-    ###########################################################################
-
-    def _forward_pass_no_reset(self, scene, flags, env_idx=-1):
-        # Set up camera matrices
-        V, P = self._get_camera_matrices(scene)
-
-        # Now, render each object in sorted order
-        for node in scene.sorted_mesh_nodes():
-            mesh = node.mesh
-
-            # Skip the mesh if it's not visible
-            if not mesh.is_visible:
-                continue
-
-            for primitive in mesh.primitives:
-
-                # First, get and bind the appropriate program
-                program = self._get_primitive_program(primitive, flags, ProgramFlags.USE_MATERIAL)
-                program._bind()
-
-                # Set the camera uniforms
-                program.set_uniform("V", V)
-                program.set_uniform("P", P)
-                program.set_uniform("cam_pos", scene.get_pose(scene.main_camera_node)[:3, 3])
-
-                # Next, bind the lighting
-                if not flags & RenderFlags.DEPTH_ONLY and not flags & RenderFlags.FLAT:
-                    self._bind_lighting(scene, program, node, flags)
-
-                # Finally, bind and draw the primitive
-                self._bind_and_draw_primitive(
-                    primitive=primitive,
-                    pose=scene.get_pose(node),
-                    program=program,
-                    flags=flags,
-                    env_idx=env_idx,
-                )
-                self._reset_active_textures()
-
-        # Unbind the shader and flush the output
-        if program is not None:
-            program._unbind()
-        glFlush()
-
-    def _render_light_shadowmaps(self, scene, light_nodes, flags, tile=False, env_idx=-1):
-        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0)
-        glClearColor(*scene.bg_color)
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
-        glEnable(GL_DEPTH_TEST)
-        glDepthMask(GL_TRUE)
-        glDepthFunc(GL_LESS)
-        glDepthRange(0.0, 1.0)
-
-        w, h = self.viewport_width, self.viewport_height
-        viewport_dims = {
-            (0, 2): [0, h // 2, w // 2, h],
-            (1, 2): [w // 2, h // 2, w, h],
-            (0, 3): [0, h // 2, w // 2, h],
-            (1, 3): [w // 2, h // 2, w, h],
-            (2, 3): [0, 0, w // 2, h // 2],
-            (0, 4): [0, h // 2, w // 2, h],
-            (1, 4): [w // 2, h // 2, w, h],
-            (2, 4): [0, 0, w // 2, h // 2],
-            (3, 4): [w // 2, 0, w, h // 2],
-        }
-
-        num_nodes = len(light_nodes)
-        for i, ln in enumerate(light_nodes):
-            light = ln.light
-
-            if light.shadow_texture is None:
-                raise ValueError("Light does not have a shadow texture")
-
-            if tile:
-                glViewport(*viewport_dims[(i, num_nodes + 1)])
-            else:
-                glViewport(0, 0, self.viewport_width, self.viewport_height)
-
-            program = self._get_debug_quad_program()
-            program._bind()
-            self._bind_texture(light.shadow_texture, "depthMap", program)
-            self._render_debug_quad()
-            self._reset_active_textures()
-            glFlush()
-            if not tile:
-                return
-        glViewport(*viewport_dims[(num_nodes, num_nodes + 1)])
-        self._forward_pass_no_reset(scene, flags, env_idx=env_idx)
-
-    def _get_debug_quad_program(self):
-        program = self._program_cache.get_program(vertex_shader="debug_quad.vert", fragment_shader="debug_quad.frag")
-        if not program._in_context():
-            program._add_to_context()
-        return program
-
-    def _render_debug_quad(self):
-        x = glGenVertexArrays(1)
-        glBindVertexArray(x)
-        glDrawArrays(GL_TRIANGLES, 0, 6)
-        glBindVertexArray(0)
-        glDeleteVertexArrays(1, [x])
+        return np.array(img, copy=False)
 
     def reload_program(self):
         self._program_cache.clear()

--- a/genesis/ext/pyrender/scene.py
+++ b/genesis/ext/pyrender/scene.py
@@ -277,12 +277,14 @@ class Scene(object):
             raise TypeError("Unrecognized object type")
 
         if parent_node is None and parent_name is not None:
-            parent_nodes = self.get_nodes(name=parent_name)
-            if len(parent_nodes) == 0:
-                raise ValueError("No parent node with name {} found".format(parent_name))
-            elif len(parent_nodes) > 1:
-                raise ValueError("More than one parent node with name {} found".format(parent_name))
-            parent_node = list(parent_nodes)[0]
+            try:
+                parent_node, = self.get_nodes(name=parent_name)
+            except ValueError:
+                if len(parent_nodes) == 0:
+                    raise ValueError(f"No parent node with name '{parent_name}' found")
+                elif len(parent_nodes) > 1:
+                    raise ValueError(f"More than one parent node with name '{parent_name}' found")
+                raise
 
         self.add_node(node, parent_node=parent_node)
 

--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -281,10 +281,6 @@ class Viewer(pyglet.window.Window):
             elif key in self.viewer_flags:
                 self._viewer_flags[key] = kwargs[key]
 
-        # # TODO MAC OS BUG FOR SHADOWS
-        # if sys.platform == 'darwin':
-        #     self._render_flags['shadows'] = False
-
         self._registered_keys = {}
         if registered_keys is not None:
             self._registered_keys = {ord(k.lower()): registered_keys[k] for k in registered_keys}

--- a/genesis/vis/visualizer.py
+++ b/genesis/vis/visualizer.py
@@ -151,12 +151,12 @@ class Visualizer(RBC):
             self._batch_renderer.reset()
 
         if self.viewer_lock is not None:
+            if self._viewer is not None:
+                self._viewer.update(auto_refresh=True)
+
             if self._batch_renderer is None:
                 for camera in self._cameras:
                     self._rasterizer.render_camera(camera)
-
-            if self._viewer is not None:
-                self._viewer.update(auto_refresh=True)
 
     def build(self):
         self._context.build(self._scene)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -361,6 +361,7 @@ def test_batched_mounted_camera_rendering(show_viewer, tol):
                 assert np.count_nonzero(diff) > diff_tol * np.prod(diff.shape)
 
 
+@pytest.mark.required
 def test_debug_draw(show_viewer):
     scene = gs.Scene(
         vis_options=gs.options.VisOptions(
@@ -421,7 +422,6 @@ def test_debug_draw(show_viewer):
 
 @pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.cuda])
-@pytest.mark.skipif(sys.platform != "linux", reason="Madrona batch renderer only supports Linux.")
 @pytest.mark.parametrize("use_rasterizer", [True, False])
 @pytest.mark.parametrize("render_all_cameras", [True, False])
 @pytest.mark.parametrize("n_envs", [0, 4])

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -411,7 +411,8 @@ def test_debug_draw(show_viewer):
     )
     scene.step()
     rgb_array, *_ = cam.render(rgb=True, depth=False, segmentation=False, colorize_seg=False, normal=False)
-    assert np.max(np.std(rgb_array.reshape((-1, 3)), axis=0)) > 10.0
+    # assert np.max(np.std(rgb_array.reshape((-1, 3)), axis=0)) > 10.0
+    assert_allclose(np.std(rgb_array.reshape((-1, 3)), axis=0), 0.0, tol=gs.EPS)
     scene.clear_debug_objects()
     scene.step()
     rgb_array, *_ = cam.render(rgb=True, depth=False, segmentation=False, colorize_seg=False, normal=False)


### PR DESCRIPTION
## Description

Markers added via `draw_debug_*` API are not "invisible markers" instead of physical objects. In that sense, they are only rendered on the onscreen graphical windows, and do not cast shadow and reflection on the floor. They are not rendered on any of the camera ouputs, i.e. RGB, depth map and segmentation map.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/942

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?

Running the example script 'single_franka_envs.py'.

## Screenshots (if appropriate):

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.