### PR TITLE
[MISC] Update performance mode emoji in welcome message.

### DIFF
--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -291,7 +291,7 @@ def init(
             ("🌱 seed", seed),
             ("🐛 debug", debug),
             ("📏 precision", precision),
-            ("🏎️ performance", performance_mode),
+            ("🔥 performance", performance_mode),
             ("💬 verbose", _logging.getLevelName(gs.logger.level)),
         )
     )


### PR DESCRIPTION
The previous racing car emoji (🏎️) is a multi-codepoint Unicode and cannot be displayed properly in non-modern terminal.