### PR TITLE
[FEATURE] Animate cloth by attaching its particles to RigidLinks

### DIFF
--- a/examples/coupling/cloth_on_rigid2.py
+++ b/examples/coupling/cloth_on_rigid2.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import gstaichi as ti
 
 import argparse
@@ -5,10 +7,14 @@ import argparse
 import numpy as np
 from numpy.typing import ArrayLike
 
-
 import genesis as gs
 
-dt: float = 2e-3
+import genesis.utils.geom as gu
+
+if TYPE_CHECKING:
+    from genesis.engine.entities.rigid_entity.rigid_entity import RigidEntity
+
+dt: float = 2e-2
 
 
 def main():
@@ -20,18 +26,21 @@ def main():
     ########################## init ##########################
     gs.init(seed=0, precision="32", logging_level="debug", backend=gs.cpu if args.cpu else gs.gpu)
 
+    particle_size = 1e-2
+
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
             dt=dt,
             substeps=10,
         ),
         pbd_options=gs.options.PBDOptions(
-            particle_size=1e-2,
+            particle_size=particle_size,
         ),
         viewer_options=gs.options.ViewerOptions(
             camera_pos=(3.5, 0.0, 2.5),
             camera_lookat=(0.0, 0.0, 0.5),
             camera_fov=40,
+            max_FPS=50,
         ),
         vis_options=gs.options.VisOptions(
             rendered_envs_idx=[0],
@@ -47,13 +56,11 @@ def main():
         morph=gs.morphs.Plane(),
     )
 
-    cube = scene.add_entity(
+    cube: "RigidEntity" = scene.add_entity(
         material=frictionless_rigid,
         morph=gs.morphs.Box(
-            pos=(0.25, 0.75, 0.2),
-            size=(0.2, 0.2, 0.2),
-            euler=(30, 40, 0),
-            fixed=False,
+            pos=(0.25, 0.25, 0.25),
+            size=(0.25, 0.25, 0.25),
         ),
     )
 
@@ -63,9 +70,8 @@ def main():
         material=gs.materials.PBD.Cloth(),
         morph=gs.morphs.Mesh(
             file="meshes/cloth.obj",
-            scale=1.0,
-            pos=(0.5, 0.5, 0.5),
-            euler=(180.0, 0.0, 0.0),
+            scale=0.5,
+            pos=(0.25, 0.25, 0.25 + 0.125 + particle_size),  # offset by particle size
         ),
         surface=gs.surfaces.Default(
             color=(0.2, 0.4, 0.8, 1.0),
@@ -76,31 +82,26 @@ def main():
     ########################## build ##########################
     scene.build(n_envs=0)
 
-    # scene.pbd_solver.fix_particle(0, 0)
-    # scene.pbd_solver.fix_particle(1, 0)
-    # scene.pbd_solver.fix_particle(2, 0)
-    # scene.pbd_solver.fix_particle(3, 0)
-    # scene.pbd_solver.fix_particle(4, 0)
-    # scene.pbd_solver.fix_particle(5, 0)
-    # scene.pbd_solver.fix_particle(6, 0)
-    # scene.pbd_solver.fix_particle(7, 0)
-
-    # scene.pbd_solver.set_animate_particles_by_link(np.array([0, 1, 2, 3, 4, 5, 6, 7]), cube.links[0].idx, scene.rigid_solver.links_state)
     particles_idx = np.array([0, 1, 2, 3, 4, 5, 6, 7])
-    particles_idx = np.array([0])
     link_idx = cube.links[0].idx
     scene.pbd_solver.set_animate_particles_by_link(particles_idx, link_idx, scene.rigid_solver.links_state)
 
-    horizon = 500
-
+    horizon = 50
     for i in range(horizon):
         scene.step()
 
-        # for i in range(8):
-        #     pos: gs.ti_vec3 =scene.pbd_solver.get_particle_position_ref(i, 0)
-        #     pos_copy = ti.math.vec3(pos)
-        #     pos_copy[2] += 0.5 * dt  # this is a reference !?
-        #     scene.pbd_solver.set_particle_position_vec(i, pos_copy, 0)
+    num_teleports = 5
+    for j in range(num_teleports):
+        if j == num_teleports - 3:
+            scene.pbd_solver.clear_animate_particles_by_link(particles_idx)
+        pos = np.zeros(3)
+        pos[0] = np.sin(j) * 0.2
+        pos[1] = np.cos(j) * 0.2
+        pos[2] = 0.5
+        cube.set_pos(pos)
+        cube.set_quat(gu.euler_to_quat((-30 * j, -40 * j, 70 * j)))
+        for i in range(horizon):
+            scene.step()
 
 
 if __name__ == "__main__":

--- a/examples/coupling/cloth_on_rigid2.py
+++ b/examples/coupling/cloth_on_rigid2.py
@@ -1,0 +1,107 @@
+import gstaichi as ti
+
+import argparse
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+import genesis as gs
+
+dt: float = 2e-3
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--vis", action="store_true", default=False)
+    parser.add_argument("-c", "--cpu", action="store_true", default=False)
+    args = parser.parse_args()
+
+    ########################## init ##########################
+    gs.init(seed=0, precision="32", logging_level="debug", backend=gs.cpu if args.cpu else gs.gpu)
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            dt=dt,
+            substeps=10,
+        ),
+        pbd_options=gs.options.PBDOptions(
+            particle_size=1e-2,
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(3.5, 0.0, 2.5),
+            camera_lookat=(0.0, 0.0, 0.5),
+            camera_fov=40,
+        ),
+        vis_options=gs.options.VisOptions(
+            rendered_envs_idx=[0],
+        ),
+        show_viewer=args.vis,
+    )
+
+    ########################## entities ##########################
+    frictionless_rigid = gs.materials.Rigid(needs_coup=True, coup_friction=0.0)
+
+    plane = scene.add_entity(
+        material=frictionless_rigid,
+        morph=gs.morphs.Plane(),
+    )
+
+    cube = scene.add_entity(
+        material=frictionless_rigid,
+        morph=gs.morphs.Box(
+            pos=(0.25, 0.75, 0.2),
+            size=(0.2, 0.2, 0.2),
+            euler=(30, 40, 0),
+            fixed=False,
+        ),
+    )
+
+    # sphere = scene.add_entity(gs.morphs.Sphere.create((1, 1, 1), 0.5))
+
+    cloth = scene.add_entity(
+        material=gs.materials.PBD.Cloth(),
+        morph=gs.morphs.Mesh(
+            file="meshes/cloth.obj",
+            scale=1.0,
+            pos=(0.5, 0.5, 0.5),
+            euler=(180.0, 0.0, 0.0),
+        ),
+        surface=gs.surfaces.Default(
+            color=(0.2, 0.4, 0.8, 1.0),
+            vis_mode="particle",
+        ),
+    )
+
+    ########################## build ##########################
+    scene.build(n_envs=0)
+
+    # scene.pbd_solver.fix_particle(0, 0)
+    # scene.pbd_solver.fix_particle(1, 0)
+    # scene.pbd_solver.fix_particle(2, 0)
+    # scene.pbd_solver.fix_particle(3, 0)
+    # scene.pbd_solver.fix_particle(4, 0)
+    # scene.pbd_solver.fix_particle(5, 0)
+    # scene.pbd_solver.fix_particle(6, 0)
+    # scene.pbd_solver.fix_particle(7, 0)
+
+    # scene.pbd_solver.set_animate_particles_by_link(np.array([0, 1, 2, 3, 4, 5, 6, 7]), cube.links[0].idx, scene.rigid_solver.links_state)
+    particles_idx = np.array([0, 1, 2, 3, 4, 5, 6, 7])
+    particles_idx = np.array([0])
+    link_idx = cube.links[0].idx
+    scene.pbd_solver.set_animate_particles_by_link(particles_idx, link_idx, scene.rigid_solver.links_state)
+
+    horizon = 500
+
+    for i in range(horizon):
+        scene.step()
+
+        # for i in range(8):
+        #     pos: gs.ti_vec3 =scene.pbd_solver.get_particle_position_ref(i, 0)
+        #     pos_copy = ti.math.vec3(pos)
+        #     pos_copy[2] += 0.5 * dt  # this is a reference !?
+        #     scene.pbd_solver.set_particle_position_vec(i, pos_copy, 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/genesis/engine/couplers/legacy_coupler.py
+++ b/genesis/engine/couplers/legacy_coupler.py
@@ -8,6 +8,8 @@ import genesis.utils.sdf_decomp as sdf_decomp
 
 from genesis.options.solvers import LegacyCouplerOptions
 from genesis.repr_base import RBC
+from genesis.utils.array_class import LinksState
+from genesis.utils.geom import ti_inv_transform_by_trans_quat, ti_transform_by_trans_quat
 
 if TYPE_CHECKING:
     from genesis.engine.simulator import Simulator
@@ -592,6 +594,77 @@ class LegacyCoupler(RBC):
                             i_b,
                         )
 
+    @ti.kernel
+    def kernel_pbd_rigid_set_animate_particles_by_link(
+        self,
+        particles_idx: ti.types.ndarray(),  # 1d array
+        link_idx: ti.i32,
+        links_state: LinksState,
+        envs_idx: ti.types.ndarray(),  # 1d array
+    ) -> None:
+        """
+        Sets listed particles in listed environments to be animated by the link.
+
+        Current position of the particle, relatively to the link, is stored and preserved.
+        """
+        pdb = self.pbd_solver
+        for i_env_ in range(envs_idx.shape[0]):
+            i_env = envs_idx[i_env_]
+            link_pos = links_state.pos[link_idx, i_env]
+            link_quat = links_state.quat[link_idx, i_env]
+
+            for i_p_ in range(particles_idx.shape[0]):
+                i_p = particles_idx[i_p_]
+
+                # compute local offset from link to the particle
+                world_pos = pdb.particles[i_p, i_env].pos
+                local_pos = ti_inv_transform_by_trans_quat(world_pos, link_pos, link_quat)
+
+                # set particle to be animated (not free) and store animation info
+                pdb.particles[i_p, i_env].free = ti.int32(0)  # optional
+                pdb.particle_animation_info[i_p, i_env].link_idx = link_idx
+                pdb.particle_animation_info[i_p, i_env].local_pos = local_pos
+
+    @ti.kernel
+    def kernel_pbd_rigid_solve_animate_particles_by_link(self, clamped_inv_dt: ti.f32, links_state: LinksState):
+        """
+        Itearates all particles and environments, and sets corrective velocity for all animated particle.
+
+        Computes target position and velocity from the attachment/reference link and local offset position.
+
+        Note, that this step shoudl be done after rigid solver update, and before PDB solver update.
+        Currently, this is done after both rigid and PBD solver updates, hence the corrective velocity
+        is off by a frame.
+
+        Note, it's adviced to clamp inv_dt to avoid large jerks and instability. 1/0.02 might be a good max value.
+        """
+        pdb = self.pbd_solver
+        for i_p, i_env in ti.ndrange(pdb._n_particles, pdb._B):
+            if pdb.particle_animation_info[i_p, i_env].link_idx >= 0:
+
+                # read link state
+                link_idx = pdb.particle_animation_info[i_p, i_env].link_idx
+                link_pos = links_state.pos[link_idx, i_env]
+                link_quat = links_state.quat[link_idx, i_env]
+
+                link_lin_vel = links_state.cd_vel[link_idx, i_env]
+                link_ang_vel = links_state.cd_ang[link_idx, i_env]
+                link_com_in_world = links_state.COM[link_idx, i_env]
+
+                # calculate target pos and vel of the particle
+                local_pos = pdb.particle_animation_info[i_p, i_env].local_pos
+                target_world_pos = ti_transform_by_trans_quat(local_pos, link_pos, link_quat)
+
+                world_arm = target_world_pos - link_com_in_world
+                target_world_vel = link_lin_vel + link_ang_vel.cross(world_arm)
+
+                # compute and apply corrective velocity
+                i_rp = pdb.particles_ng[i_p, i_env].reordered_idx
+                particle_pos = pdb.particles_reordered[i_rp, i_env].pos
+                pos_correction = target_world_pos - particle_pos
+                corrective_vel = pos_correction * clamped_inv_dt
+                pdb.particles_reordered[i_rp, i_env].vel = corrective_vel + target_world_vel
+
     @ti.func
     def _func_pbd_collide_with_rigid_geom(self, i, pos, vel, mass, normal_prev, geom_idx, batch_idx):
         """
@@ -674,17 +747,12 @@ class LegacyCoupler(RBC):
 
         # PBD <-> Rigid
         if self._rigid_pbd and self.rigid_solver.is_active():
-            # 2-way collision coupling
             self.kernel_pbd_rigid_collide()
 
-            # 1-way particle to link coupling
-            self.pbd_solver.kernel_pbd_rigid_animate_particles_to_links(self.rigid_solver.links_state)
-
-            # Setting particle velocities and positions here has not effect, why?
-            #
-            # full_step_inv_dt = 1.0 / self.pbd_solver._dt
-            # clamped_inv_dt = min(full_step_inv_dt, 50.0)
-            # self.pbd_solver.kernel_pbd_rigid_solve_animate_particles_by_link(clamped_inv_dt)
+            # 1-way: animate particles by links
+            full_step_inv_dt = 1.0 / self.pbd_solver._dt
+            clamped_inv_dt = min(full_step_inv_dt, 50.0)
+            self.kernel_pbd_rigid_solve_animate_particles_by_link(clamped_inv_dt, self.rigid_solver.links_state)
 
         if self.fem_solver.is_active():
             self.fem_surface_force(f)

--- a/genesis/engine/couplers/legacy_coupler.py
+++ b/genesis/engine/couplers/legacy_coupler.py
@@ -626,6 +626,24 @@ class LegacyCoupler(RBC):
                 pdb.particle_animation_info[i_p, i_env].local_pos = local_pos
 
     @ti.kernel
+    def kernel_pbd_rigid_clear_animate_particles_by_link(
+        self,
+        particles_idx: ti.types.ndarray(),  # 1d array
+        envs_idx: ti.types.ndarray(),  # 1d array
+    ) -> None:
+        """Detach listed particles from links, and simulate them freely."""
+        pdb = self.pbd_solver
+        for i_env_ in range(envs_idx.shape[0]):
+            i_env = envs_idx[i_env_]
+
+            for i_p_ in range(particles_idx.shape[0]):
+                i_p = particles_idx[i_p_]
+
+                pdb.particles[i_p, i_env].free = ti.int32(1)
+                pdb.particle_animation_info[i_p, i_env].link_idx = -1
+                pdb.particle_animation_info[i_p, i_env].local_pos = ti.math.vec3([0.0, 0.0, 0.0])
+
+    @ti.kernel
     def kernel_pbd_rigid_solve_animate_particles_by_link(self, clamped_inv_dt: ti.f32, links_state: LinksState):
         """
         Itearates all particles and environments, and sets corrective velocity for all animated particle.

--- a/genesis/engine/entities/base_entity.py
+++ b/genesis/engine/entities/base_entity.py
@@ -1,7 +1,12 @@
+from typing import TYPE_CHECKING
+
 import gstaichi as ti
 
 import genesis as gs
 from genesis.repr_base import RBC
+
+if TYPE_CHECKING:
+    from genesis.engine.scene import Scene
 
 
 @ti.data_oriented
@@ -21,7 +26,7 @@ class Entity(RBC):
     ):
         self._uid = gs.UID()
         self._idx = idx
-        self._scene = scene
+        self._scene: "Scene" = scene
         self._solver = solver
         self._material = material
         self._morph = morph

--- a/genesis/engine/solvers/pbd_solver.py
+++ b/genesis/engine/solvers/pbd_solver.py
@@ -15,7 +15,7 @@ from genesis.engine.entities import (
 )
 from genesis.engine.states.solvers import PBDSolverState
 from genesis.utils.array_class import LinksState
-from genesis.utils.geom import SpatialHasher, ti_inv_transform_by_trans_quat, ti_transform_by_trans_quat
+from genesis.utils.geom import SpatialHasher
 
 from .base_solver import Solver
 
@@ -36,14 +36,10 @@ class PBDSolver(Solver):
     class ParticleAnimateByLinkInfo:
         """
         Index to and offset from the RigidLink that keyframe-animates this particle.
-
-        And temporary target position and velocity, used for corrective velocity calculation during solving.
         """
 
         link_idx: ti.i32  # not available, possibly due to circular improt: gs.ti_int
         local_pos: ti.math.vec3  # uncomprehendalbe error: gs.ti_vec3
-        target_world_pos: ti.math.vec3
-        target_world_vel: ti.math.vec3
 
     def __init__(self, scene, sim, options):
         super().__init__(scene, sim, options)
@@ -812,11 +808,6 @@ class PBDSolver(Solver):
             # boundary collision
             self._kernel_solve_boundary_collision(f)
 
-            # animate particles by links
-            full_step_inv_dt = 1.0 / self._dt
-            clamped_inv_dt = min(full_step_inv_dt, 50.0)
-            self.kernel_pbd_rigid_solve_animate_particles_by_link(clamped_inv_dt)
-
     def substep_post_coupling_grad(self, f):
         pass
 
@@ -986,93 +977,9 @@ class PBDSolver(Solver):
         envs_idx: NDArray[np.int32] | None = None,
     ) -> None:
         envs_idx: torch.Tensor = self._scene._sanitize_envs_idx(envs_idx)
-        self._kernel_set_animate_particles_by_link(particles_idx, link_idx, links_state, envs_idx)
-
-    @ti.kernel
-    def _kernel_set_animate_particles_by_link(
-        self,
-        particles_idx: ti.types.ndarray(),  # 1d array
-        link_idx: ti.i32,
-        links_state: LinksState,
-        envs_idx: ti.types.ndarray(),  # 1d array
-    ) -> None:
-        """
-        Sets listed particles in listed environments to be animated by the link.
-
-        Current position of the particle, relatively to the link, is stored and preserved.
-        """
-        for i_env_ in range(envs_idx.shape[0]):
-            i_env = envs_idx[i_env_]
-            link_pos = links_state.pos[link_idx, i_env]
-            link_quat = links_state.quat[link_idx, i_env]
-
-            for i_p_ in range(particles_idx.shape[0]):
-                i_p = particles_idx[i_p_]
-
-                # compute local offset from link to the particle
-                world_pos = self.particles[i_p, i_env].pos
-                local_pos = ti_inv_transform_by_trans_quat(world_pos, link_pos, link_quat)
-
-                # set particle to be animated (not free) and store animation info
-                self.particles[i_p, i_env].free = ti.int32(0)  # optional
-                self.particle_animation_info[i_p, i_env].link_idx = link_idx
-                self.particle_animation_info[i_p, i_env].local_pos = local_pos
-
-    @ti.kernel
-    def kernel_pbd_rigid_animate_particles_to_links(self, links_state: LinksState):
-        """
-        Itearates all particles and environments, and computes target position and velocity for animated particles.
-        """
-        # Warning: when link & particle mass are comparable, you'll need to run particle loop in series,
-        # and only parallelize across environments. Additionally, we'd need to
-        for i_p, i_env in ti.ndrange(self._n_particles, self._B):
-            if self.particle_animation_info[i_p, i_env].link_idx >= 0:
-                # read link state
-                link_idx = self.particle_animation_info[i_p, i_env].link_idx
-                link_pos = links_state.pos[link_idx, i_env]
-                link_quat = links_state.quat[link_idx, i_env]
-
-                # update target pos
-                local_pos = self.particle_animation_info[i_p, i_env].local_pos
-                world_pos = ti_transform_by_trans_quat(local_pos, link_pos, link_quat)
-
-                self.particle_animation_info[i_p, i_env].target_world_pos = world_pos
-
-                # read link state
-                link_lin_vel = links_state.cd_vel[link_idx, i_env]
-                link_ang_vel = links_state.cd_ang[link_idx, i_env]
-                link_com_in_world = links_state.COM[link_idx, i_env]
-
-                # update target vel
-                world_arm = world_pos - link_com_in_world
-                world_vel = link_lin_vel + link_ang_vel.cross(world_arm)
-
-                self.particle_animation_info[i_p, i_env].target_world_vel = world_vel
-
-    @ti.kernel
-    def kernel_pbd_rigid_solve_animate_particles_by_link(self, clamped_inv_dt: ti.f32):
-        """
-        Sets corrective velocity for all animated particle.
-
-        Note, that this step shoudl be done after rigid solver update, and before PDB solver update.
-        Currently, this is done after both rigid and PBD solver updates, hence the corrective velocity
-        is off by a frame.
-
-        Note, it's adviced to clamp inv_dt to avoid large jerks and instability. 1/0.02 might be a good max value.
-        """
-        for i_p, i_env in ti.ndrange(self._n_particles, self._B):
-            if self.particle_animation_info[i_p, i_env].link_idx >= 0:
-
-                # read current and target positions and velocity
-                particle_pos = self.particles[i_p, i_env].pos
-                target_pos = self.particle_animation_info[i_p, i_env].target_world_pos
-                target_vel = self.particle_animation_info[i_p, i_env].target_world_vel
-
-                # compute and apply corrective velocity
-                pos_correction = target_pos - particle_pos
-                corrective_vel = pos_correction * clamped_inv_dt
-                self.particles[i_p, i_env].vel = corrective_vel + target_vel
-                self.particles[i_p, i_env].pos = target_pos
+        self._sim._coupler.kernel_pbd_rigid_set_animate_particles_by_link(
+            particles_idx, link_idx, links_state, envs_idx
+        )
 
     @gs.assert_built
     def release_particle(self, particle_idx, i_b):

--- a/genesis/engine/solvers/pbd_solver.py
+++ b/genesis/engine/solvers/pbd_solver.py
@@ -38,8 +38,8 @@ class PBDSolver(Solver):
         Index to and offset from the RigidLink that keyframe-animates this particle.
         """
 
-        link_idx: ti.i32  # not available, possibly due to circular improt: gs.ti_int
-        local_pos: ti.math.vec3  # uncomprehendalbe error: gs.ti_vec3
+        link_idx: ti.i32  # gs.ti_int not available before gs.init()
+        local_pos: ti.math.vec3  # gs.ti_vec3 causes uncomprehensible error !!
 
     def __init__(self, scene, sim, options):
         super().__init__(scene, sim, options)
@@ -969,6 +969,7 @@ class PBDSolver(Solver):
             self.particles[particle_idx, i_b].vel[i] = vel[i]
         self.particles[particle_idx, i_b].free = 0
 
+    @gs.assert_built
     def set_animate_particles_by_link(
         self,
         particles_idx: NDArray[np.int32],
@@ -980,6 +981,15 @@ class PBDSolver(Solver):
         self._sim._coupler.kernel_pbd_rigid_set_animate_particles_by_link(
             particles_idx, link_idx, links_state, envs_idx
         )
+
+    @gs.assert_built
+    def clear_animate_particles_by_link(
+        self,
+        particles_idx: NDArray[np.int32],
+        envs_idx: NDArray[np.int32] | None = None,
+    ) -> None:
+        envs_idx: torch.Tensor = self._scene._sanitize_envs_idx(envs_idx)
+        self._sim._coupler.kernel_pbd_rigid_clear_animate_particles_by_link(particles_idx, envs_idx)
 
     @gs.assert_built
     def release_particle(self, particle_idx, i_b):


### PR DESCRIPTION
## Description
* attach (animate) cloth by rigid links
  * rigid link is not affected by cloth's mass
* detaching cloth sometimes causes the cloth to disappear. This has not been debugged yet.
* attachment force is clipped to avoid super-high corrective velocities at smaller time steps (via clamped_inv_dt in LegacyCoupler)

## Known issues
* this is one-way interaction, while cloth-link collisions are two-way interactions, hence unrealistic spinning or explosion can occur if the particles are attached in an overlapping/colliding configuration
  * when attaching cloth to a robot, this may cause unexpected forces on joints

## How Has This Been / Can This Be Tested?
Manual/visual testing only, with the attached demo that teleports the body around.

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/47c14bf5-5189-49df-b9f3-ed3e199f3caa



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
