### PR TITLE
[MISC] Improve unit test infrastructure.

### DIFF
--- a/tests/test_bvh.py
+++ b/tests/test_bvh.py
@@ -27,6 +27,7 @@ def lbvh():
     return lbvh
 
 
+@pytest.mark.required
 def test_morton_code(lbvh):
     morton_codes = lbvh.morton_codes.to_numpy()
     # Check that the morton codes are sorted
@@ -37,6 +38,7 @@ def test_morton_code(lbvh):
             ), f"Morton codes are not sorted: {morton_codes[i_b, i]} < {morton_codes[i_b, i - 1]}"
 
 
+@pytest.mark.required
 def test_expand_bits():
     """
     Test the expand_bits function for LBVH.
@@ -71,6 +73,7 @@ def test_expand_bits():
         ), f"Expected {str_expanded_x}, got {''.join(f'00{bit}' for bit in str_x)}"
 
 
+@pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
 def test_build_tree(lbvh):
     nodes = lbvh.nodes.to_numpy()
@@ -123,6 +126,7 @@ def query_kernel(lbvh: ti.template(), aabbs: ti.template()):
     lbvh.query(aabbs)
 
 
+@pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
 def test_query(lbvh):
     aabbs = lbvh.aabbs

--- a/tests/test_deformable_physics.py
+++ b/tests/test_deformable_physics.py
@@ -6,6 +6,7 @@ import genesis as gs
 from .utils import assert_allclose
 
 
+@pytest.mark.required
 @pytest.mark.parametrize("muscle_material", [gs.materials.MPM.Muscle, gs.materials.FEM.Muscle])
 @pytest.mark.parametrize("backend", [gs.cpu])
 def test_muscle(muscle_material, show_viewer):
@@ -91,6 +92,7 @@ def test_muscle(muscle_material, show_viewer):
         scene.step()
 
 
+@pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.gpu])
 def test_deformable_parallel(show_viewer):
     scene = gs.Scene(

--- a/tests/test_fem.py
+++ b/tests/test_fem.py
@@ -20,7 +20,8 @@ def fem_material():
     )
 
 
-@pytest.mark.parametrize("backend", [gs.cpu])
+@pytest.mark.required
+@pytest.mark.parametrize("precision", ["64"])
 def test_multiple_fem_entities(fem_material, show_viewer):
     """Test adding multiple FEM entities to the scene"""
     scene = gs.Scene(
@@ -61,7 +62,7 @@ def test_multiple_fem_entities(fem_material, show_viewer):
         scene.step()
 
 
-@pytest.mark.parametrize("backend", [gs.cpu])
+@pytest.mark.required
 def test_interior_tetrahedralized_vertex(fem_material, show_viewer, box_obj_path, cube_verts_and_faces):
     """
     Test tetrahedralization of a FEM entity with a small maxvolume value that introduces
@@ -175,7 +176,7 @@ def test_interior_tetrahedralized_vertex(fem_material, show_viewer, box_obj_path
     )
 
 
-@pytest.mark.parametrize("backend", [gs.cpu])
+@pytest.mark.required
 def test_maxvolume(fem_material, show_viewer, box_obj_path):
     """Test that imposing a maximum element volume constraint produces a finer mesh (i.e., more elements)."""
     scene = gs.Scene(
@@ -206,6 +207,8 @@ def fem_material_linear():
     return gs.materials.FEM.Elastic()
 
 
+# @pytest.mark.required
+@pytest.mark.parametrize("precision", ["64"])
 def test_sphere_box_fall_implicit_fem_coupler(fem_material_linear, show_viewer):
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
@@ -255,6 +258,8 @@ def test_sphere_box_fall_implicit_fem_coupler(fem_material_linear, show_viewer):
         )
 
 
+@pytest.mark.required
+@pytest.mark.parametrize("precision", ["64"])
 def test_sphere_fall_implicit_fem_sap_coupler(fem_material_linear, show_viewer):
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
@@ -301,6 +306,8 @@ def fem_material_linear_corotated():
     return gs.materials.FEM.Elastic(model="linear_corotated")
 
 
+# FIXME: Compilation is crashing on Apple Metal backend
+@pytest.mark.required
 def test_linear_corotated_sphere_fall_implicit_fem_sap_coupler(fem_material_linear_corotated, show_viewer):
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
@@ -357,6 +364,8 @@ def fem_material_linear_corotated_soft():
     return gs.materials.FEM.Elastic(model="linear_corotated", E=1.0e5, nu=0.4)
 
 
+# @pytest.mark.required
+@pytest.mark.parametrize("precision", ["64"])
 def test_fem_sphere_box_self(fem_material_linear_corotated, fem_material_linear_corotated_soft, show_viewer):
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
@@ -410,6 +419,8 @@ def test_fem_sphere_box_self(fem_material_linear_corotated, fem_material_linear_
         )
 
 
+@pytest.mark.required
+@pytest.mark.parametrize("precision", ["64"])
 def test_box_hard_vertex_constraint(show_viewer):
     """
     Test if a box with hard vertex constraints has those vertices fixed,
@@ -486,6 +497,8 @@ def test_box_hard_vertex_constraint(show_viewer):
         )
 
 
+@pytest.mark.required
+@pytest.mark.parametrize("precision", ["64"])
 def test_box_soft_vertex_constraint(show_viewer):
     """Test if a box with strong soft vertex constraints has those vertices near."""
     scene = gs.Scene(
@@ -536,6 +549,8 @@ def test_box_soft_vertex_constraint(show_viewer):
     )
 
 
+# @pytest.mark.required
+@pytest.mark.parametrize("precision", ["64"])
 def test_fem_articulated(fem_material_linear_corotated_soft, show_viewer):
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
@@ -601,6 +616,8 @@ def test_fem_articulated(fem_material_linear_corotated_soft, show_viewer):
     )
 
 
+@pytest.mark.required
+@pytest.mark.parametrize("precision", ["64"])
 def test_implicit_hard_vertex_constraint(fem_material_linear_corotated, show_viewer):
     """
     Test if a box with hard vertex constraints has those vertices fixed, and that updating and removing constraints
@@ -699,6 +716,8 @@ def test_implicit_hard_vertex_constraint(fem_material_linear_corotated, show_vie
     )
 
 
+# @pytest.mark.required
+@pytest.mark.parametrize("precision", ["64"])
 def test_sphere_box_vertex_constraint(fem_material_linear_corotated, show_viewer):
     """
     Test if a box with hard vertex constraints has those vertices fixed, and collisiong with a sphere works correctly.
@@ -786,6 +805,8 @@ def fem_material_linear_corotated_rough():
     return gs.materials.FEM.Elastic(model="linear_corotated", friction_mu=1.0)
 
 
+# @pytest.mark.required
+@pytest.mark.parametrize("precision", ["64"])
 def test_franka_panda_grasp_cube(fem_material_linear_corotated_rough, show_viewer):
     """
     Test if the Franka Panda can successfully grasp the cube.
@@ -876,6 +897,8 @@ def fem_material_linear_corotated_soft_rough():
     return gs.materials.FEM.Elastic(model="linear_corotated", E=1e5, nu=0.4, friction_mu=1.0)
 
 
+# @pytest.mark.required
+@pytest.mark.parametrize("precision", ["64"])
 def test_franka_panda_grasp_soft_sphere(fem_material_linear_corotated_soft_rough, show_viewer):
     """
     Test if the Franka Panda can successfully grasp the soft sphere.

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -6,6 +6,7 @@ import genesis as gs
 from .utils import assert_allclose
 
 
+@pytest.mark.required
 def test_rigid_mpm_muscle(show_viewer):
     ball_pos_init = (0.8, 0.6, 0.12)
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -299,6 +299,7 @@ def test_usd_parse(usd_filename):
         )
 
 
+@pytest.mark.required
 @pytest.mark.skipif(
     sys.version_info[:2] != (3, 10) or sys.platform not in ("linux", "win32"),
     reason="omniverse-kit used by USD Baking cannot be correctly installed on this platform now.",
@@ -306,6 +307,7 @@ def test_usd_parse(usd_filename):
 @pytest.mark.parametrize(
     "usd_file", ["usd/WoodenCrate/WoodenCrate_D1_1002.usda", "usd/franka_mocap_teleop/table_scene.usd"]
 )
+@pytest.mark.parametrize("backend", [gs.cuda])
 def test_usd_bake(usd_file, show_viewer):
     asset_path = get_hf_dataset(pattern=os.path.join(os.path.dirname(usd_file), "*"), local_dir_use_symlinks=False)
     usd_file = os.path.join(asset_path, usd_file)

--- a/tests/test_pbd.py
+++ b/tests/test_pbd.py
@@ -12,7 +12,7 @@ def pbd_material():
     return gs.materials.PBD.Elastic()
 
 
-@pytest.mark.parametrize("backend", [gs.cpu])
+@pytest.mark.required
 def test_maxvolume(pbd_material, show_viewer, box_obj_path):
     """Test that imposing a maximum element volume constraint produces a finer mesh (i.e., more elements)."""
     scene = gs.Scene(

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import torch
 
 import genesis as gs
@@ -7,6 +8,7 @@ from genesis.sensors.imu import IMUOptions
 from .utils import assert_allclose, assert_array_equal
 
 
+@pytest.mark.required
 def test_imu_sensor(show_viewer):
     """Test if the IMU sensor returns the correct data."""
     GRAVITY = -10.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,7 @@ def clear_seen_fixture():
     warnings_mod._seen.clear()
 
 
+@pytest.mark.required
 def test_warn_once_logs_once(clear_seen_fixture):
     msg = "This is a warning"
     with patch.object(gs, "logger", create=True) as mock_logger:
@@ -37,6 +38,7 @@ def test_warn_once_logs_once(clear_seen_fixture):
             mock_warning.assert_called_once_with(msg)
 
 
+@pytest.mark.required
 def test_warn_once_logs_different_messages(clear_seen_fixture):
     msg1 = "Warning 1"
     msg2 = "Warning 2"
@@ -49,6 +51,7 @@ def test_warn_once_logs_different_messages(clear_seen_fixture):
             mock_warning.assert_any_call(msg2)
 
 
+@pytest.mark.required
 def test_warn_once_with_empty_message(clear_seen_fixture):
     with patch.object(gs, "logger", create=True) as mock_logger:
         with patch.object(mock_logger, "warning") as mock_warning:
@@ -105,6 +108,7 @@ def _ti_kernel_wrapper(ti_func, num_inputs, num_outputs):
     return kernel
 
 
+@pytest.mark.required
 @pytest.mark.parametrize("batch_shape", [(10, 40, 25), ()])
 def test_utils_geom_taichi_vs_tensor_consistency(batch_shape):
     import taichi as ti
@@ -160,6 +164,7 @@ def test_utils_geom_taichi_vs_tensor_consistency(batch_shape):
             np.testing.assert_allclose(np_out, tc_out, atol=1e2 * gs.EPS)
 
 
+@pytest.mark.required
 @pytest.mark.parametrize("batch_shape", [(10, 40, 25), ()])
 def test_utils_geom_numpy_vs_tensor_consistency(batch_shape):
     for py_func, shapes_in, shapes_out in (
@@ -192,6 +197,7 @@ def test_utils_geom_numpy_vs_tensor_consistency(batch_shape):
             np.testing.assert_allclose(np_out, tc_out, atol=gs.EPS)
 
 
+@pytest.mark.required
 @pytest.mark.parametrize("batch_shape", [(10, 40, 25), ()])
 def test_utils_geom_taichi_inverse(batch_shape):
     import taichi as ti
@@ -237,6 +243,7 @@ def test_utils_geom_taichi_inverse(batch_shape):
             np.testing.assert_allclose(ti_value_in_arg.to_numpy(), ti_value_inv_out_arg.to_numpy(), atol=1e2 * gs.EPS)
 
 
+@pytest.mark.required
 @pytest.mark.parametrize("batch_shape", [(10, 40, 25), ()])
 def test_utils_geom_taichi_identity(batch_shape):
     import taichi as ti
@@ -262,6 +269,7 @@ def test_utils_geom_taichi_identity(batch_shape):
         np.testing.assert_allclose(ti_args[0].to_numpy(), ti_args[-1].to_numpy(), atol=1e2 * gs.EPS)
 
 
+@pytest.mark.required
 @pytest.mark.parametrize("batch_shape", [(10, 40, 25), ()])
 def test_utils_geom_tensor_identity(batch_shape):
     import taichi as ti


### PR DESCRIPTION
## Description

* Mark all unit tests that take less than 6min to run as required
* Add new mechanism to overwrite the default precision and use it for FEM unit tests

# Motivation

Currently, the production CI is running all the unit tests systematically, but not our small GPU-poor cross-platform runners. The latter only run a minimal set of so-called "required" tests that are considered fast enough (i.e. less than about 360s). This is a good compromise between reliability and cost efficiency. However, many tests that were eligible to this "required" flag were not marked as such by mistake. This is an issue because we are not testing our codebase as extensively as we could.

Besides, FEM tests must run with 64bits precision enabled regardless the backend that is being used, because of numerical instability issues. This PR add a pytest marker to force overwriting the default logic for selecting the precision, i.e. 32bits with running on GPU, 64bits otherwise. Tests will be skipped if 64bits precision is required on Apple Metal GPU because it is not supported. As a reminder, if no backend is explicitly enforced, it will use CPU by default, unless the command line argument `--backend gpu` is specified.