### PR TITLE
[BUG FIX] Fix terrain with non-zero offset

### DIFF
--- a/genesis/engine/solvers/rigid/collider_decomp.py
+++ b/genesis/engine/solvers/rigid/collider_decomp.py
@@ -974,11 +974,17 @@ def func_contact_mpr_terrain(
     #         is_return = True
 
     if not is_return:
+        # move to terrain's frame
         geoms_state.pos[i_ga, i_b], geoms_state.quat[i_ga, i_b] = gu.ti_transform_pos_quat_by_trans_quat(
             ga_pos - geoms_state.pos[i_gb, i_b],
             ga_quat,
             ti.Vector.zero(gs.ti_float, 3),
             gu.ti_inv_quat(geoms_state.quat[i_gb, i_b]),
+        )
+        geoms_state.pos[i_gb, i_b] = ti.Vector.zero(gs.ti_float, 3)
+        geoms_state.quat[i_gb, i_b] = gu.ti_identity_quat()
+        center_a = gu.ti_transform_by_trans_quat(
+            geoms_info.center[i_ga], geoms_state.pos[i_ga, i_b], geoms_state.quat[i_ga, i_b]
         )
 
         for i_axis, i_m in ti.ndrange(3, 2):
@@ -1041,14 +1047,10 @@ def func_contact_mpr_terrain(
                                 or collider_state.prism[4, i_b][2] >= collider_state.xyz_max_min[5, i_b]
                                 or collider_state.prism[5, i_b][2] >= collider_state.xyz_max_min[5, i_b]
                             ):
-                                center_a = gu.ti_transform_by_trans_quat(geoms_info.center[i_ga], ga_pos, ga_quat)
                                 center_b = ti.Vector.zero(gs.ti_float, 3)
                                 for i_p in ti.static(range(6)):
                                     center_b = center_b + collider_state.prism[i_p, i_b]
                                 center_b = center_b / 6.0
-
-                                geoms_state.pos[i_gb, i_b] = ti.Vector.zero(gs.ti_float, 3)
-                                geoms_state.quat[i_gb, i_b] = gu.ti_identity_quat()
 
                                 is_col, normal, penetration, contact_pos = mpr.func_mpr_contact_from_centers(
                                     geoms_state,

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2030,8 +2030,10 @@ def test_nan_reset(gs_sim, mode):
     assert not torch.isnan(qvel).any()
 
 
+@pytest.mark.required
+@pytest.mark.parametrize("offset", [(0.0, 0.0, 0.0), (10.0, -10.0, 0.5)])
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
-def test_terrain_generation(show_viewer):
+def test_terrain_generation(offset, show_viewer):
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(
             dt=0.01,
@@ -2046,14 +2048,14 @@ def test_terrain_generation(show_viewer):
     )
     terrain = scene.add_entity(
         morph=gs.morphs.Terrain(
-            pos=(0.0, 0.0, 0.0),
+            pos=offset,
             n_subterrains=(2, 2),
             subterrain_size=(6.0, 6.0),
             horizontal_scale=0.25,
             vertical_scale=0.005,
             subterrain_types=[
-                ["flat_terrain", "random_uniform_terrain"],
-                ["pyramid_sloped_terrain", "discrete_obstacles_terrain"],
+                ["stairs_terrain", "stairs_terrain"],
+                ["flat_terrain", "flat_terrain"],
             ],
         ),
     )
@@ -2065,25 +2067,23 @@ def test_terrain_generation(show_viewer):
     )
     scene.build(n_envs=225)
 
-    ball.set_pos(torch.cartesian_prod(*(torch.linspace(1.0, 10.0, 15),) * 2, torch.tensor((0.6,))))
+    ball.set_pos(
+        torch.tensor(offset).unsqueeze(0)
+        + torch.cartesian_prod(*(torch.linspace(3.0, 8.0, 15),) * 2, torch.tensor((0.6,)))
+    )
     for _ in range(400):
         scene.step()
 
-    # Get the position of the balls that are still on the terrain
-    balls_pos = ball.get_pos()
-    balls_pos = balls_pos[
-        (balls_pos[:, 0] > 0.0) & (balls_pos[:, 0] < 12.0) & (balls_pos[:, 1] > 0.0) & (balls_pos[:, 1] < 12.0)
-    ]
-
-    # Make sure that at least one ball is as minimum height, and some are signficantly higher
+    # ball should not fall out of the terrain
     height_field = terrain.geoms[0].metadata["height_field"]
     height_field_min = terrain.terrain_scale[1] * height_field.min()
-    height_field_max = terrain.terrain_scale[1] * height_field.max()
+
+    balls_pos = ball.get_pos()
     height_balls = balls_pos[:, 2]
     height_balls_min = height_balls.min() - 0.1
-    height_balls_max = height_balls.max() - 0.1
-    assert_allclose(height_balls_min, height_field_min, atol=2e-3)
-    assert height_balls_max - height_balls_min > 0.5 * (height_field_max - height_field_min)
+
+    safe_margin = 0.01
+    assert height_balls_min > height_field_min - safe_margin
 
 
 @pytest.mark.required


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [CHANGING] for changes that will change simulation's behaviour
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->
Fix #1727

The center of the object was wrong when the offset of a terrain is not zero.


## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
