### PR TITLE
[BUG FIX] Fix shadow map not properly rendered for objects far away from floor plane.

### DIFF
--- a/genesis/ext/pyrender/renderer.py
+++ b/genesis/ext/pyrender/renderer.py
@@ -704,13 +704,12 @@ class Renderer(object):
     def _get_light_cam_matrices(self, scene, light_node, flags):
         light = light_node.light
         pose = scene.get_pose(light_node).copy()
-        s = scene.scale
-        camera = light._get_shadow_camera(s)
+        camera = light._get_shadow_camera(scene.scale)
         P = camera.get_projection_matrix()
         if isinstance(light, DirectionalLight):
             direction = -pose[:3, 2]
             c = scene.centroid
-            loc = c - direction * s
+            loc = c - direction * scene.scale
             pose[:3, 3] = loc
         V = np.linalg.inv(pose)  # V maps from world to camera
         return V, P

--- a/genesis/ext/pyrender/scene.py
+++ b/genesis/ext/pyrender/scene.py
@@ -214,8 +214,10 @@ class Scene(object):
             for mesh_node in self.mesh_nodes:
                 mesh = mesh_node.mesh
                 if any(primitive.is_floor for primitive in mesh.primitives):
-                    continue
-                corners_local = trimesh.bounds.corners(mesh.bounds)
+                    # Only take into account the centroid for floor plane
+                    corners_local = mesh.centroid[np.newaxis]
+                else:
+                    corners_local = trimesh.bounds.corners(mesh.bounds)
                 pose = self.get_pose(mesh_node)
                 corners_world = corners_local @ pose[:3, :3].T + pose[:3, 3]
                 corners.append(corners_world)

--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -343,8 +343,8 @@ class Viewer(pyglet.window.Window):
         # Set defaults as needed
         if zfar is None:
             zfar = max(self.scene.scale * 10.0, DEFAULT_Z_FAR)
-        if znear is None or znear == 0:
-            if self.scene.scale == 0:
+        if znear is None or znear < 1e-6:
+            if self.scene.scale < 1e-6:
                 znear = DEFAULT_Z_NEAR
             else:
                 znear = min(self.scene.scale / 10.0, DEFAULT_Z_NEAR)
@@ -353,7 +353,7 @@ class Viewer(pyglet.window.Window):
             self._default_persp_cam = PerspectiveCamera(yfov=np.pi / 3.0, znear=znear, zfar=zfar)
         if self._default_orth_cam is None:
             xmag = ymag = self.scene.scale
-            if self.scene.scale == 0:
+            if self.scene.scale < 1e-6:
                 xmag = ymag = 1.0
             self._default_orth_cam = OrthographicCamera(xmag=xmag, ymag=ymag, znear=znear, zfar=zfar)
         if self._default_camera_pose is None:

--- a/genesis/utils/hybrid.py
+++ b/genesis/utils/hybrid.py
@@ -110,11 +110,11 @@ def reduce_graph(G, straight_thresh=10):
         path = nx.shortest_path(
             G, source=ref_node, target=node
         )  # NOTE: if there is loop, we pick shortest path to the reference node
-        node_curr = ref_node
+        node_cur = ref_node
         for node_on_path in path:
             if node_on_path in G_reduced.nodes():
-                G_reduced.add_edge(node_curr, node_on_path)
-                node_curr = node_on_path
+                G_reduced.add_edge(node_cur, node_on_path)
+                node_cur = node_on_path
 
     return G_reduced
 


### PR DESCRIPTION
## Description

* Take into account floor plane centroid in scene bounds computation.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis/issues/1663

## How Has This Been / Can This Be Tested?

Running the example `examples/drone/fly_route.py`.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.