### PR TITLE
[MISC] Flag more unit tests as 'slow'.

### DIFF
--- a/tests/test_deformable_physics.py
+++ b/tests/test_deformable_physics.py
@@ -104,6 +104,7 @@ def test_muscle(n_envs, muscle_material, show_viewer):
         scene.step()
 
 
+@pytest.mark.slow  # ~150s
 @pytest.mark.required
 @pytest.mark.skipif(platform.machine() == "aarch64", reason="Module 'tetgen' is crashing on Linux ARM.")
 @pytest.mark.parametrize("backend", [gs.gpu])

--- a/tests/test_gstaichi.py
+++ b/tests/test_gstaichi.py
@@ -145,6 +145,7 @@ def gs_static_child(args: list[str]):
     sys.exit(RET_SUCCESS)
 
 
+@pytest.mark.slow  # ~170s
 @pytest.mark.required
 @pytest.mark.parametrize("backend", [None])  # Disable genesis initialization at worker level
 @pytest.mark.parametrize("test_backend", ["cpu", "gpu"])
@@ -234,6 +235,7 @@ def gs_num_envs_child(args: list[str]):
     sys.exit(RET_SUCCESS)
 
 
+@pytest.mark.slow  # ~230s
 @pytest.mark.required
 @pytest.mark.parametrize("backend", [None])  # Disable genesis initialization at worker level
 @pytest.mark.parametrize("test_backend", ["cpu", "gpu"])
@@ -339,6 +341,7 @@ def change_scene(args: list[str]):
     sys.exit(RET_SUCCESS)
 
 
+@pytest.mark.slow  # ~120s
 @pytest.mark.required
 @pytest.mark.parametrize("backend", [None])  # Disable genesis initialization at worker level
 # Note that, on GPU, PARA_LEVEL is changing between batched and non-batched simulation

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,6 +6,7 @@ import genesis as gs
 from .utils import assert_allclose, get_hf_dataset
 
 
+@pytest.mark.slow  # ~120s
 @pytest.mark.parametrize("mode", [0, 1, 2])
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
 def test_pick_and_place(mode, show_viewer):
@@ -207,6 +208,7 @@ def test_hanging_rigid_cable(show_viewer, tol):
     assert_allclose(links_quat_err, 0.0, tol=1e-3)
 
 
+@pytest.mark.slow  # ~150s
 @pytest.mark.parametrize("primitive_type", ["box", "sphere"])
 @pytest.mark.parametrize("precision", ["64"])
 def test_franka_panda_grasp_fem_entity(primitive_type, show_viewer):

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -861,7 +861,7 @@ def test_box_box_dynamics(gs_sim):
         assert_allclose(qpos[8], 0.6, atol=2e-3)
 
 
-@pytest.mark.slow
+@pytest.mark.slow  # ~840s
 @pytest.mark.parametrize(
     "box_box_detection, gjk_collision, dynamics",
     [
@@ -1361,6 +1361,7 @@ def test_set_sol_params(n_envs, batched, tol):
             assert_allclose(obj.sol_params, sol_params, tol=tol)
 
 
+@pytest.mark.slow  # ~160s
 @pytest.mark.required
 @pytest.mark.mujoco_compatibility(False)
 @pytest.mark.parametrize("xml_path", ["xml/humanoid.xml"])
@@ -1457,6 +1458,7 @@ def test_multilink_inverse_kinematics(show_viewer):
     assert_allclose(wrist.get_pos(envs_idx=(1,)), wrist_pos, tol=TOL)
 
 
+@pytest.mark.slow  # ~180s
 @pytest.mark.required
 @pytest.mark.parametrize("n_envs", [0, 2])
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
@@ -1929,6 +1931,7 @@ def test_mesh_repair(convexify, show_viewer, gjk_collision):
     assert_allclose(qpos[:2], (0.3, 0.0), atol=2e-3)
 
 
+@pytest.mark.slow  # ~160s
 @pytest.mark.required
 @pytest.mark.parametrize("euler", [(90, 0, 90), (74, 15, 90)])
 @pytest.mark.parametrize("gjk_collision", [True, False])
@@ -2547,6 +2550,7 @@ def test_gravity(show_viewer, tol):
     )
 
 
+@pytest.mark.slow  # ~110s
 @pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
 def test_scene_saver_franka(tmp_path, show_viewer, tol):
@@ -2732,6 +2736,7 @@ def test_get_constraints_api(show_viewer, tol):
         assert_allclose((link_a_[1], link_b_[1]), ((link_a,), (link_b,)), tol=0)
 
 
+@pytest.mark.slow  # ~100s
 @pytest.mark.parametrize(
     "n_envs, batched, backend",
     [
@@ -3210,6 +3215,7 @@ def test_mesh_primitive_COM(show_viewer, tol):
     assert_allclose(cube_COM[2], 0.25, atol=2e-3)
 
 
+@pytest.mark.slow  # ~110s
 @pytest.mark.required
 @pytest.mark.parametrize("scale", [0.1, 10.0])
 @pytest.mark.parametrize("box_box_detection", [False, True])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -107,6 +107,7 @@ def _ti_kernel_wrapper(ti_func, num_inputs, num_outputs, *args):
     return kernel
 
 
+@pytest.mark.slow  # ~110s
 @pytest.mark.required
 @pytest.mark.parametrize("batch_shape", [(10, 40, 25), ()])
 def test_utils_geom_taichi_vs_tensor_consistency(batch_shape):


### PR DESCRIPTION
## Description

This will schedule them in priority, so that pytest-xdist worksteal scheduling mechanism can better balance the workload across workers. This should ultimately speed up the CI job in production by maxing out compute for the entire duration of the workflow. Besides, it makes it easier for devs to run almost the entire test suite much faster to validate local changes.

