### PR TITLE
[BUG FIX] Fix missing libGLU.so.1 in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,6 +68,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     bash-completion \
     libgl1 \
+    libgl1-mesa-glx \
     libglu1-mesa \
     libegl-dev \
     libegl1 \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [CHANGING] for changes that will change simulation's behaviour
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
* Importing genesis in the provided Docker environment results in an error that `libGLU.so.1` cannot be loaded
    * As a result, running the examples in Docker fails


```
root@4d121a9114ea:/workspace# python -c "import genesis"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/workspace/genesis/__init__.py", line 381, in <module>
    from pygel3d import graph, hmesh
  File "/opt/conda/lib/python3.11/site-packages/pygel3d/__init__.py", line 50, in <module>
    lib_py_gel = ct.cdll.LoadLibrary(_get_script_path() + "/" + _get_lib_name())
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/ctypes/__init__.py", line 454, in LoadLibrary
    return self._dlltype(name)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/ctypes/__init__.py", line 376, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: libGLU.so.1: cannot open shared object file: No such file or directory
```


* This library is normally provided by the system (e.g. `ubuntu-desktop`) but since Docker is headless, it isn't explicitly available
* Restoring this shared library file via `libglu1-mesa` (see Motivation section) resolves the issue  



## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

[Resolves Genesis-Embodied-AI/Genesis#1895](https://github.com/Genesis-Embodied-AI/Genesis/issues/1895)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

* Fixes / unblocks folks using the provided Docker instructions to get up and running quickly with examples
* Currently any import of `genesis` from within that Docker container will face this issue

* We can fix by adding `libglu1-mesa` to the runtime dependencies in the Dockerfile

```
apt-get install apt-file -y && apt-file update
apt-file search "libGLU.so.1"
```

Returns

```
libglu1-mesa: /usr/lib/x86_64-linux-gnu/libGLU.so.1
libglu1-mesa: /usr/lib/x86_64-linux-gnu/libGLU.so.1.3.1
```

* Note that the previous included `libgl1-mesa-glx` is a transitional package, ~~and we should be ok to remove it~~
    * EDIT: keeping this package just in case Genesis depends on it 

```
root@1709171c7d5a:/workspace# apt show libgl1-mesa-glx -a
Package: libgl1-mesa-glx
Version: 23.0.4-0ubuntu1~22.04.1
Priority: optional
Section: universe/libs
Source: mesa
Origin: Ubuntu
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Original-Maintainer: Debian X Strike Force <debian-x@lists.debian.org>
Bugs: https://bugs.launchpad.net/ubuntu/+filebug
Installed-Size: 74.8 kB
Depends: libgl1, libglx-mesa0
Homepage: https://mesa3d.org/
Download-Size: 5584 B
APT-Manual-Installed: yes
APT-Sources: http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages
Description: transitional dummy package

Package: libgl1-mesa-glx
Version: 22.0.1-1ubuntu2
Priority: optional
Section: universe/libs
Source: mesa
Origin: Ubuntu
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Original-Maintainer: Debian X Strike Force <debian-x@lists.debian.org>
Bugs: https://bugs.launchpad.net/ubuntu/+filebug
Installed-Size: 71.7 kB
Depends: libgl1, libglx-mesa0
Homepage: https://mesa3d.org/
Download-Size: 5456 B
APT-Sources: http://archive.ubuntu.com/ubuntu jammy/universe amd64 Packages
Description: transitional dummy package
``` 


## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->


```bash
# build / run docker as described in README
docker build -t genesis -f docker/Dockerfile docker
docker run --gpus all --rm -it -e DISPLAY=$DISPLAY -e LOCAL_USER_ID="$(id -u)" \
    -v /dev/dri:/dev/dri -v /tmp/.X11-unix/:/tmp/.X11-unix -v $(pwd):/workspace \
    --name genesis genesis:latest

# within docker 
python -c "import genesis"
# or 
python examples/smoke.py -n 5
```

**Before the change:** errors on `libGLU.so.1`

```
root@4d121a9114ea:/workspace# python -c "import genesis"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/workspace/genesis/__init__.py", line 381, in <module>
    from pygel3d import graph, hmesh
  File "/opt/conda/lib/python3.11/site-packages/pygel3d/__init__.py", line 50, in <module>
    lib_py_gel = ct.cdll.LoadLibrary(_get_script_path() + "/" + _get_lib_name())
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/ctypes/__init__.py", line 454, in LoadLibrary
    return self._dlltype(name)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/ctypes/__init__.py", line 376, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: libGLU.so.1: cannot open shared object file: No such file or directory

root@4d121a9114ea:/workspace# python examples/smoke.py 
[GsTaichi] version 3.0.0, llvm 15.0.7, commit 7fb4ee55, linux, python 3.11.10
Traceback (most recent call last):
  File "/workspace/examples/smoke.py", line 10, in <module>
    import genesis as gs
  File "/opt/conda/lib/python3.11/site-packages/genesis/__init__.py", line 381, in <module>
    from pygel3d import graph, hmesh
  File "/opt/conda/lib/python3.11/site-packages/pygel3d/__init__.py", line 50, in <module>
    lib_py_gel = ct.cdll.LoadLibrary(_get_script_path() + "/" + _get_lib_name())
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/ctypes/__init__.py", line 454, in LoadLibrary
    return self._dlltype(name)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/ctypes/__init__.py", line 376, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: libGLU.so.1: cannot open shared object file: No such file or directory
```


**After the change:** successfully runs

```
root@a4f7c937834f:/workspace# python -c "import genesis"
root@a4f7c937834f:/workspace# python examples/smoke.py -n 5
[GsTaichi] version 3.1.0, llvm 15.0.7, commit 8bb92559, linux, python 3.11.10
[Genesis] [21:39:38] [INFO] ╭─────────────────────────────────────────────────────────────────────────────────────╮
[Genesis] [21:39:38] [INFO] │┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉ Genesis ┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉┈┉│
[Genesis] [21:39:38] [INFO] ╰─────────────────────────────────────────────────────────────────────────────────────╯
[Genesis] [21:39:39] [INFO] Running on [NVIDIA GeForce RTX 4070 Ti SUPER] with backend gs.cuda. Device memory: 15.54 GB.
[Genesis] [21:39:39] [INFO] 🚀 Genesis initialized. 🔖 version: 0.3.4, 🎨 theme: dark, 🌱 seed: 0, 🐛 debug: False, 📏 precision: 32, 🏎️ performance: False, ℹ️ verbose: INFO
/opt/conda/lib/python3.11/site-packages/gstaichi/_test_tools/warnings_helper.py:11: UserWarning: @ti.kernel parameter `pure` is deprecated. Please use parameter `fastcache`. `pure` parameter is intended to be removed in 4.0.0
  warnings.warn(message)
[Genesis] [21:39:40] [INFO] Scene <9d74551> created.
[Genesis] [21:39:40] [INFO] Building scene <9d74551>...
/opt/conda/lib/python3.11/site-packages/gstaichi/lang/_fast_caching/src_hasher.py:66: PydanticDeprecatedSince20: The `json` method is deprecated; use `model_dump_json` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
  cache.store(cache_key, cache_value_obj.json())
[Genesis] [21:39:41] [INFO] Compiling simulation kernels...
[Genesis] [21:39:44] [INFO] Building visualizer...
[Genesis] [21:39:47] [INFO] Running at 187.48 FPS.
[Genesis] [21:39:47] [INFO] Running at 187.27 FPS.
[Genesis] [21:39:47] [INFO] Running at 187.37 FPS.
[Genesis] [21:39:47] [INFO] Running at 146.23 FPS.
[Genesis] [21:39:48] [INFO] Running at 38.30 FPS.
[Genesis] [21:39:48] [INFO] Running at 22.53 FPS.
[Genesis] [21:39:49] [INFO] Running at 16.18 FPS.
...
```

## Screenshots (if appropriate):

With fix:

<img width="1244" height="520" alt="image" src="https://github.com/user-attachments/assets/c90caa3d-19db-4ba0-8c61-08cfa1a20844" />



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
