### PR TITLE
[BUG FIX] Fix taichi debug mode errors and warnings

### DIFF
--- a/genesis/engine/couplers/sap_coupler.py
+++ b/genesis/engine/couplers/sap_coupler.py
@@ -655,7 +655,7 @@ class SAPCoupler(RBC):
         for i_b, i_v in ti.ndrange(self._B, self.fem_solver.n_vertices):
             if not self.batch_linesearch_active[i_b]:
                 continue
-            self.linesearch_state.dell_dalpha[i_b] += dp[i_b, i_v].dot(v[i_b, i_v] - v_star[i_step + 1, i_b, i_v])
+            self.linesearch_state.dell_dalpha[i_b] += dp[i_b, i_v].dot(v[i_b, i_v] - v_star[i_step + 1, i_v, i_b])
 
     @ti.kernel
     def compute_inertia_elastic_hessian_alpha(self):
@@ -679,7 +679,7 @@ class SAPCoupler(RBC):
         for i_b, i_v in ti.ndrange(self._B, self.fem_solver.n_vertices):
             if not self.batch_linesearch_active[i_b]:
                 continue
-            energy[i_b] += alpha[i_b] * dp[i_b, i_v].dot(v[i_b, i_v] - v_star[i_step + 1, i_b, i_v])
+            energy[i_b] += alpha[i_b] * dp[i_b, i_v].dot(v[i_b, i_v] - v_star[i_step + 1, i_v, i_b])
 
     def prepare_search_direction_data(self):
         self.prepare_inertia_elastic_search_direction_data()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->
- Add ti.i32 and ti.u32 explicit typing to avoid overflow.
- Change expand_bits function to avoid taichi compiler warning in debug modes.
- Fix bugs in indexing.

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Now the code can be run in taichi debug mode without outputting tons of warning messages.

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Tested with code
```
import taichi as ti
import time

@ti.func
def expand1(x: ti.u32) -> ti.u32:
    x = (x | (x << 16)) & ti.u32(0xFF0000FF)
    x = (x | (x <<  8)) & ti.u32(0x0F00F00F)
    x = (x | (x <<  4)) & ti.u32(0xC30C30C3)
    x = (x | (x <<  2)) & ti.u32(0x49249249)
    return x

@ti.func
def expand2(x: ti.u32) -> ti.u32:
    x = (x * ti.u32(0x00010001)) & ti.u32(0xFF0000FF)
    x = (x * ti.u32(0x00000101)) & ti.u32(0x0F00F00F)
    x = (x * ti.u32(0x00000011)) & ti.u32(0xC30C30C3)
    x = (x * ti.u32(0x00000005)) & ti.u32(0x49249249)
    return x

@ti.func
def expand3(x: ti.u32) -> ti.u32:
    x = (x * ti.u32(0x00010001)) & ti.u32(0xFF0000FF)
    x = (x | ((x & 0x00FFFFFF) <<  8)) & 0x0F00F00F
    x = (x * ti.u32(0x00000011)) & ti.u32(0xC30C30C3)
    x = (x * ti.u32(0x00000005)) & ti.u32(0x49249249)
    return x

@ti.kernel
def test1(n_test: ti.i32):
    for i, j in ti.ndrange(n_test, 1024):
        data1[i, j] = expand1(j)

@ti.kernel
def test2(n_test: ti.i32):
    for i, j in ti.ndrange(n_test, 1024):
        data2[i, j] = expand2(j)

@ti.kernel
def test3(n_test: ti.i32):
    for i, j in ti.ndrange(n_test, 1024):
        data3[i, j] = expand3(j)

if __name__ == "__main__":
    ti.init(arch=ti.gpu, debug=False)
    n_test = 100000
    n_rounds = 10
    data1 = ti.field(ti.u32, shape=(n_test, 1024))
    data2 = ti.field(ti.u32, shape=(n_test, 1024))
    data3 = ti.field(ti.u32, shape=(n_test, 1024))
    for _ in range(n_rounds):
        data1.fill(0)
        start = time.time()
        test1(n_test)
        print("expand1 time:", time.time() - start)
        data2.fill(0)
        start = time.time()
        test2(n_test)
        print("expand2 time:", time.time() - start)
        data3.fill(0)
        start = time.time()
        test3(n_test)
        print("expand3 time:", time.time() - start)
        assert (data1.to_numpy() == data2.to_numpy()).all()
        assert (data1.to_numpy() == data3.to_numpy()).all()
```

Negligible difference:
expand1 time: 0.01114034652709961
expand2 time: 0.01214289665222168
expand3 time: 0.012060403823852539
expand1 time: 3.123283386230469e-05
expand2 time: 1.7642974853515625e-05
expand3 time: 1.6927719116210938e-05
expand1 time: 1.3589859008789062e-05
expand2 time: 1.2636184692382812e-05
expand3 time: 1.3589859008789062e-05
expand1 time: 1.239776611328125e-05
expand2 time: 1.3113021850585938e-05
expand3 time: 1.1920928955078125e-05
expand1 time: 1.2874603271484375e-05
expand2 time: 6.103515625e-05
expand3 time: 1.3589859008789062e-05
expand1 time: 1.239776611328125e-05
expand2 time: 1.2159347534179688e-05
expand3 time: 1.1920928955078125e-05
expand1 time: 1.2159347534179688e-05
expand2 time: 1.2159347534179688e-05
expand3 time: 1.1920928955078125e-05
expand1 time: 1.1920928955078125e-05
expand2 time: 1.1682510375976562e-05
expand3 time: 1.1920928955078125e-05
expand1 time: 1.6450881958007812e-05
expand2 time: 1.239776611328125e-05
expand3 time: 1.3589859008789062e-05
expand1 time: 1.33514404296875e-05
expand2 time: 1.430511474609375e-05
expand3 time: 1.2636184692382812e-05

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
