### PR TITLE
[BUG FIX] Remove access to gstaichi internal attributes, which violates encapsulation

### DIFF
--- a/genesis/utils/misc.py
+++ b/genesis/utils/misc.py
@@ -422,12 +422,8 @@ def _launch_kernel(self, t_kernel, *args):
 
 
 _to_pytorch_type_fast = functools.lru_cache(maxsize=None)(to_pytorch_type)
-_tensor_to_ext_arr_fast = ti.kernel(tensor_to_ext_arr._primal.func)
-_tensor_to_ext_arr_fast._primal.launch_kernel = types.MethodType(_launch_kernel, _tensor_to_ext_arr_fast._primal)
-_tensor_to_ext_arr_fast._primal.ensure_compiled = types.MethodType(_ensure_compiled, _tensor_to_ext_arr_fast._primal)
-_matrix_to_ext_arr_fast = ti.kernel(matrix_to_ext_arr._primal.func)
-_matrix_to_ext_arr_fast._primal.launch_kernel = types.MethodType(_launch_kernel, _matrix_to_ext_arr_fast._primal)
-_matrix_to_ext_arr_fast._primal.ensure_compiled = types.MethodType(_ensure_compiled, _matrix_to_ext_arr_fast._primal)
+_tensor_to_ext_arr_fast = tensor_to_ext_arr
+_matrix_to_ext_arr_fast = matrix_to_ext_arr
 
 
 def ti_field_to_torch(


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->

Remove access to gstaichi internal attributes, which violates encapsulation, and causes test failures.

To reproduce the test failures:
- install dev branch of gstaichi, which fixes a gstaichi src-ll-cache bug, https://github.com/Genesis-Embodied-AI/gstaichi/pull/159
- run:
```
pytest -s -v tests/test_rigid_physics.py::test_walker[cpu-False-implicitfast-CG-xml/walker.xml] -x
```
=> will crash with:
```
(genesis) system ~/git/Genesis (main|✔) $ pytest -s -v tests/test_rigid_physics.py::test_walker[cpu-False-implicitfast-CG-xml/walker.xml] -x
DEPRECATION WARNING: The system version of Tk is deprecated and may be removed in a future release. Please don't rely on it. Set TK_SILENCE_DEPRECATION=1 to suppress this warning.
=============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.10.16, pytest-8.3.5, pluggy-1.5.0 -- /Users/hugh/.pyenv/versions/3.10.16/envs/genesis/bin/python
cachedir: .pytest_cache
Using --random-order-bucket=global
Using --random-order-seed=0

rootdir: /Users/hugh/git/Genesis
configfile: pyproject.toml
plugins: anyio-4.9.0, syrupy-4.9.1, random-order-1.1.1, rerunfailures-15.1, print-1.1.0, forked-1.6.0, xdist-3.6.1
10 workers [1 item]
scheduling tests via WorkStealingScheduling

tests/test_rigid_physics.py::test_walker[cpu-False-implicitfast-CG-xml/walker.xml]
[gw9] FAILED tests/test_rigid_physics.py::test_walker[cpu-False-implicitfast-CG-xml/walker.xml]

==================================================================================== FAILURES =====================================================================================
______________________________________________________________ test_walker[cpu-False-implicitfast-CG-xml/walker.xml] ______________________________________________________________
[gw9] darwin -- Python 3.10.16 /Users/hugh/.pyenv/versions/3.10.16/envs/genesis/bin/python

gs_sim = ──────────────────── <gs.Simulator> ────────────────────
        'n_entitie...>: 1
    'substeps_local': <int>: 1

mj_sim = MjSim(model=<mujoco._structs.MjModel object at 0x14cda3530>, data=<mujoco._structs.MjData object at 0x14c675f70>), gjk_collision = False, tol = 1e-09

    @pytest.mark.required
    @pytest.mark.multi_contact(False)
    @pytest.mark.parametrize("xml_path", ["xml/walker.xml"])
    @pytest.mark.parametrize(
        "gs_solver",
        [
            gs.constraint_solver.CG,
            # gs.constraint_solver.Newton,  # FIXME: This test is not passing because collision detection is too sensitive
        ],
    )
    @pytest.mark.parametrize("gs_integrator", [gs.integrator.implicitfast, gs.integrator.Euler])
    @pytest.mark.parametrize("gjk_collision", [True, False])
    @pytest.mark.parametrize("backend", [gs.cpu])
    def test_walker(gs_sim, mj_sim, gjk_collision, tol):
        # Force numpy seed because this test is very sensitive to the initial condition
        np.random.seed(0)
        (gs_robot,) = gs_sim.entities
        qpos = np.zeros((gs_robot.n_qs,))
        qpos[2] += 0.5
        qvel = np.random.rand(gs_robot.n_dofs) * 0.2

        # Cannot simulate any longer because collision detection is very sensitive
>       simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos, qvel, num_steps=1, tol=tol)

tests/test_rigid_physics.py:434:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/utils.py:993: in simulate_and_check_mujoco_consistency
    check_mujoco_model_consistency(gs_sim, mj_sim, tol=tol)
tests/utils.py:710: in check_mujoco_model_consistency
    gs_joint_solparams = np.array([joint.sol_params.cpu() for entity in gs_sim.entities for joint in entity.joints])
tests/utils.py:710: in <listcomp>
    gs_joint_solparams = np.array([joint.sol_params.cpu() for entity in gs_sim.entities for joint in entity.joints])
../taichi/python/gstaichi/lang/kernel_impl.py:1332: in _getattr
    return x(self)
genesis/engine/entities/rigid_entity/rigid_joint.py:152: in sol_params
    return self._solver.get_sol_params(joints_idx=self._idx, envs_idx=None, unsafe=True)[..., 0, :]
genesis/engine/solvers/rigid/rigid_solver_decomp.py:2055: in get_sol_params
    tensor = ti_field_to_torch(self.joints_info.sol_params, envs_idx, joints_idx, transpose=True, unsafe=unsafe)
genesis/utils/misc.py:532: in ti_field_to_torch
    _matrix_to_ext_arr_fast(field, out, as_vector)
../taichi/python/gstaichi/lang/kernel_impl.py:160: in __call__
    return self.wrapper.__call__(*args, **kwargs)
../taichi/python/gstaichi/lang/kernel_impl.py:1204: in wrapped_func
    return primal(*args, **kwargs)
../taichi/python/gstaichi/lang/kernel_impl.py:1132: in __call__
    return self.launch_kernel(kernel_cpp, compiled_kernel_data, *args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <gstaichi.lang.kernel_impl.Kernel object at 0x11fd158a0>, t_kernel = <gstaichi._lib.core.gstaichi_python.KernelCxx object at 0x1733facb0>
args = (None, <7x1 ti.Matrix.field>, tensor([[0., 0., 0., 0., 0., 0., 0.],
        [0., 0., 0., 0., 0., 0., 0.],
        [0.,...      [0., 0., 0., 0., 0., 0., 0.],
        [0., 0., 0., 0., 0., 0., 0.],
        [0., 0., 0., 0., 0., 0., 0.]]), True)
launch_ctx = <gstaichi._lib.core.gstaichi_python.KernelLaunchContext object at 0x14cdb65b0>, template_num = 1, i = 1

    def _launch_kernel(self, t_kernel, *args):
        launch_ctx = t_kernel.make_launch_context()

        template_num = 0
        for i, v in enumerate(args):
            needed = self.arg_metas[i].annotation
            if isinstance(needed, ti.template):
                template_num += 1
                continue

            array_shape = v.shape
            if needed.dtype is None or id(needed.dtype) in primitive_types.type_ids:
                element_dim = 0
            else:
                is_soa = needed.layout == ti.Layout.SOA
                element_dim = needed.dtype.ndim
                array_shape = v.shape[element_dim:] if is_soa else v.shape[:-element_dim]

>           if v.requires_grad and v.grad is None:
E           AttributeError: 'MatrixField' object has no attribute 'requires_grad'

genesis/utils/misc.py:394: AttributeError
------------------------------------------------------------------------------- Captured log setup --------------------------------------------------------------------------------
INFO     genesis:logger.py:127 ~<╭───────────────────────────────────────────────╮>~
INFO     genesis:logger.py:127 ~<│┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈>~ ~~~~<Genesis>~~~~ ~<┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈│>~
INFO     genesis:logger.py:127 ~<╰───────────────────────────────────────────────╯>~
INFO     genesis:logger.py:127 Consider setting 'performance_mode=True' in production to maximise runtime speed, if significantly increasing compilation time is not a concern.
INFO     genesis:logger.py:127 Running on ~~<[Apple M4]>~~ with backend ~~<gs.cpu>~~. Device memory: ~~<32.00>~~ GB.
INFO     genesis:logger.py:127 🚀 Genesis initialized. 🔖 version: ~~<0.3.1>~~, 🌱 seed: ~~<0>~~, 📏 precision: '~~<64>~~', 🐛 debug: ~~<False>~~, 🎨 theme: '~~<dark>~~'.
WARNING  genesis:logger.py:131 Scene.show_FPS is deprecated. Please use Scene.profiling_options.show_FPS
INFO     genesis:logger.py:127 Scene ~~~<<122cfd1>>~~~ created.
INFO     genesis:logger.py:127 Adding ~<<gs.RigidEntity>>~. idx: ~<0>~, uid: ~~~<<b8e3fa1>>~~~, morph: ~<<gs.morphs.MJCF(file='/Users/hugh/git/Genesis/genesis/assets/xml/walker.xml')>>~, material: ~<<gs.materials.Rigid>>~.
INFO     genesis:logger.py:127 Collision meshes are not visualized by default. To visualize them, please use `vis_mode='collision'` when calling `scene.add_entity`.
INFO     genesis:logger.py:127 Applying offset to base link's pose with user provided value in morph.
INFO     genesis:logger.py:127 Building scene ~~~<<122cfd1>>~~~...
INFO     genesis:logger.py:127 Compiling simulation kernels...
INFO     genesis:logger.py:127 Building visualizer...
------------------------------------------------------------------------------ Captured log teardown ------------------------------------------------------------------------------
INFO     genesis:logger.py:127 💤 Exiting Genesis and caching compiled kernels...
```

Looking at the code, Genesis is accessing internal private attributes of gstaichi objects, i.e. `_primal`. This PR addresses this issue. Test then passes:
```
(genesis) system ~/git/Genesis (main|△1) $ pytest -s -v tests/test_rigid_physics.py::test_walker[cpu-False-implicitfast-CG-xml/walker.xml] -x
DEPRECATION WARNING: The system version of Tk is deprecated and may be removed in a future release. Please don't rely on it. Set TK_SILENCE_DEPRECATION=1 to suppress this warning.
=============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.10.16, pytest-8.3.5, pluggy-1.5.0 -- /Users/hugh/.pyenv/versions/3.10.16/envs/genesis/bin/python
cachedir: .pytest_cache
Using --random-order-bucket=global
Using --random-order-seed=0

rootdir: /Users/hugh/git/Genesis
configfile: pyproject.toml
plugins: anyio-4.9.0, syrupy-4.9.1, random-order-1.1.1, rerunfailures-15.1, print-1.1.0, forked-1.6.0, xdist-3.6.1
10 workers [1 item]
scheduling tests via WorkStealingScheduling

tests/test_rigid_physics.py::test_walker[cpu-False-implicitfast-CG-xml/walker.xml]
[gw9] PASSED tests/test_rigid_physics.py::test_walker[cpu-False-implicitfast-CG-xml/walker.xml]

================================================================================ slowest durations ================================================================================

(3 durations < 40s hidden.  Use -vv to show these durations.)
=============================================================================== 1 passed in 15.77s ================================================================================
(genesis) system ~/git/Genesis (main|△2)
```

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
