### PR TITLE
[BUG FIX] Randomize uniform terrain along both axes.

### DIFF
--- a/genesis/ext/isaacgym/terrain_utils.py
+++ b/genesis/ext/isaacgym/terrain_utils.py
@@ -59,6 +59,8 @@ def random_uniform_terrain(
     """
     if downsampled_scale is None:
         downsampled_scale = terrain.horizontal_scale
+    scaled_width = terrain.width * terrain.horizontal_scale
+    scaled_length = terrain.length * terrain.horizontal_scale
 
     # switch parameters to discrete units
     min_height = int(min_height / terrain.vertical_scale)
@@ -69,19 +71,19 @@ def random_uniform_terrain(
     height_field_downsampled = np.random.choice(
         heights_range,
         (
-            int(terrain.width * terrain.horizontal_scale / downsampled_scale),
-            int(terrain.length * terrain.horizontal_scale / downsampled_scale),
+            int(scaled_width / downsampled_scale),
+            int(scaled_length / downsampled_scale),
         ),
     )
 
-    x = np.linspace(0, terrain.width * terrain.horizontal_scale, height_field_downsampled.shape[0])
-    y = np.linspace(0, terrain.length * terrain.horizontal_scale, height_field_downsampled.shape[1])
+    x = np.linspace(0, scaled_width, height_field_downsampled.shape[0])
+    y = np.linspace(0, scaled_length, height_field_downsampled.shape[1])
 
-    f = interpolate.RegularGridInterpolator((y, x), height_field_downsampled, method="linear")
+    f = interpolate.RectBivariateSpline(x, y, height_field_downsampled)
 
-    x_upsampled = np.linspace(0, terrain.width * terrain.horizontal_scale, terrain.width)
-    y_upsampled = np.linspace(0, terrain.length * terrain.horizontal_scale, terrain.length)
-    z_upsampled = np.rint(f((y_upsampled, x_upsampled)))
+    x_upsampled = np.linspace(0, scaled_width, terrain.width)
+    y_upsampled = np.linspace(0, scaled_length, terrain.length)
+    z_upsampled = np.rint(f(x_upsampled, y_upsampled))
 
     terrain.height_field_raw += z_upsampled
     return terrain

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -1999,6 +1999,7 @@ def test_terrain_generation(show_viewer):
     )
     terrain = scene.add_entity(
         morph=gs.morphs.Terrain(
+            pos=(0.0, 0.0, 0.0),
             n_subterrains=(2, 2),
             subterrain_size=(6.0, 6.0),
             horizontal_scale=0.25,
@@ -2021,11 +2022,17 @@ def test_terrain_generation(show_viewer):
     for _ in range(400):
         scene.step()
 
+    # Get the position of the balls that are still on the terrain
+    balls_pos = ball.get_pos()
+    balls_pos = balls_pos[
+        (balls_pos[:, 0] > 0.0) & (balls_pos[:, 0] < 12.0) & (balls_pos[:, 1] > 0.0) & (balls_pos[:, 1] < 12.0)
+    ]
+
     # Make sure that at least one ball is as minimum height, and some are signficantly higher
     height_field = terrain.geoms[0].metadata["height_field"]
     height_field_min = terrain.terrain_scale[1] * height_field.min()
     height_field_max = terrain.terrain_scale[1] * height_field.max()
-    height_balls = ball.get_pos()[:, 2]
+    height_balls = balls_pos[:, 2]
     height_balls_min = height_balls.min() - 0.1
     height_balls_max = height_balls.max() - 0.1
     assert_allclose(height_balls_min, height_field_min, atol=2e-3)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [CHANGING] for changes that will change simulation's behaviour
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
Currently, the `random_uniform_terrain` subterrain only creates a random height field along one axis, and duplicates it for each row, leading to horizontal bumps, like speed bumps or a washboard.

<img width="425" height="300" alt="Screenshot 2025-09-17 at 9 23 19 PM" src="https://github.com/user-attachments/assets/fc437ad7-40ef-4ae4-bd39-73b39749e93d" />

As this seems to be modeled after the [isaac lab terrain of the same name](https://github.com/isaac-sim/IsaacLab/blob/931679641ee84e1b4175c15b48f9286d44ba9b04/source/isaaclab/isaaclab/terrains/height_field/hf_terrains.py#L21), I believe it's intended to create a random terrain in both axes.

<img width="419" height="300" alt="Screenshot 2025-09-17 at 9 21 15 PM" src="https://github.com/user-attachments/assets/58f2501e-eb7c-4e3b-a285-c736773c0f2a" />

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#1748

## Motivation and Context

* Brings this terrain to parity with issac lab
* Provides an effective rugged terrain for locomotion training.

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

I ported the code change from Isaac Lab and visually confirmed the result.

Run this example to verify: `python ./examples/rigid/terrain_subterrain.py`

I'm currently developing/running this on a Mac M1 Max

## Screenshots (if appropriate):

See above

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
