### PR TITLE
[BUG FIX] Fix gravity setters.

### DIFF
--- a/genesis/engine/simulator.py
+++ b/genesis/engine/simulator.py
@@ -403,7 +403,8 @@ class Simulator(RBC):
 
     def set_gravity(self, gravity, envs_idx=None):
         for solver in self._solvers:
-            solver.set_gravity(gravity, envs_idx)
+            if solver.is_active():
+                solver.set_gravity(gravity, envs_idx)
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------

--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -42,7 +42,7 @@ class Solver(RBC):
     @gs.assert_built
     def set_gravity(self, gravity, envs_idx=None):
         if self._gravity is None:
-            gs.logger.warning("Gravity is not initialized, skipping set_gravity.")
+            gs.logger.debug("Gravity is not defined, skipping `set_gravity`.")
             return
         g = np.asarray(gravity, dtype=gs.np_float)
         if envs_idx is None:

--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -49,7 +49,14 @@ class Solver(RBC):
                 g = np.tile(g, (self._B, 1))
             self._gravity.from_numpy(g)
         else:
-            self._gravity[envs_idx] = g
+            assert g.shape == (envs_idx.shape[0], 3), "Input gravity array should match (len(envs_idx), 3)"
+            self._kernel_set_gravity(g, envs_idx)
+
+    @ti.kernel
+    def _kernel_set_gravity(self, gravity: ti.types.ndarray(), envs_idx: ti.types.ndarray()):
+        for i_b_ in range(envs_idx.shape[0]):
+            for j in ti.static(range(3)):
+                self._gravity[envs_idx[i_b_]][j] = gravity[i_b_, j]
 
     def dump_ckpt_to_numpy(self) -> dict[str, np.ndarray]:
         arrays: dict[str, np.ndarray] = {}

--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -42,14 +42,19 @@ class Solver(RBC):
     @gs.assert_built
     def set_gravity(self, gravity, envs_idx=None):
         if self._gravity is None:
+            gs.logger.warning("Gravity is not initialized, skipping set_gravity.")
             return
         g = np.asarray(gravity, dtype=gs.np_float)
         if envs_idx is None:
             if g.ndim == 1:
                 g = np.tile(g, (self._B, 1))
+            assert g.shape == (self._B, 3), "Input gravity array should match (n_envs, 3)"
             self._gravity.from_numpy(g)
         else:
-            assert g.shape == (envs_idx.shape[0], 3), "Input gravity array should match (len(envs_idx), 3)"
+            envs_idx = np.atleast_1d(np.array(envs_idx, dtype=gs.np_int))
+            if g.ndim == 1:
+                g = np.tile(g, (len(envs_idx), 1))
+            assert g.shape == (len(envs_idx), 3), "Input gravity array should match (len(envs_idx), 3)"
             self._kernel_set_gravity(g, envs_idx)
 
     @ti.kernel

--- a/genesis/engine/solvers/rigid/rigid_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/rigid_solver_decomp.py
@@ -2194,16 +2194,9 @@ class RigidSolver(Solver):
 
     @gs.assert_built
     def set_gravity(self, gravity, envs_idx=None):
-        if not hasattr(self, "_rigid_global_info"):
-            super().set_gravity(gravity, envs_idx)
-            return
-        g = np.asarray(gravity, dtype=gs.np_float)
-        if envs_idx is None:
-            if g.ndim == 1:
-                g = np.tile(g, (self._B, 1))
-            self._rigid_global_info.gravity.from_numpy(g)
-        else:
-            self._rigid_global_info.gravity[envs_idx] = g
+        super().set_gravity(gravity, envs_idx)
+        if hasattr(self, "_rigid_global_info"):
+            self._rigid_global_info.gravity.copy_from(self._gravity)
 
     def rigid_entity_inverse_kinematics(
         self,

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2177,13 +2177,11 @@ def test_gravity(show_viewer, tol):
     )
 
     sphere = scene.add_entity(gs.morphs.Sphere())
-    scene.build(n_envs=7)
+    scene.build(n_envs=3)
 
-    scene.sim.set_gravity(torch.tensor([-1.0, 0.0, 0.0]))
-    scene.sim.set_gravity(torch.tensor([[-2.0, 0.0, 0.0]] * 10))
-    scene.sim.set_gravity(torch.tensor([0.0, 0.0, 0.0]), envs_idx=[0, 1])
-    scene.sim.set_gravity(torch.tensor([0.0, 0.0, 100.0]), envs_idx=3)
-    scene.sim.set_gravity(torch.tensor([[0.0, 0.0, -10.0], [0.0, 0.0, -1.0]]), envs_idx=[2, 4])
+    scene.sim.set_gravity(torch.tensor([0.0, 0.0, 0.0]))
+    scene.sim.set_gravity(torch.tensor([[1.0, 0.0, 0.0], [0.0, 2.0, 0.0]]), envs_idx=[0, 1])
+    scene.sim.set_gravity(torch.tensor([0.0, 0.0, 3.0]), envs_idx=2)
 
     with np.testing.assert_raises(AssertionError):
         scene.sim.set_gravity(torch.tensor([0.0, -10.0]))
@@ -2194,18 +2192,12 @@ def test_gravity(show_viewer, tol):
     scene.step()
 
     assert_allclose(
-        np.array(
-            [
-                [0.0, 0.0, 0.0],
-                [0.0, 0.0, 0.0],
-                [0.0, 0.0, -10.0],
-                [0.0, 0.0, 100.0],
-                [0.0, 0.0, -1.0],
-                [-2.0, 0.0, 0.0],
-                [-2.0, 0.0, 0.0],
-            ]
-        ),
-        sphere.get_links_acc().squeeze(dim=1),
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 2.0, 0.0],
+            [0.0, 0.0, 3.0],
+        ],
+        sphere.get_links_acc().squeeze(),
         tol=tol,
     )
 

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2177,18 +2177,38 @@ def test_gravity(show_viewer, tol):
     )
 
     sphere = scene.add_entity(gs.morphs.Sphere())
-    scene.build(n_envs=2)
+    scene.build(n_envs=7)
 
-    scene.sim.set_gravity(torch.tensor([0.0, 0.0, -9.8]), envs_idx=0)
-    scene.sim.set_gravity(torch.tensor([0.0, 0.0, 9.8]), envs_idx=1)
+    scene.sim.set_gravity(torch.tensor([-1.0, 0.0, 0.0]))
+    scene.sim.set_gravity(torch.tensor([[-2.0, 0.0, 0.0]] * 10))
+    scene.sim.set_gravity(torch.tensor([0.0, 0.0, 0.0]), envs_idx=[0, 1])
+    scene.sim.set_gravity(torch.tensor([0.0, 0.0, 100.0]), envs_idx=3)
+    scene.sim.set_gravity(torch.tensor([[0.0, 0.0, -10.0], [0.0, 0.0, -1.0]]), envs_idx=[2, 4])
 
-    for _ in range(200):
+    with np.testing.assert_raises(AssertionError):
+        scene.sim.set_gravity(torch.tensor([0.0, -10.0]))
+
+    with np.testing.assert_raises(AssertionError):
+        scene.sim.set_gravity(torch.tensor([[0.0, 0.0, -10.0], [0.0, 0.0, -10.0]]), envs_idx=1)
+
+    for _ in range(10):
         scene.step()
 
-    first_pos = sphere.get_dofs_position()[0, 2]
-    second_pos = sphere.get_dofs_position()[1, 2]
-
-    assert_allclose(first_pos * -1, second_pos, tol=tol)
+    assert_allclose(
+        np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0],
+                [0.0, 0.0, -1.0],
+                [0.0, 0.0, 10.0],
+                [0.0, 0.0, -0.1],
+                [-0.2, 0.0, 0.0],
+                [-0.2, 0.0, 0.0],
+            ]
+        ),
+        sphere.get_vel(),
+        tol=tol,
+    )
 
 
 @pytest.mark.required

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2191,22 +2191,21 @@ def test_gravity(show_viewer, tol):
     with np.testing.assert_raises(AssertionError):
         scene.sim.set_gravity(torch.tensor([[0.0, 0.0, -10.0], [0.0, 0.0, -10.0]]), envs_idx=1)
 
-    for _ in range(10):
-        scene.step()
+    scene.step()
 
     assert_allclose(
         np.array(
             [
                 [0.0, 0.0, 0.0],
                 [0.0, 0.0, 0.0],
+                [0.0, 0.0, -10.0],
+                [0.0, 0.0, 100.0],
                 [0.0, 0.0, -1.0],
-                [0.0, 0.0, 10.0],
-                [0.0, 0.0, -0.1],
-                [-0.2, 0.0, 0.0],
-                [-0.2, 0.0, 0.0],
+                [-2.0, 0.0, 0.0],
+                [-2.0, 0.0, 0.0],
             ]
         ),
-        sphere.get_vel(),
+        sphere.get_links_acc().squeeze(dim=1),
         tol=tol,
     )
 


### PR DESCRIPTION
## Description
Allow for `set_gravity` per env

## Related Issue
`set_gravity` was first introduced in https://github.com/Genesis-Embodied-AI/Genesis/pull/1324

## Motivation and Context
Previous implementation did not properly set gravity per environment; taichi field should be set using kernel (no slicing)

## How Has This Been / Can This Be Tested?
Updated `test_rigid_physics.py`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I tested my changes and added instructions on how to test it for reviewers.