### PR TITLE
[FEATURE] Add dedicated sensor manager.

### DIFF
--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -26,6 +26,7 @@ from genesis.options import (
     PBDOptions,
     ProfilingOptions,
     RigidOptions,
+    SensorOptions,
     SFOptions,
     SimOptions,
     SPHOptions,
@@ -513,6 +514,10 @@ class Scene(RBC):
             )
         else:
             gs.raise_exception("Adding lights is only supported by 'RayTracer' and 'BatchRenderer'.")
+
+    @gs.assert_unbuilt
+    def add_sensor(self, sensor_options: SensorOptions):
+        return self._sim._sensor_manager.create_sensor(sensor_options)
 
     @gs.assert_unbuilt
     def add_camera(

--- a/genesis/engine/simulator.py
+++ b/genesis/engine/simulator.py
@@ -36,6 +36,7 @@ from .solvers import (
 )
 from .states.cache import QueriedStates
 from .states.solvers import SimState
+from genesis.sensors.sensor_manager import SensorManager
 
 if TYPE_CHECKING:
     from genesis.engine.scene import Scene
@@ -151,6 +152,9 @@ class Simulator(RBC):
         # entities
         self._entities: list[Entity] = gs.List()
 
+        # sensors
+        self._sensor_manager = SensorManager()
+
     def _add_entity(self, morph: Morph, material, surface, visualize_contact=False):
         if isinstance(material, gs.materials.Tool):
             entity = self.tool_solver.add_entity(self.n_entities, material, morph, surface)
@@ -205,6 +209,8 @@ class Simulator(RBC):
 
         if self.n_envs > 0 and self.sf_solver.is_active():
             gs.raise_exception("Batching is not supported for SF solver as of now.")
+
+        self._sensor_manager.build()
 
         # hybrid
         for entity in self._entities:

--- a/genesis/engine/simulator.py
+++ b/genesis/engine/simulator.py
@@ -153,7 +153,7 @@ class Simulator(RBC):
         self._entities: list[Entity] = gs.List()
 
         # sensors
-        self._sensor_manager = SensorManager()
+        self._sensor_manager = SensorManager(self)
 
     def _add_entity(self, morph: Morph, material, surface, visualize_contact=False):
         if isinstance(material, gs.materials.Tool):

--- a/genesis/engine/simulator.py
+++ b/genesis/engine/simulator.py
@@ -281,6 +281,8 @@ class Simulator(RBC):
         if self.rigid_solver.is_active():
             self.rigid_solver.clear_external_force()
 
+        self._sensor_manager.step()
+
     def _step_grad(self):
         for _ in range(self._substeps - 1, -1, -1):
 

--- a/genesis/options/__init__.py
+++ b/genesis/options/__init__.py
@@ -2,6 +2,6 @@ from .misc import *
 from .solvers import *
 from .vis import *
 from .profiling import ProfilingOptions
-
+from .sensors import SensorOptions
 
 __all__ = ["ProfilingOptions"]

--- a/genesis/options/sensors.py
+++ b/genesis/options/sensors.py
@@ -1,0 +1,11 @@
+from genesis.options import Options
+
+
+class SensorOptions(Options):
+    """
+    Base class for all sensor options.
+    Each sensor should have their own options class that inherits from this class.
+    The options class should be registered with the SensorManager using the @register_sensor decorator.
+    """
+
+    pass

--- a/genesis/options/sensors.py
+++ b/genesis/options/sensors.py
@@ -6,6 +6,11 @@ class SensorOptions(Options):
     Base class for all sensor options.
     Each sensor should have their own options class that inherits from this class.
     The options class should be registered with the SensorManager using the @register_sensor decorator.
+
+    Parameters
+    ----------
+    read_delay : float
+        The delay in seconds before the sensor data is read.
     """
 
-    pass
+    read_delay: float = 0.0

--- a/genesis/sensors/base_sensor.py
+++ b/genesis/sensors/base_sensor.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, TYPE_CHECKING
 
 import numpy as np
 import taichi as ti
@@ -8,7 +8,10 @@ import genesis as gs
 from genesis.options.sensors import SensorOptions
 from genesis.repr_base import RBC
 
-from .sensor_manager import SensorManager
+if TYPE_CHECKING:
+    from genesis.utils.ring_buffer import TensorRingBuffer
+    from genesis.options.sensors import SensorOptions
+    from .sensor_manager import SensorManager
 
 
 @ti.data_oriented
@@ -23,6 +26,8 @@ class Sensor(RBC):
         self._idx: int = sensor_idx
         self._manager: SensorManager = sensor_manager
         self._cache_idx: int = -1  # cache_idx is set by the SensorManager during the scene build phase
+        self._read_delay_steps: int = 0
+        self._cache_buffer_length: int = 0
 
     # =============================== implementable methods ===============================
 
@@ -32,7 +37,14 @@ class Sensor(RBC):
         This method is called by the SensorManager during the scene build phase to initialize the sensor.
         This is where any shared metadata should be initialized.
         """
-        pass
+        delay_steps_float = self._options.read_delay / self._manager._sim.dt
+        self._read_delay_steps = round(delay_steps_float)
+        if not np.isclose(delay_steps_float, self._read_delay_steps):
+            gs.logger.warn(
+                f"Read delay should be a multiple of the simulation time step. Got {self._options.read_delay} and "
+                f"{self._manager._sim.dt}. Actual read delay will be {1/self._read_delay_steps}."
+            )
+        self._cache_buffer_length = self._read_delay_steps + 1
 
     def _get_return_format(self) -> dict[str, tuple[int, int]] | None:
         """
@@ -42,6 +54,14 @@ class Sensor(RBC):
         None: the entire tensor (B, cache_length, cache_shape) will be returned.
         """
         raise NotImplementedError("Sensors must implement `return_format()`.")
+
+    @gs.assert_built
+    def _update_shared_gt_cache(self):
+        """
+        Update the shared sensor ground truth cache for all sensors of this class.
+        Shared information is stored in SensorManager
+        """
+        raise NotImplementedError("Sensors must implement `update_shared_gt_cache()`.")
 
     @gs.assert_built
     def _update_shared_cache(self):
@@ -76,7 +96,7 @@ class Sensor(RBC):
     @gs.assert_built
     def read(self, envs_idx: Optional[List[int]] = None):
         """
-        Read the sensor data.
+        Read the sensor data (with noise applied if applicable) from SensorManager._cache.
         """
         if envs_idx is None:
             envs_idx = 0 if self._manager._sim.n_envs == 0 else np.arange(self._cache.shape[0])
@@ -87,7 +107,27 @@ class Sensor(RBC):
         else:
             cache_length = self._get_cache_length()
             return {
-                key: self._cache[
+                key: self._cache.get(self._read_delay_steps)[
+                    envs_idx, self._cache_idx : self._cache_idx + cache_length, start_idx:end_idx
+                ].squeeze()
+                for key, (start_idx, end_idx) in return_format.items()
+            }
+
+    @gs.assert_built
+    def read_ground_truth(self, envs_idx: Optional[List[int]] = None):
+        """
+        Read the ground truth sensor data (without noise) from SensorManager._gt_cache.
+        """
+        if envs_idx is None:
+            envs_idx = 0 if self._manager._sim.n_envs == 0 else np.arange(self._gt_cache.shape[0])
+
+        return_format = self._get_return_format()
+        if return_format is None:
+            return self._gt_cache[envs_idx, self._cache_idx, :].squeeze()
+        else:
+            cache_length = self._get_cache_length()
+            return {
+                key: self._gt_cache[
                     envs_idx, self._cache_idx : self._cache_idx + cache_length, start_idx:end_idx
                 ].squeeze()
                 for key, (start_idx, end_idx) in return_format.items()
@@ -97,13 +137,13 @@ class Sensor(RBC):
     def is_built(self) -> bool:
         return self._manager._sim._scene._is_built
 
-    @gs.assert_built
-    def _get_cache(self) -> torch.Tensor:
-        return self._manager.get_sensor_cache(self.__class__, self._cache_idx)
+    @property
+    def _cache(self) -> "TensorRingBuffer":
+        return self._manager._cache[self.__class__]
 
     @property
-    def _cache(self) -> torch.Tensor:
-        return self._manager._cache[self.__class__]
+    def _gt_cache(self) -> torch.Tensor:
+        return self._manager._gt_cache[self.__class__]
 
     @property
     def _shared_metadata(self) -> dict[str, Any]:

--- a/genesis/sensors/base_sensor.py
+++ b/genesis/sensors/base_sensor.py
@@ -114,7 +114,7 @@ class Sensor(RBC):
 
     def _get_return_data_from_tensor(self, tensor: torch.Tensor, envs_idx: List[int] | None) -> torch.Tensor:
         if envs_idx is None:
-            envs_idx = 0 if self._manager._sim.n_envs == 0 else np.arange(tensor.shape[0])
+            envs_idx = [0] if self._manager._sim.n_envs == 0 else np.arange(tensor.shape[0])
 
         return_format = self._get_return_format()
 
@@ -122,18 +122,18 @@ class Sensor(RBC):
             return (
                 tensor[envs_idx, self._cache_idx : self._cache_idx + self._cache_size]
                 .clone()
-                .reshape(return_format)
+                .reshape(len(envs_idx), *return_format)
                 .squeeze()
             )
         elif isinstance(return_format, dict):
             data_dict = {}
+            data_tensor = tensor[envs_idx, self._cache_idx : self._cache_idx + self._cache_size].clone()
             tensor_idx = 0
             for key, data_shape in return_format.items():
                 data_size = np.prod(data_shape)
                 data_dict[key] = (
-                    tensor[envs_idx, self._cache_idx : self._cache_idx + self._cache_size]
-                    .clone()[tensor_idx : tensor_idx + data_size]
-                    .reshape(data_shape)
+                    data_tensor[0 : len(envs_idx), tensor_idx : tensor_idx + data_size]
+                    .reshape(len(envs_idx), *data_shape)
                     .squeeze()
                 )
                 tensor_idx += data_size

--- a/genesis/sensors/base_sensor.py
+++ b/genesis/sensors/base_sensor.py
@@ -21,10 +21,10 @@ class Sensor(RBC):
     A sensor must have a read() method that returns the sensor data.
     """
 
-    def __init__(self, sensor_options: SensorOptions, sensor_idx: int, sensor_manager: SensorManager):
-        self._options: SensorOptions = sensor_options
+    def __init__(self, sensor_options: "SensorOptions", sensor_idx: int, sensor_manager: "SensorManager"):
+        self._options: "SensorOptions" = sensor_options
         self._idx: int = sensor_idx
-        self._manager: SensorManager = sensor_manager
+        self._manager: "SensorManager" = sensor_manager
         self._cache_idx: int = -1  # cache_idx is set by the SensorManager during the scene build phase
         self._read_delay_steps: int = 0
         self._cache_buffer_length: int = 0

--- a/genesis/sensors/base_sensor.py
+++ b/genesis/sensors/base_sensor.py
@@ -109,7 +109,9 @@ class Sensor(RBC):
             return {
                 key: self._cache.get(self._read_delay_steps)[
                     envs_idx, self._cache_idx : self._cache_idx + cache_length, start_idx:end_idx
-                ].squeeze()
+                ]
+                .squeeze()
+                .clone()
                 for key, (start_idx, end_idx) in return_format.items()
             }
 
@@ -127,9 +129,9 @@ class Sensor(RBC):
         else:
             cache_length = self._get_cache_length()
             return {
-                key: self._gt_cache[
-                    envs_idx, self._cache_idx : self._cache_idx + cache_length, start_idx:end_idx
-                ].squeeze()
+                key: self._gt_cache[envs_idx, self._cache_idx : self._cache_idx + cache_length, start_idx:end_idx]
+                .squeeze()
+                .clone()
                 for key, (start_idx, end_idx) in return_format.items()
             }
 

--- a/genesis/sensors/base_sensor.py
+++ b/genesis/sensors/base_sensor.py
@@ -1,8 +1,12 @@
-import taichi as ti
-import genesis as gs
-
 from typing import List, Optional
+
+import taichi as ti
+
+import genesis as gs
+from genesis.options.sensors import SensorOptions
 from genesis.repr_base import RBC
+
+from .sensor_manager import SensorManager
 
 
 @ti.data_oriented
@@ -12,10 +16,30 @@ class Sensor(RBC):
     A sensor must have a read() method that returns the sensor data.
     """
 
+    def __init__(self, sensor_options: SensorOptions, sensor_idx: int, sensor_manager: SensorManager):
+        self._options: SensorOptions = sensor_options
+        self._idx: int = sensor_idx
+        self._manager: SensorManager = sensor_manager
+        self._cache_idx: int = -1  # cache_idx is set by the SensorManager during the scene build phase
+
+    @gs.assert_unbuilt
+    def build(self):
+        """
+        This method is called by the SensorManager during the scene build phase to initialize the sensor.
+        """
+        pass
+
     @gs.assert_built
     def read(self, envs_idx: Optional[List[int]] = None):
         """
         Read the sensor data.
-        Sensor implementations should ideally cache the data to avoid unnecessary computations.
+        Sensor implementations should make use of the caching system located in SensorManager when possible.
         """
-        raise NotImplementedError("The Sensor subclass must implement `read()`.")
+        raise NotImplementedError("Sensors must implement `read()`.")
+
+    @property
+    def cache_length(self) -> int:
+        """
+        The length (first dimension of cache size) of the cache for this sensor.
+        """
+        raise NotImplementedError("Sensors must implement `cache_length()`.")

--- a/genesis/sensors/base_sensor.py
+++ b/genesis/sensors/base_sensor.py
@@ -25,7 +25,7 @@ class Sensor(RBC):
         self._idx: int = sensor_idx
         self._manager: "SensorManager" = sensor_manager
 
-        # initialized by SceneManager during build
+        # initialized by SensorManager during build
         self._read_delay_steps: int = 0
         self._shape_indices: list[tuple[int, int]] = []
         self._shared_metadata: dict[str, Any] | None = None

--- a/genesis/sensors/base_sensor.py
+++ b/genesis/sensors/base_sensor.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
 class Sensor(RBC):
     """
     Base class for all types of sensors.
-    A sensor must have a read() method that returns the sensor data.
     """
 
     def __init__(self, sensor_options: "SensorOptions", sensor_idx: int, sensor_manager: "SensorManager"):

--- a/genesis/sensors/base_sensor.py
+++ b/genesis/sensors/base_sensor.py
@@ -26,27 +26,19 @@ class Sensor(RBC):
         self._idx: int = sensor_idx
         self._manager: "SensorManager" = sensor_manager
 
-        # initialized during build
-        self._read_delay_steps: int = 0
         # initialized by SceneManager during build
+        self._read_delay_steps: int = 0
         self._shape_indices: list[tuple[int, int]] = []
         self._shared_metadata: dict[str, Any] | None = None
 
     # =============================== implementable methods ===============================
 
-    @gs.assert_unbuilt
     def build(self):
         """
         This method is called by the SensorManager during the scene build phase to initialize the sensor.
         This is where any shared metadata should be initialized.
         """
-        delay_steps_float = self._options.read_delay / self._manager._sim.dt
-        self._read_delay_steps = round(delay_steps_float)
-        if not np.isclose(delay_steps_float, self._read_delay_steps):
-            gs.logger.warn(
-                f"Read delay should be a multiple of the simulation time step. Got {self._options.read_delay} and "
-                f"{self._manager._sim.dt}. Actual read delay will be {1/self._read_delay_steps}."
-            )
+        raise NotImplementedError("Sensors must implement `build()`.")
 
     def _get_return_format(self) -> dict[str, tuple[int, ...]] | tuple[int, ...]:
         """

--- a/genesis/sensors/base_sensor.py
+++ b/genesis/sensors/base_sensor.py
@@ -29,6 +29,7 @@ class Sensor(RBC):
         self._read_delay_steps: int = 0
         self._shape_indices: list[tuple[int, int]] = []
         self._shared_metadata: dict[str, Any] | None = None
+        self._cache: "TensorRingBuffer" | None = None
 
     # =============================== implementable methods ===============================
 
@@ -91,10 +92,7 @@ class Sensor(RBC):
         """
         Read the sensor data (with noise applied if applicable).
         """
-        return self._get_formatted_data(
-            self._manager.get_cloned_from_cache(self).get(self._read_delay_steps),
-            envs_idx,
-        )
+        return self._get_formatted_data(self._cache.get(self._read_delay_steps), envs_idx)
 
     @gs.assert_built
     def read_ground_truth(self, envs_idx: List[int] | None = None):

--- a/genesis/sensors/base_sensor.py
+++ b/genesis/sensors/base_sensor.py
@@ -1,6 +1,7 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import taichi as ti
+import torch
 
 import genesis as gs
 from genesis.options.sensors import SensorOptions
@@ -16,11 +17,18 @@ class Sensor(RBC):
     A sensor must have a read() method that returns the sensor data.
     """
 
+    # These class variables are used by SensorManager to determine the cache metadata for the sensor.
+    # Sensor implementations should override these class variable values.
+    CACHE_DTYPE: torch.dtype = torch.float32
+    CACHE_SHAPE: tuple[int, ...] = (1,)
+
     def __init__(self, sensor_options: SensorOptions, sensor_idx: int, sensor_manager: SensorManager):
         self._options: SensorOptions = sensor_options
         self._idx: int = sensor_idx
         self._manager: SensorManager = sensor_manager
         self._cache_idx: int = -1  # cache_idx is set by the SensorManager during the scene build phase
+
+    # =============================== implementable methods ===============================
 
     @gs.assert_unbuilt
     def build(self):
@@ -33,7 +41,6 @@ class Sensor(RBC):
     def read(self, envs_idx: Optional[List[int]] = None):
         """
         Read the sensor data.
-        Sensor implementations should make use of the caching system located in SensorManager when possible.
         """
         raise NotImplementedError("Sensors must implement `read()`.")
 
@@ -42,4 +49,30 @@ class Sensor(RBC):
         """
         The length (first dimension of cache size) of the cache for this sensor.
         """
-        raise NotImplementedError("Sensors must implement `cache_length()`.")
+        return 1
+
+    # =============================== shared methods ===============================
+
+    @property
+    def is_built(self) -> bool:
+        return self._manager._sim._scene._is_built
+
+    @gs.assert_built
+    def _get_cache(self) -> torch.Tensor:
+        return self._manager.get_sensor_cache(self.__class__, self._cache_idx)
+
+    @gs.assert_built
+    def _is_cache_updated(self) -> bool:
+        return self._manager.is_cache_updated(self.__class__)
+
+    @gs.assert_built
+    def _set_cache_updated(self):
+        self._manager.set_cache_updated(self.__class__)
+
+    @property
+    def _cache(self) -> torch.Tensor:
+        return self._manager._cache[self.__class__]
+
+    @property
+    def _shared_metadata(self) -> dict[str, Any]:
+        return self._manager._sensors_metadata[self.__class__]

--- a/genesis/sensors/sensor_manager.py
+++ b/genesis/sensors/sensor_manager.py
@@ -1,0 +1,65 @@
+from typing import Type
+
+import torch
+
+from genesis.options.sensors import SensorOptions
+
+from .base_sensor import Sensor
+
+
+class SensorManager:
+    SENSOR_TYPES_MAP: dict[Type[SensorOptions], Type[Sensor]] = {}
+    SENSOR_CACHE_METADATA_MAP: dict[Type[Sensor], (torch.dtype, tuple[int, ...])] = {}
+
+    def __init__(self):
+        self.sensors_by_type: dict[Type[Sensor], list[Sensor]] = {}
+        self.cache: dict[Type[Sensor], torch.Tensor] = {}
+        self.cache_size_map: dict[Type[Sensor], int] = {}
+
+    def create_sensor(self, sensor_options: SensorOptions):
+        sensor_cls = SensorManager.SENSOR_TYPES_MAP[type(sensor_options)]
+        sensor = sensor_cls(sensor_options, len(self.sensors_by_type[sensor_cls]), self)
+        if sensor_cls not in self.sensors_by_type:
+            self.sensors_by_type[sensor_cls] = []
+        self.sensors_by_type[sensor_cls].append(sensor)
+        return sensor
+
+    def build(self):
+        for sensor_cls, sensors in self.sensors_by_type.items():
+            total_cache_length = 0
+            for sensor in sensors:
+                sensor.build()
+                sensor._cache_idx = total_cache_length
+                total_cache_length += sensor.cache_length
+
+            cache_dtype, cache_shape = SensorManager.SENSOR_CACHE_METADATA_MAP[sensor_cls]
+            self.cache[sensor_cls] = torch.zeros((total_cache_length, *cache_shape), dtype=cache_dtype)
+
+            for sensor in sensors:
+                sensor.build()
+
+    def get_sensor_cache(self, sensor_cls: Type[Sensor], sensor_idx: int | None = None) -> torch.Tensor:
+        cache_size = SensorManager.SENSOR_CACHE_SIZE_MAP[sensor_cls]
+        if sensor_idx is None:
+            return self.cache[sensor_cls]
+        return self.cache[sensor_cls][sensor_idx * cache_size : (sensor_idx + 1) * cache_size]
+
+    def set_sensor_cache(self, new_values: torch.Tensor, sensor_cls: Type[Sensor], sensor_idx: int | None = None):
+        cache_size = SensorManager.SENSOR_CACHE_SIZE_MAP[sensor_cls]
+        if sensor_idx is None:
+            self.cache[sensor_cls] = new_values
+        else:
+            self.cache[sensor_cls][sensor_idx * cache_size : (sensor_idx + 1) * cache_size] = new_values
+
+    @property
+    def sensors(self):
+        return [sensor for sensor_list in self.sensors_by_type.values() for sensor in sensor_list]
+
+
+def register_sensor(sensor_cls: Type[Sensor], cache_dtype: torch.dtype, cache_shape: tuple[int, ...]):
+    def _impl(sensor_options: SensorOptions):
+        SensorManager.SENSOR_TYPES_MAP[type(sensor_options)] = sensor_cls
+        SensorManager.SENSOR_CACHE_METADATA_MAP[sensor_cls] = (cache_dtype, cache_shape)
+        return sensor_options
+
+    return _impl

--- a/genesis/sensors/sensor_manager.py
+++ b/genesis/sensors/sensor_manager.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any, Type
 
+import numpy as np
 import torch
 
 from genesis.utils.ring_buffer import TensorRingBuffer
@@ -19,6 +20,7 @@ class SensorManager:
         self._sensors_metadata: dict[Type["Sensor"], dict[str, Any]] = {}
         self._ground_truth_cache: dict[Type[torch.dtype], torch.Tensor] = {}
         self._cache: dict[Type[torch.dtype], TensorRingBuffer] = {}
+        self._cache_slices_by_type: dict[Type["Sensor"], slice] = {}
 
     def create_sensor(self, sensor_options: "SensorOptions"):
         sensor_cls = SensorManager.SENSOR_TYPES_MAP[type(sensor_options)]
@@ -32,27 +34,57 @@ class SensorManager:
         cache_size_per_dtype = {}
         for sensor_cls, sensors in self._sensors_by_type.items():
             self._sensors_metadata[sensor_cls] = {}
+            dtype = sensor_cls._get_cache_dtype()
+            cache_size_per_dtype.setdefault(dtype, 0)
+            cls_cache_start_idx = cache_size_per_dtype[dtype]
 
             for sensor in sensors:
-                sensor.build()
+                return_format = sensor._get_return_format()
+                return_shapes = return_format.values() if isinstance(return_format, dict) else (return_format,)
 
-                cache_size_per_dtype.setdefault(sensor._dtype, 0)
+                tensor_size = 0
+                for shape in return_shapes:
+                    data_size = np.prod(shape)
+                    sensor._shape_indices.append((tensor_size, tensor_size + data_size))
+                    tensor_size += data_size
 
-                sensor._cache_start_idx = cache_size_per_dtype[sensor._dtype]
-                sensor._cache_end_idx = sensor._cache_start_idx + sensor._cache_size
-                cache_size_per_dtype[sensor._dtype] += sensor._cache_size
+                sensor._cache_size = sensor._get_cache_length() * tensor_size
+                sensor._cache_idx = cache_size_per_dtype[dtype]
+                cache_size_per_dtype[dtype] += sensor._cache_size
 
                 max_cache_buf_len = max(max_cache_buf_len, sensor._read_delay_steps + 1)
 
-            for dtype in cache_size_per_dtype.keys():
-                cache_shape = (self._sim._B, cache_size_per_dtype[dtype])
-                self._ground_truth_cache[dtype] = torch.zeros(cache_shape, dtype=dtype)
-                self._cache[dtype] = TensorRingBuffer(max_cache_buf_len, cache_shape, dtype=dtype)
+            cls_cache_end_idx = cache_size_per_dtype[dtype]
+            self._cache_slices_by_type[sensor_cls] = slice(cls_cache_start_idx, cls_cache_end_idx)
+
+        for dtype in cache_size_per_dtype.keys():
+            cache_shape = (self._sim._B, cache_size_per_dtype[dtype])
+            self._ground_truth_cache[dtype] = torch.zeros(cache_shape, dtype=dtype)
+            self._cache[dtype] = TensorRingBuffer(max_cache_buf_len, cache_shape, dtype=dtype)
+
+        for sensor_cls, sensors in self._sensors_by_type.items():
+            dtype = sensor_cls._get_cache_dtype()
+            for sensor in sensors:
+                sensor._shared_metadata = self._sensors_metadata[sensor_cls]
+
+                cache_slice = slice(sensor._cache_idx, sensor._cache_idx + sensor._cache_size)
+                sensor._cache = self._cache[dtype][cache_slice]
+                sensor._ground_truth_cache = self._ground_truth_cache[dtype][cache_slice]
+
+                sensor.build()
 
     def step(self):
-        for sensor_cls, sensors in self._sensors_by_type.items():
-            sensors[0]._update_shared_ground_truth_cache()
-            sensors[0]._update_shared_cache()
+        for sensor_cls in self._sensors_by_type.keys():
+            dtype = sensor_cls._get_cache_dtype()
+            cache_slice = self._cache_slices_by_type[sensor_cls]
+            sensor_cls._update_shared_ground_truth_cache(
+                self._sensors_metadata[sensor_cls], self._ground_truth_cache[dtype][cache_slice]
+            )
+            sensor_cls._update_shared_cache(
+                self._sensors_metadata[sensor_cls],
+                self._ground_truth_cache[dtype][cache_slice],
+                self._cache[dtype][cache_slice],
+            )
 
     @property
     def sensors(self):

--- a/genesis/sensors/sensor_manager.py
+++ b/genesis/sensors/sensor_manager.py
@@ -23,9 +23,7 @@ class SensorManager:
         self._cache: dict[Type[torch.dtype], TensorRingBuffer] = {}
         self._cache_slices_by_type: dict[Type["Sensor"], slice] = {}
 
-        self._last_cache_cloned_step: int = -1
         self._last_ground_truth_cache_cloned_step: int = -1
-        self._cloned_cache: dict[Type[torch.dtype], TensorRingBuffer] = {}
         self._cloned_ground_truth_cache: dict[Type[torch.dtype], torch.Tensor] = {}
 
     def create_sensor(self, sensor_options: "SensorOptions"):
@@ -80,11 +78,7 @@ class SensorManager:
             dtype = sensor_cls._get_cache_dtype()
             for sensor in sensors:
                 sensor._shared_metadata = self._sensors_metadata[sensor_cls]
-
-                cache_slice = slice(sensor._cache_idx, sensor._cache_idx + sensor._cache_size)
-                sensor._cache = self._cache[dtype][cache_slice]
-                sensor._ground_truth_cache = self._ground_truth_cache[dtype][cache_slice]
-
+                sensor._cache = self._cache[dtype][sensor._cache_idx : sensor._cache_idx + sensor._cache_size]
                 sensor.build()
 
     def step(self):
@@ -99,13 +93,6 @@ class SensorManager:
                 self._ground_truth_cache[dtype][cache_slice],
                 self._cache[dtype][cache_slice],
             )
-
-    def get_cloned_from_cache(self, sensor: "Sensor") -> "TensorRingBuffer":
-        dtype = sensor._get_cache_dtype()
-        if self._last_cache_cloned_step != self._sim.cur_step_global:
-            self._last_cache_cloned_step = self._sim.cur_step_global
-            self._cloned_cache[dtype] = self._cache[dtype].clone()
-        return self._cloned_cache[dtype][:, sensor._cache_idx : sensor._cache_idx + sensor._cache_size]
 
     def get_cloned_from_ground_truth_cache(self, sensor: "Sensor") -> torch.Tensor:
         dtype = sensor._get_cache_dtype()

--- a/genesis/sensors/sensor_manager.py
+++ b/genesis/sensors/sensor_manager.py
@@ -5,6 +5,7 @@ import torch
 from genesis.utils.ring_buffer import TensorRingBuffer
 
 if TYPE_CHECKING:
+    from genesis.options.sensors import SensorOptions
     from .base_sensor import Sensor
 
 
@@ -18,7 +19,7 @@ class SensorManager:
         self._gt_cache: dict[Type["Sensor"], torch.Tensor] = {}
         self._cache: dict[Type["Sensor"], TensorRingBuffer] = {}
 
-    def create_sensor(self, sensor_options: SensorOptions):
+    def create_sensor(self, sensor_options: "SensorOptions"):
         sensor_cls = SensorManager.SENSOR_TYPES_MAP[type(sensor_options)]
         if sensor_cls not in self._sensors_by_type:
             self._sensors_by_type[sensor_cls] = []
@@ -55,7 +56,7 @@ class SensorManager:
 
 
 def register_sensor(sensor_cls: Type["Sensor"]):
-    def _impl(options_cls: Type[SensorOptions]):
+    def _impl(options_cls: Type["SensorOptions"]):
         SensorManager.SENSOR_TYPES_MAP[options_cls] = sensor_cls
         return options_cls
 

--- a/genesis/sensors/sensor_manager.py
+++ b/genesis/sensors/sensor_manager.py
@@ -19,7 +19,6 @@ class SensorManager:
         self._sensors_by_type: dict[Type["Sensor"], list["Sensor"]] = {}
         self._sensors_metadata: dict[Type["Sensor"], dict[str, Any]] = {}
         self._cache: dict[Type["Sensor"], torch.Tensor] = {}
-        self._cache_size_map: dict[Type["Sensor"], int] = {}
         self._cache_last_updated_step_map: dict[Type["Sensor"], int] = {}
 
     def create_sensor(self, sensor_options: SensorOptions):

--- a/genesis/sensors/sensor_manager.py
+++ b/genesis/sensors/sensor_manager.py
@@ -1,65 +1,63 @@
-from typing import Type
+from typing import Any, Type
 
 import torch
 
 from genesis.options.sensors import SensorOptions
 
-from .base_sensor import Sensor
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .base_sensor import Sensor
 
 
 class SensorManager:
-    SENSOR_TYPES_MAP: dict[Type[SensorOptions], Type[Sensor]] = {}
-    SENSOR_CACHE_METADATA_MAP: dict[Type[Sensor], (torch.dtype, tuple[int, ...])] = {}
+    SENSOR_TYPES_MAP: dict[Type[SensorOptions], Type["Sensor"]] = {}
+    SENSOR_CACHE_METADATA_MAP: dict[Type["Sensor"], (torch.dtype, tuple[int, ...])] = {}
 
-    def __init__(self):
-        self.sensors_by_type: dict[Type[Sensor], list[Sensor]] = {}
-        self.cache: dict[Type[Sensor], torch.Tensor] = {}
-        self.cache_size_map: dict[Type[Sensor], int] = {}
+    def __init__(self, sim):
+        self._sim = sim
+        self._sensors_by_type: dict[Type["Sensor"], list["Sensor"]] = {}
+        self._sensors_metadata: dict[Type["Sensor"], dict[str, Any]] = {}
+        self._cache: dict[Type["Sensor"], torch.Tensor] = {}
+        self._cache_size_map: dict[Type["Sensor"], int] = {}
+        self._cache_last_updated_step_map: dict[Type["Sensor"], int] = {}
 
     def create_sensor(self, sensor_options: SensorOptions):
         sensor_cls = SensorManager.SENSOR_TYPES_MAP[type(sensor_options)]
-        sensor = sensor_cls(sensor_options, len(self.sensors_by_type[sensor_cls]), self)
-        if sensor_cls not in self.sensors_by_type:
-            self.sensors_by_type[sensor_cls] = []
-        self.sensors_by_type[sensor_cls].append(sensor)
+        if sensor_cls not in self._sensors_by_type:
+            self._sensors_by_type[sensor_cls] = []
+        sensor = sensor_cls(sensor_options, len(self._sensors_by_type[sensor_cls]), self)
+        self._sensors_by_type[sensor_cls].append(sensor)
         return sensor
 
     def build(self):
-        for sensor_cls, sensors in self.sensors_by_type.items():
+        for sensor_cls, sensors in self._sensors_by_type.items():
             total_cache_length = 0
+            self._cache_last_updated_step_map[sensor_cls] = -1
+            self._sensors_metadata[sensor_cls] = {}
             for sensor in sensors:
                 sensor.build()
                 sensor._cache_idx = total_cache_length
                 total_cache_length += sensor.cache_length
 
             cache_dtype, cache_shape = SensorManager.SENSOR_CACHE_METADATA_MAP[sensor_cls]
-            self.cache[sensor_cls] = torch.zeros((total_cache_length, *cache_shape), dtype=cache_dtype)
+            self._cache[sensor_cls] = torch.zeros((self._sim._B, total_cache_length, *cache_shape), dtype=cache_dtype)
 
-            for sensor in sensors:
-                sensor.build()
+    def is_cache_updated(self, sensor_cls: Type["Sensor"]) -> bool:
+        return self._cache_last_updated_step_map[sensor_cls] == self._sim.cur_step_global
 
-    def get_sensor_cache(self, sensor_cls: Type[Sensor], sensor_idx: int | None = None) -> torch.Tensor:
-        cache_size = SensorManager.SENSOR_CACHE_SIZE_MAP[sensor_cls]
-        if sensor_idx is None:
-            return self.cache[sensor_cls]
-        return self.cache[sensor_cls][sensor_idx * cache_size : (sensor_idx + 1) * cache_size]
-
-    def set_sensor_cache(self, new_values: torch.Tensor, sensor_cls: Type[Sensor], sensor_idx: int | None = None):
-        cache_size = SensorManager.SENSOR_CACHE_SIZE_MAP[sensor_cls]
-        if sensor_idx is None:
-            self.cache[sensor_cls] = new_values
-        else:
-            self.cache[sensor_cls][sensor_idx * cache_size : (sensor_idx + 1) * cache_size] = new_values
+    def set_cache_updated(self, sensor_cls: Type["Sensor"]):
+        self._cache_last_updated_step_map[sensor_cls] = self._sim.cur_step_global
 
     @property
     def sensors(self):
-        return [sensor for sensor_list in self.sensors_by_type.values() for sensor in sensor_list]
+        return [sensor for sensor_list in self._sensors_by_type.values() for sensor in sensor_list]
 
 
-def register_sensor(sensor_cls: Type[Sensor], cache_dtype: torch.dtype, cache_shape: tuple[int, ...]):
-    def _impl(sensor_options: SensorOptions):
-        SensorManager.SENSOR_TYPES_MAP[type(sensor_options)] = sensor_cls
-        SensorManager.SENSOR_CACHE_METADATA_MAP[sensor_cls] = (cache_dtype, cache_shape)
-        return sensor_options
+def register_sensor(sensor_cls: Type["Sensor"]):
+    def _impl(options_cls: Type[SensorOptions]):
+        SensorManager.SENSOR_TYPES_MAP[options_cls] = sensor_cls
+        SensorManager.SENSOR_CACHE_METADATA_MAP[sensor_cls] = (sensor_cls.CACHE_DTYPE, sensor_cls.CACHE_SHAPE)
+        return options_cls
 
     return _impl

--- a/genesis/utils/ring_buffer.py
+++ b/genesis/utils/ring_buffer.py
@@ -1,18 +1,25 @@
-import genesis as gs
 import torch
+
+import genesis as gs
 
 
 class TensorRingBuffer:
-    def __init__(self, N, shape, dtype=torch.float32):
-        self.buffer = torch.empty((N, *shape), dtype=dtype, device=gs.device)
+    def __init__(
+        self, N: int, shape: tuple[int, ...], dtype=torch.float32, buffer: torch.Tensor | None = None, idx_ptr: int = 0
+    ):
+        if buffer is None:
+            self.buffer = torch.empty((N, *shape), dtype=dtype, device=gs.device)
+        else:
+            assert buffer.shape == (N, *shape)
+            self.buffer = buffer
         self.N = N
-        self._idx_ptr = 0  # idx_ptr points to the next free slot
+        self._idx_ptr = idx_ptr  # idx_ptr points to the next free slot
 
-    def append(self, tensor):
+    def append(self, tensor: torch.Tensor):
         self.buffer[self._idx_ptr].copy_(tensor)
         self._idx_ptr = (self._idx_ptr + 1) % self.N
 
-    def get(self, idx):
+    def get(self, idx: int):
         """
         Parameters
         ----------
@@ -20,3 +27,31 @@ class TensorRingBuffer:
             Index of the element to get, where 0 is the latest element, 1 is the second latest, etc.
         """
         return self.buffer[(self._idx_ptr - idx) % self.N]
+
+    def __getitem__(self, key: int | slice | tuple):
+        """
+        Enable slicing of the tensor ring buffer.
+
+        Parameters
+        ----------
+        key : int | slice | tuple
+            Slice object (e.g., 3:6) or integer index or tuple of indices
+
+        Returns
+        -------
+        TensorRingBuffer
+            A new ring buffer containing a view of the sliced data
+        """
+        if isinstance(key, int):
+            sliced_buffer = self.buffer[:, key : key + 1]
+        elif isinstance(key, slice):
+            sliced_buffer = self.buffer[:, key]
+        elif isinstance(key, tuple):
+            indexes = (slice(None),) + key
+            sliced_buffer = self.buffer[indexes]
+        else:
+            raise TypeError(f"Unsupported key type: {type(key)}")
+
+        return TensorRingBuffer(
+            self.N, sliced_buffer.shape[1:], dtype=sliced_buffer.dtype, buffer=sliced_buffer, idx_ptr=self._idx_ptr
+        )

--- a/genesis/utils/ring_buffer.py
+++ b/genesis/utils/ring_buffer.py
@@ -29,14 +29,17 @@ class TensorRingBuffer:
         self.buffer[self._idx_ptr.value].copy_(tensor)
         self._idx_ptr.value = (self._idx_ptr.value + 1) % self.N
 
-    def get(self, idx: int):
+    def get(self, idx: int, clone: bool = True):
         """
         Parameters
         ----------
         idx : int
             Index of the element to get, where 0 is the latest element, 1 is the second latest, etc.
+        clone : bool
+            Whether to clone the tensor.
         """
-        return self.buffer[(self._idx_ptr.value - idx) % self.N]
+        tensor = self.buffer[(self._idx_ptr.value - idx) % self.N]
+        return tensor.clone() if clone else tensor
 
     def clone(self):
         return TensorRingBuffer(

--- a/genesis/utils/ring_buffer.py
+++ b/genesis/utils/ring_buffer.py
@@ -28,6 +28,11 @@ class TensorRingBuffer:
         """
         return self.buffer[(self._idx_ptr - idx) % self.N]
 
+    def clone(self):
+        return TensorRingBuffer(
+            self.N, self.buffer.shape[1:], dtype=self.buffer.dtype, buffer=self.buffer.clone(), idx_ptr=self._idx_ptr
+        )
+
     def __getitem__(self, key: int | slice | tuple):
         """
         Enable slicing of the tensor ring buffer.

--- a/genesis/utils/ring_buffer.py
+++ b/genesis/utils/ring_buffer.py
@@ -1,0 +1,22 @@
+import genesis as gs
+import torch
+
+
+class TensorRingBuffer:
+    def __init__(self, N, shape, dtype=torch.float32):
+        self.buffer = torch.empty((N, *shape), dtype=dtype, device=gs.device)
+        self.N = N
+        self._idx_ptr = 0  # idx_ptr points to the next free slot
+
+    def append(self, tensor):
+        self.buffer[self._idx_ptr].copy_(tensor)
+        self._idx_ptr = (self._idx_ptr + 1) % self.N
+
+    def get(self, idx):
+        """
+        Parameters
+        ----------
+        idx : int
+            Index of the element to get, where 0 is the latest element, 1 is the second latest, etc.
+        """
+        return self.buffer[(self._idx_ptr - idx) % self.N]

--- a/genesis/vis/camera.py
+++ b/genesis/vis/camera.py
@@ -1,8 +1,7 @@
 import inspect
+import math
 import os
 import time
-import math
-from functools import lru_cache
 
 import cv2
 import numpy as np
@@ -10,7 +9,7 @@ import torch
 
 import genesis as gs
 import genesis.utils.geom as gu
-from genesis.sensors import Sensor
+from genesis.repr_base import RBC
 from genesis.utils.misc import tensor_to_array
 
 
@@ -26,7 +25,7 @@ def _T_to_quat_for_madrona(T):
     return torch.stack([x + w, x - w, y - z, y + z], dim=1) / math.sqrt(2.0)
 
 
-class Camera(Sensor):
+class Camera(RBC):
     """
     A camera which can be used to render RGB, depth, and segmentation images.
     Supports either rasterizer or raytracer for rendering, specified by `scene.renderer`.


### PR DESCRIPTION
## Description
Add SensorManager to Simulator. Sensor classes can now have per-scene multi-sensor caching.

## Related Issue
Rigid Tactile Sensors https://github.com/Genesis-Embodied-AI/Genesis/pull/1451 will be rebased on this PR.
IMU Sensor https://github.com/Milotrince/Genesis/pull/1 is also based on this PR. (I can't do a "stacked PR" directly in Genesis repo since my branch doesn't live there, which is why the PR currently lives in my fork of Genesis)

## Motivation and Context
The current sensor implementation does not allow for caching across multiple sensors, and usage is un-Genesis-like (unintuitive, e.g. does not align with `add_camera` pattern). See new [IMU](https://github.com/Milotrince/Genesis/pull/1) for an implementation/usage example.

## How Has This Been / Can This Be Tested?
Will add tests per sensor.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.
