### PR TITLE
[FEATURE] Add debug camera for monitoring.

### DIFF
--- a/examples/rigid/single_franka_batch_render.py
+++ b/examples/rigid/single_franka_batch_render.py
@@ -15,6 +15,7 @@ def main():
     parser.add_argument("-r", "--render_all_cameras", action="store_true", default=False)
     parser.add_argument("-o", "--output_dir", type=str, default="img_output/test")
     parser.add_argument("-u", "--use_rasterizer", action="store_true", default=False)
+    parser.add_argument("-d", "--debug", action="store_true", default=False)
     args = parser.parse_args()
 
     ########################## init ##########################
@@ -37,6 +38,14 @@ def main():
     )
 
     ########################## cameras ##########################
+    debug_cam = scene.add_camera(
+        res=(720, 1280),
+        pos=(1.5, -0.5, 1.0),
+        lookat=(0.0, 0.0, 0.5),
+        fov=60,
+        GUI=args.vis,
+        debug=True,
+    )
     cam_0 = scene.add_camera(
         res=(512, 512),
         pos=(1.5, 0.5, 1.5),
@@ -75,14 +84,20 @@ def main():
     # Create an image exporter
     exporter = FrameImageExporter(args.output_dir)
 
+    if args.debug:
+        debug_cam.start_recording()
     for i in range(args.n_steps):
         scene.step()
+        if args.debug:
+            debug_cam.render()
         if args.render_all_cameras:
             rgba, depth, _, _ = scene.render_all_cameras(rgb=True, depth=True)
             exporter.export_frame_all_cameras(i, rgb=rgba, depth=depth)
         else:
             rgba, depth, _, _ = cam_1.render(rgb=True, depth=True)
             exporter.export_frame_single_camera(i, cam_1.idx, rgb=rgba, depth=depth)
+    if args.debug:
+        debug_cam.stop_recording("debug_cam.mp4")
 
 
 if __name__ == "__main__":

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -529,6 +529,7 @@ class Scene(RBC):
         spp=256,
         denoise=None,
         env_idx=None,
+        debug=False,
     ):
         """
         Add a camera to the scene.
@@ -567,6 +568,12 @@ class Scene(RBC):
             Whether to denoise the camera's rendered image. Only available when using the RayTracer renderer. Defaults
             to True on Linux, otherwise False. If OptiX denoiser is not available in your platform, consider enabling
             the OIDN denoiser option when building the RayTracer.
+        debug : bool
+            Whether to use the debug camera. It enables to create cameras that can used to monitor / debug the
+            simulation without being part of the "sensors". Their output is rendered by the usual simple Rasterizer
+            systematically, no matter if BatchRender and RayTracer is enabled. This way, it is possible to record the
+            simulation with arbitrary resolution and camera pose, without interfering with what robots can perceive
+            from their environment. Defaults to False.
 
         Returns
         -------
@@ -576,7 +583,7 @@ class Scene(RBC):
         if denoise is None:
             denoise = sys.platform != "darwin"
         return self._visualizer.add_camera(
-            res, pos, lookat, up, model, fov, aperture, focus_dist, GUI, spp, denoise, env_idx
+            res, pos, lookat, up, model, fov, aperture, focus_dist, GUI, spp, denoise, env_idx, debug
         )
 
     @gs.assert_unbuilt

--- a/genesis/vis/visualizer.py
+++ b/genesis/vis/visualizer.py
@@ -127,10 +127,26 @@ class Visualizer(RBC):
         self.viewer_lock = None
         self._renderer = None
 
-    def add_camera(self, res, pos, lookat, up, model, fov, aperture, focus_dist, GUI, spp, denoise, env_idx):
-        cam_idx = len(self._cameras)
+    def add_camera(self, res, pos, lookat, up, model, fov, aperture, focus_dist, GUI, spp, denoise, env_idx, debug):
+        cam_idx = (
+            len([c for c in self._cameras if not c.debug]) if not debug else len([c for c in self._cameras if c.debug])
+        )
         camera = Camera(
-            self, cam_idx, model, res, pos, lookat, up, fov, aperture, focus_dist, GUI, spp, denoise, env_idx=env_idx
+            self,
+            cam_idx,
+            model,
+            res,
+            pos,
+            lookat,
+            up,
+            fov,
+            aperture,
+            focus_dist,
+            GUI,
+            spp,
+            denoise,
+            env_idx=0 if debug else env_idx,
+            debug=debug,
         )
         self._cameras.append(camera)
         return camera
@@ -138,6 +154,8 @@ class Visualizer(RBC):
     def add_light(self, pos, dir, intensity, directional, castshadow, cutoff):
         if self._batch_renderer is not None:
             self._batch_renderer.add_light(pos, dir, intensity, directional, castshadow, cutoff)
+        else:
+            gs.raise_exception("`add_light` is specifically for batch renderer.")
 
     def reset(self):
         self._t = -1

--- a/genesis/vis/visualizer.py
+++ b/genesis/vis/visualizer.py
@@ -128,9 +128,7 @@ class Visualizer(RBC):
         self._renderer = None
 
     def add_camera(self, res, pos, lookat, up, model, fov, aperture, focus_dist, GUI, spp, denoise, env_idx, debug):
-        cam_idx = (
-            len([c for c in self._cameras if not c.debug]) if not debug else len([c for c in self._cameras if c.debug])
-        )
+        cam_idx = len([camera for camera in self._cameras if camera.debug == debug])
         camera = Camera(
             self,
             cam_idx,
@@ -145,7 +143,7 @@ class Visualizer(RBC):
             GUI,
             spp,
             denoise,
-            env_idx=0 if debug else env_idx,
+            env_idx=env_idx,
             debug=debug,
         )
         self._cameras.append(camera)


### PR DESCRIPTION
## Description

* Enable to use PyRenderer camera to render along with Madrona Batched renderer
* Only add rasterizer camera if needed instead of systematically as before

## Motivation and Context

This will be useful for monitoring the training (logging eval video) in different resolution from what policy sees (e.g., HD camera for human monitoring and 64x64 for policy input) in a headless environment (like a server) where viewer is not available or when you don't want to use viewer to prevent slow down for the entire training.

## How Has This Been / Can This Be Tested?

```bash
python examples/rigid/single_franka_batch_render.py -r # batch_renderer only
python examples/rigid/single_franka_batch_render.py -r -d # batch_renderer + rasterizer for debug
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
