### PR TITLE
[BUG FIX] Fix material friction being ignore when parsing URDF/MJCF files.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -763,9 +763,9 @@ class RigidEntity(Entity):
 
         # Add collision geometries
         for g_info in cg_infos:
-            friction = g_info.get("friction", self.material.friction)
+            friction = self.material.friction
             if friction is None:
-                friction = gu.default_friction()
+                friction = g_info.get("friction", gu.default_friction())
             link._add_geom(
                 mesh=g_info["mesh"],
                 init_pos=g_info.get("pos", gu.zero_pos()),


### PR DESCRIPTION
## Description

Parse geometry-specific friction coefficient if and only if material friction coefficient is undefined.

## Motivation and Context

Global material friction coefficient should have higher priority than pre-defined URDF / MJCF geometry-specific friction coefficient. This would better aligns with what is done for primitive geometries and meshes, and probably less confusing / error prone for the end-user.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.