### PR TITLE
[BUG FIX, CHANGING] Fix primitive and mesh's COM. Add 'ref' optional argument to 'get_links_pos'.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@
     - [BUG FIX] for non-breaking changes which fix an issue
     - [FEATURE] for non-breaking changes which add functionality
     - [MISC] for minor changes such as improved inline documentation or fixing typos
+    - [CHANGING] for changes that will change simulation's behaviour
     - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
 -->
 

--- a/genesis/engine/couplers/sap_coupler.py
+++ b/genesis/engine/couplers/sap_coupler.py
@@ -1980,7 +1980,7 @@ class RigidContactHandler(BaseContactHandler):
                     cdof_vel = self.rigid_solver.dofs_state.cdof_vel[i_d, i_b]
 
                     t_quat = gu.ti_identity_quat()
-                    t_pos = self.contact_pairs[i_p].contact_pos - self.rigid_solver.links_state.COM[link, i_b]
+                    t_pos = self.contact_pairs[i_p].contact_pos - self.rigid_solver.links_state.root_COM[link, i_b]
                     _, vel = gu.ti_transform_motion_by_trans_quat(cdof_ang, cdof_vel, t_pos, t_quat)
 
                     diff = vel

--- a/genesis/engine/entities/hybrid_entity.py
+++ b/genesis/engine/entities/hybrid_entity.py
@@ -432,7 +432,7 @@ class HybridEntity(Entity):
                 mass_real = self._solver_soft.particles_info[i_global].mass / self._solver_soft._p_vol_scale
                 acc = vel_d / dt_for_rigid_acc
                 frc_vel = mass_real * acc
-                frc_ang = (x_pos - self._solver_rigid.links_state.COM[link_idx, i_b]).cross(frc_vel)
+                frc_ang = (x_pos - self._solver_rigid.links_state.root_COM[link_idx, i_b]).cross(frc_vel)
                 self._solver_rigid.links_state.cfrc_applied_vel[link_idx, i_b] += frc_vel
                 self._solver_rigid.links_state.cfrc_applied_ang[link_idx, i_b] += frc_ang
 

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1628,9 +1628,16 @@ class RigidEntity(Entity):
         return self._solver.get_links_ang(self._base_links_idx, envs_idx, unsafe=unsafe).squeeze(-2)
 
     @gs.assert_built
-    def get_links_pos(self, links_idx_local=None, envs_idx=None, *, unsafe=False):
+    def get_links_pos(
+        self,
+        links_idx_local=None,
+        envs_idx=None,
+        *,
+        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        unsafe=False,
+    ):
         """
-        Returns position of all the entity's links.
+        Returns the position of a given reference point for all the entity's links.
 
         Parameters
         ----------
@@ -1638,6 +1645,11 @@ class RigidEntity(Entity):
             The indices of the links. Defaults to None.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
+        ref: "link_origin" | "link_com" | "root_com"
+            The reference point being used to express the position of each link.
+            * "root_com": center of mass of the sub-entities to which the link belongs. As a reminder, a single
+              kinematic tree (aka. 'RigidEntity') may compromise multiple "physical" entities, i.e. a kinematic tree
+              that may have at most one free joint, at its root.
 
         Returns
         -------
@@ -1645,7 +1657,7 @@ class RigidEntity(Entity):
             The position of all the entity's links.
         """
         links_idx = self._get_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
-        return self._solver.get_links_pos(links_idx, envs_idx, unsafe=unsafe)
+        return self._solver.get_links_pos(links_idx, envs_idx, ref=ref, unsafe=unsafe)
 
     @gs.assert_built
     def get_links_quat(self, links_idx_local=None, envs_idx=None, *, unsafe=False):

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -191,7 +191,7 @@ class RigidEntity(Entity):
                 name=f"{link_name_prefix}_baselink",
                 pos=np.array(morph.pos),
                 quat=np.array(morph.quat),
-                inertial_pos=gu.zero_pos(),
+                inertial_pos=None,  # we will compute the COM later based on the geometry
                 inertial_quat=gu.identity_quat(),
                 parent_idx=-1,
             ),
@@ -263,7 +263,7 @@ class RigidEntity(Entity):
                 name=f"{link_name}_baselink",
                 pos=np.array(morph.pos),
                 quat=np.array(morph.quat),
-                inertial_pos=gu.zero_pos(),
+                inertial_pos=None,  # we will compute the COM later based on the geometry
                 inertial_quat=gu.identity_quat(),
                 parent_idx=-1,
             ),

--- a/genesis/engine/solvers/rigid/constraint_solver_decomp.py
+++ b/genesis/engine/solvers/rigid/constraint_solver_decomp.py
@@ -504,7 +504,7 @@ def add_collision_constraints(
                             cdot_vel = dofs_state.cdof_vel[i_d, i_b]
 
                             t_quat = gu.ti_identity_quat()
-                            t_pos = contact_data_pos - links_state.COM[link, i_b]
+                            t_pos = contact_data_pos - links_state.root_COM[link, i_b]
                             _, vel = gu.ti_transform_motion_by_trans_quat(cdof_ang, cdot_vel, t_pos, t_quat)
 
                             diff = sign * vel
@@ -613,7 +613,7 @@ def func_equality_connect(
                     cdot_vel = dofs_state.cdof_vel[i_d, i_b]
 
                     t_quat = gu.ti_identity_quat()
-                    t_pos = pos - links_state.COM[link, i_b]
+                    t_pos = pos - links_state.root_COM[link, i_b]
                     ang, vel = gu.ti_transform_motion_by_trans_quat(cdof_ang, cdot_vel, t_pos, t_quat)
 
                     diff = sign * vel
@@ -887,7 +887,7 @@ def func_equality_weld(
                     cdot_vel = dofs_state.cdof_vel[i_d, i_b]
 
                     t_quat = gu.ti_identity_quat()
-                    t_pos = pos_anchor - links_state.COM[link, i_b]
+                    t_pos = pos_anchor - links_state.root_COM[link, i_b]
                     ang, vel = gu.ti_transform_motion_by_trans_quat(cdof_ang, cdot_vel, t_pos, t_quat)
                     diff = sign * vel
                     jac = diff[i]

--- a/genesis/engine/solvers/rigid/constraint_solver_decomp_island.py
+++ b/genesis/engine/solvers/rigid/constraint_solver_decomp_island.py
@@ -191,7 +191,7 @@ class ConstraintSolverIsland:
 
                             t_quat = gu.ti_identity_quat()
                             contact_pos = self._collider._collider_state.contact_data.pos[i_col, i_b]
-                            t_pos = contact_pos - self._solver.links_state.COM[link, i_b]
+                            t_pos = contact_pos - self._solver.links_state.root_COM[link, i_b]
                             _, vel = gu.ti_transform_motion_by_trans_quat(cdof_ang, cdot_vel, t_pos, t_quat)
 
                             diff = sign * vel

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -1301,7 +1301,7 @@ class StructLinksState:
     cd_ang: V_ANNOTATION
     cd_vel: V_ANNOTATION
     mass_sum: V_ANNOTATION
-    COM: V_ANNOTATION
+    root_COM: V_ANNOTATION  # COM of the kinematic tree
     mass_shift: V_ANNOTATION
     i_pos_shift: V_ANNOTATION
     cacc_ang: V_ANNOTATION
@@ -1338,7 +1338,7 @@ def get_links_state(solver):
         "cd_ang": V(dtype=gs.ti_vec3, shape=shape),
         "cd_vel": V(dtype=gs.ti_vec3, shape=shape),
         "mass_sum": V(dtype=gs.ti_float, shape=shape),
-        "COM": V(dtype=gs.ti_vec3, shape=shape),
+        "root_COM": V(dtype=gs.ti_vec3, shape=shape),
         "mass_shift": V(dtype=gs.ti_float, shape=shape),
         "i_pos_shift": V(dtype=gs.ti_vec3, shape=shape),
         "cacc_ang": V(dtype=gs.ti_vec3, shape=shape),

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2858,6 +2858,7 @@ def test_contype_conaffinity(show_viewer, tol):
     assert_allclose(box3.get_pos(), np.array([0.0, 0.0, 0.75]), atol=1e-3)
 
 
+@pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.cpu])
 def test_mesh_primitive_COM(show_viewer, tol):
     scene = gs.Scene(
@@ -2895,6 +2896,11 @@ def test_mesh_primitive_COM(show_viewer, tol):
     cube_z = link_COM[2, 2]
     root_bunny_z = root_COM[1, 2]
     root_cube_z = root_COM[2, 2]
+
+    assert_allclose(bunny_z, bunny.get_links_pos(links_idx_local=[0], ref="link_com")[0, 2], atol=gs.EPS)
+    assert_allclose(cube_z, cube.get_links_pos(links_idx_local=[0], ref="link_com")[0, 2], atol=gs.EPS)
+    assert_allclose(root_bunny_z, bunny.get_links_pos(links_idx_local=[0], ref="root_com")[0, 2], atol=gs.EPS)
+    assert_allclose(root_cube_z, cube.get_links_pos(links_idx_local=[0], ref="root_com")[0, 2], atol=gs.EPS)
 
     # in the old (wrong) code, their initial COM are (0,0,0)
     # but now their z are above the plane

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -930,7 +930,7 @@ def check_mujoco_data_consistency(
 
     # ------------------------------------------------------------------------
 
-    gs_com = gs_sim.rigid_solver.links_state.COM.to_numpy()[:, 0]
+    gs_com = gs_sim.rigid_solver.links_state.root_COM.to_numpy()[:, 0]
     gs_root_idx = np.unique(gs_sim.rigid_solver.links_info.root_idx.to_numpy()[gs_bodies_idx])
     mj_com = mj_sim.data.subtree_com
     mj_root_idx = np.unique(mj_sim.model.body_rootid[mj_bodies_idx])


### PR DESCRIPTION
## Description

* Fix primitive and mesh's COM
* Change low-level COM's name from `COM` to `root_COM` for clarity
* Add 'ref' option for 'get_links_pos' matching 'get_links_vel' public API.

Here are the simulation videos before and after the change

https://github.com/user-attachments/assets/eb011e6c-beb9-485a-90f3-5e33fa49d281

https://github.com/user-attachments/assets/a30773f1-92cb-4fa6-98a3-025b9e9cca63

## Motivation and Context

- The initial COM for primitive and meshs are (0,0,0). We should set them to None and compute the inertial_pos based on their geometry
- The COM variable is used to represent root_COM, which is confusing. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
