### PR TITLE
[BUG FIX] Raise exception if trying to load PointCloud as Mesh.

### DIFF
--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -411,7 +411,7 @@ with open(os.devnull, "w") as stderr, redirect_libc_stderr(stderr):
         from pygel3d import graph, hmesh
     except OSError as e:
         # Import may fail because of missing system dependencies (libGLU.so.1).
-        # This is not blocking because it is only an issue for hybrig entities.
+        # This is not blocking because it is only an issue for hybrid entities.
         pass
 
     try:

--- a/genesis/engine/mesh.py
+++ b/genesis/engine/mesh.py
@@ -195,7 +195,7 @@ class Mesh(RBC):
         Copy the mesh.
         """
         return Mesh(
-            mesh=self._mesh.copy(include_cache=True),
+            mesh=self._mesh.copy(**(dict(include_cache=True) if isinstance(self._mesh, trimesh.Trimesh) else {})),
             surface=self._surface.copy(),
             uvs=self._uvs.copy() if self._uvs is not None else None,
             metadata=self._metadata.copy(),
@@ -221,7 +221,7 @@ class Mesh(RBC):
             surface.update_texture()
         else:
             surface = surface.copy()
-        mesh = mesh.copy(include_cache=True)
+        mesh = mesh.copy(**(dict(include_cache=True) if isinstance(mesh, trimesh.Trimesh) else {}))
 
         try:  # always parse uvs because roughness and normal map also need uvs
             uvs = mesh.visual.uv.copy()
@@ -234,9 +234,10 @@ class Mesh(RBC):
         color_factor = None
         opacity = 1.0
 
-        if mesh.visual.defined:
-            if mesh.visual.kind == "texture":
-                material = mesh.visual.material
+        visual = mesh.visual
+        if isinstance(visual, trimesh.visual.texture.TextureVisuals) and visual.defined:
+            if visual.kind == "texture":
+                material = visual.material
 
                 # TODO: Parsing PBR in obj or not
                 # trimesh from .obj file will never use PBR material, but that from .glb file will
@@ -267,12 +268,15 @@ class Mesh(RBC):
                         else:
                             color_factor = (*color_factor[:3], color_factor[3] * opacity)
                 else:
-                    gs.raise_exception()
-
+                    gs.raise_exception(f"Unsupported Trimesh material type '{type(material)}'.")
             else:
                 # TODO: support vertex/face colors in luisa
-                color_factor = tuple(np.array(mesh.visual.main_color, dtype=np.float32) / 255.0)
-
+                color_factor = tuple(np.array(visual.main_color, dtype=np.float32) / 255.0)
+        elif isinstance(visual, trimesh.visual.color.VertexColor) and visual.vertex_colors.size > 0:
+            color = np.unique(visual.vertex_colors, axis=0)
+            if len(color) > 1:
+                gs.raise_exception("Loading point clouds with heterogeneous colors is not supported.")
+            color_factor = tuple(np.array(color, dtype=np.float32) / 255.0)
         else:
             # use white color as default
             color_factor = (1.0, 1.0, 1.0, 1.0)
@@ -328,7 +332,7 @@ class Mesh(RBC):
     def from_morph_surface(cls, morph, surface=None):
         """
         Create a genesis.Mesh from morph and surface options.
-        If the morph is a Mesh morph (morphs.Mesh), it could contain multiple submeshes, so we return a list.
+        If the morph is a Mesh morph (morphs.Mesh), it could contain multiple sub-meshes, so we return a list.
         """
         if isinstance(morph, gs.options.morphs.Mesh):
             if morph.is_format(gs.options.morphs.MESH_FORMATS):
@@ -355,9 +359,7 @@ class Mesh(RBC):
                 assert all(isinstance(mesh, trimesh.Trimesh) for mesh in morph.files)
                 meshes = [mu.trimesh_to_mesh(mesh, morph.scale, surface) for mesh in morph.files]
             else:
-                gs.raise_exception(
-                    f"File type not supported (yet). Submit a feature request if you need this: {morph.file}."
-                )
+                gs.raise_exception(f"File type not supported: {morph.file}")
 
             return meshes
 

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -18,7 +18,7 @@ from .options import Options
 
 URDF_FORMAT = ".urdf"
 MJCF_FORMAT = ".xml"
-MESH_FORMATS = (".obj", ".ply", ".stl")
+MESH_FORMATS = (".obj", ".stl")
 GLTF_FORMATS = (".glb", ".gltf")
 USD_FORMATS = (".usd", ".usda", ".usdc", ".usdz")
 

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -473,8 +473,12 @@ def postprocess_collision_geoms(
 
 def parse_mesh_trimesh(path, group_by_material, scale, surface):
     meshes = []
-    for _, mesh in trimesh.load(path, force="scene", group_material=group_by_material, process=False).geometry.items():
-        meshes.append(gs.Mesh.from_trimesh(mesh=mesh, scale=scale, surface=surface, metadata={"mesh_path": path}))
+    scene = trimesh.load(path, force="scene", group_material=group_by_material, process=False)
+    for tmesh in scene.geometry.values():
+        if not isinstance(tmesh, trimesh.Trimesh):
+            gs.raise_exception(f"Mesh type not supported: {path}")
+        mesh = gs.Mesh.from_trimesh(mesh=tmesh, scale=scale, surface=surface, metadata={"mesh_path": path})
+        meshes.append(mesh)
     return meshes
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1149,7 +1149,7 @@ def test_render_planes(tmp_path, png_snapshot, renderer_type, renderer):
 @pytest.mark.required
 @pytest.mark.parametrize("renderer_type", [RENDERER_TYPE.RASTERIZER])
 @pytest.mark.skipif(not IS_INTERACTIVE_VIEWER_AVAILABLE, reason="Interactive viewer not supported on this platform.")
-def test_batch_deformable_render(tmp_path, monkeypatch, png_snapshot):
+def test_batch_deformable_render(monkeypatch, png_snapshot):
     CAM_RES = (640, 480)
 
     # Disable text rendering as it is messing up with pixel matching when using old CPU-based Mesa driver


### PR DESCRIPTION
## Description

Loading PointClould files (.ply) is currently broken because it parsed as a special `trimesh.PointCloud` object instead of a regular `trimesh.Trimesh` object. These objects are messing important information such as vertices and faces which are currently required by Rigid Solver. Let's forbid this file format completely for now, and reconsider this if it is blocking for users.

## Related Issue

Resolves https://github.com/Genesis-Embodied-AI/Genesis/issues/1958
Resolves https://github.com/Genesis-Embodied-AI/Genesis/issues/535

## Motivation and Context

The current error message is very cryptic. It is not clear for the user if it is failing because this file format is unsupported or because there is a bug in Genesis.