### PR TITLE
[BUG FIX] Fix 'discrete_obstacles_terrain' being completely flat.

### DIFF
--- a/genesis/ext/isaacgym/terrain_utils.py
+++ b/genesis/ext/isaacgym/terrain_utils.py
@@ -179,7 +179,7 @@ def discrete_obstacles_terrain(terrain, max_height, min_size, max_size, num_rect
 
     start_x, end_x = (terrain.width - platform_size) // 2, (terrain.width + platform_size) // 2
     start_y, end_y = (terrain.length - platform_size) // 2, (terrain.length + platform_size) // 2
-    terrain.height_field_raw[:] = 0.0
+    terrain.height_field_raw[start_x:end_x, start_y:end_y] = 0
 
     return terrain
 

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2156,6 +2156,33 @@ def test_terrain_generation(request, show_viewer):
     assert_allclose(terrain_mesh.verts, terrain_2_mesh.verts, tol=gs.EPS)
 
 
+@pytest.mark.required
+def test_discrete_obstacles_terrain():
+    scene = gs.Scene()
+    terrain = scene.add_entity(
+        gs.morphs.Terrain(
+            n_subterrains=(1, 1),
+            subterrain_size=(6.0, 6.0),
+            horizontal_scale=0.5,
+            vertical_scale=0.5,
+            subterrain_types=[["discrete_obstacles_terrain"]],
+            subterrain_parameters={
+                "discrete_obstacles_terrain": {
+                    "max_height": 1.0,
+                    "platform_size": 1.0,
+                }
+            },
+        )
+    )
+    scene.build()
+    height_field = terrain.geoms[0].metadata["height_field"]
+    platform = height_field[5:7, 5:7]
+
+    assert height_field.max().item() == 2.0
+    assert height_field.min().item() == -2.0
+    assert (platform == 0.0).all()
+
+
 def test_mesh_to_heightfield(tmp_path, show_viewer):
     horizontal_scale = 2.0
     path_terrain = os.path.join(get_assets_dir(), "meshes", "terrain_45.obj")


### PR DESCRIPTION
## Description
Fixes a bug which makes the discrete_obstacles_terrain terrain entirely flat

## Related Issue
Resolves Genesis-Embodied-AI/Genesis#1971

## Motivation and Context
This fixes a regression. The terrain is useful for locomotion tasks.

## How Has This Been / Can This Be Tested?
Visually, as well as I added a new unit test to ensure that the height field is not zero.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
