### PR TITLE
[BUG FIX] Contact sensors always returning zeros.

### DIFF
--- a/genesis/sensors/contact_force.py
+++ b/genesis/sensors/contact_force.py
@@ -301,5 +301,5 @@ class ContactForceSensor(
         # clip for max force
         shared_cache_per_sensor.clamp_(max=shared_metadata.max_force)
         # set to 0 for undetectable force
-        shared_cache_per_sensor[shared_cache_per_sensor < shared_metadata.min_force] = 0.0
+        shared_cache_per_sensor[torch.abs(shared_cache_per_sensor) < shared_metadata.min_force] = 0.0
         cls._quantize_to_resolution(shared_metadata.resolution, shared_cache)

--- a/genesis/utils/ring_buffer.py
+++ b/genesis/utils/ring_buffer.py
@@ -18,8 +18,8 @@ class TensorRingBuffer:
     buffer : torch.Tensor | None, optional
         The buffer tensor where all the data is stored. If not provided, a new tensor is allocated.
     idx : torch.Tensor, optional
-        The index reference to the current position in the ring buffer as a mutable 0D torch.Tensor of integer dtype.
-        If not provided, it is initialized to 0.
+        The index reference to the most recently updated position in the ring buffer as a mutable 0D torch.Tensor of
+        integer dtype. If not provided, it is initialized to -1.
     """
 
     def __init__(
@@ -37,7 +37,7 @@ class TensorRingBuffer:
             self.buffer = buffer
         self.N = N
         if idx is None:
-            self._idx = torch.tensor(0, dtype=torch.int64, device=gs.device)
+            self._idx = torch.tensor(-1, dtype=torch.int64, device=gs.device)
         else:  # torch.Tensor
             assert idx.ndim == 0 and idx.dtype in (torch.int32, torch.int64)
             self._idx = idx.to(device=gs.device)
@@ -52,8 +52,8 @@ class TensorRingBuffer:
         tensor : torch.Tensor
             The tensor to copy into the ring buffer.
         """
-        self.buffer[self._idx].copy_(tensor)
         self._idx[()] = (self._idx + 1) % self.N
+        self.buffer[self._idx].copy_(tensor)
 
     def at(
         self, idx: int | torch.Tensor, *others_idx: int | slice | torch.Tensor, copy: bool | None = None


### PR DESCRIPTION
## Description
Sensor data cache was not being set properly from the ring buffer because the index was pointing to next (not yet updated) location instead of currently updated position.

## Related Issue
https://github.com/Genesis-Embodied-AI/Genesis/issues/1760

## Motivation and Context


## How Has This Been / Can This Be Tested?
Ran the script from issue above and made sure it is reading properly.
```
[Genesis] [13:54:58] [INFO] Running at 14.62 FPS.
FR Foot Contact Force   : [7.827377796173096, -1.3204383850097656, 6.888644695281982]
FR Foot Contact Force GT: [7.827377796173096, -1.3204383850097656, 6.888644695281982]
FL Foot Contact Force   : [8.133493423461914, -0.7074760794639587, 6.780436992645264]
FL Foot Contact Force GT: [8.133493423461914, -0.7074760794639587, 6.780436992645264]
```
Also added test in `test_sensors.py` to check exact match for delay

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
