### PR TITLE
[MISC] Re-enable the world-frame in the gs view viewer.

### DIFF
--- a/genesis/_main.py
+++ b/genesis/_main.py
@@ -143,6 +143,7 @@ def view(filename, collision, rotate, scale=1.0, show_link_frame=False):
         ),
         vis_options=gs.options.VisOptions(
             show_link_frame=show_link_frame,
+            show_world_frame=True,
         ),
         show_viewer=True,
     )


### PR DESCRIPTION
## Description

The world frame was disabled in recent change by default. Enabling back for the gs viewer.

## Motivation and Context

The debug window needs coordinate frame.

## How Has This Been / Can This Be Tested?

`gs view <3d asset path>`

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.