### PR TITLE
Update observations after reset and add camera for headless rendering…

### DIFF
--- a/examples/locomotion/go2_eval.py
+++ b/examples/locomotion/go2_eval.py
@@ -25,6 +25,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-e", "--exp_name", type=str, default="go2-walking")
     parser.add_argument("--ckpt", type=int, default=100)
+    parser.add_argument("--headless_render", action="store_true",help="Enable headless rendering")
     args = parser.parse_args()
 
     gs.init(backend=gs.cpu)
@@ -39,7 +40,8 @@ def main():
         obs_cfg=obs_cfg,
         reward_cfg=reward_cfg,
         command_cfg=command_cfg,
-        show_viewer=True,
+        show_viewer= not args.headless_render,
+        headless_render=args.headless_render
     )
 
     runner = OnPolicyRunner(env, train_cfg, log_dir, device=gs.device)
@@ -47,11 +49,22 @@ def main():
     runner.load(resume_path)
     policy = runner.get_inference_policy(device=gs.device)
 
+    if args.headless_render:
+        env.camera.start_recording()
     obs, _ = env.reset()
+
     with torch.no_grad():
-        while True:
-            actions = policy(obs)
-            obs, rews, dones, infos = env.step(actions)
+        if args.headless_render:
+            for i in range(1000):
+                actions = policy(obs)
+                obs, rews, dones, infos = env.step(actions)
+                env.camera.render()
+
+            env.camera.stop_recording(save_to_filename=f'locomotion-{args.ckpt}.mp4', fps=60)
+        else:
+            while True:
+                actions = policy(obs)
+                obs, rews, dones, infos = env.step(actions)        
 
 
 if __name__ == "__main__":
@@ -59,5 +72,6 @@ if __name__ == "__main__":
 
 """
 # evaluation
-python examples/locomotion/go2_eval.py -e go2-walking -v --ckpt 100
+python examples/locomotion/go2_eval.py -e go2-walking --ckpt 100
+python examples/locomotion/go2_eval.py -e go2-walking --ckpt 100 --headless_render
 """


### PR DESCRIPTION
#### ✨ FEATURE / 🐛 BUG FIX: Fix Stale Observations on Reset & Add Headless Rendering

This PR contains a bug fix for environment observation logic and introduces a new feature for generating evaluation videos without a viewer (headless rendering).


#### 1. 🐛 Observation Bug Fix in `go2_env.py`
The original implementation of `Go2Env.reset()` returned an observation buffer (`self.obs_buf`) that contained data from the final step of the previous episode, not the true state of the newly reset environment.
**Changes:** 
A new helper method `_update_state()` was introduced to consolidate the logic for calculating base state (velocities, gravity, dof positions) and refreshing `self.obs_buf._update_state()` is now called at the end of both `step()` and `reset()`.

**Benefit:**
Ensures the policy receives an accurate state observation immediately following a reset, which is crucial for stable Reinforcement Learning.

#### 2. ✨ Headless Rendering Feature:
This feature allows users to easily record evaluation videos on machines without a display or window manager (e.g., remote servers).
**Changes:**
`go2_env.py`: Added a headless_render argument to `Go2Env.__init__`.  If true, a dedicated off-screen camera is initialized for video recording.
`go2_eval.py:`Added a new command-line argument:` --headless_render`.If `--headless_render` is enabled, the script runs for a fixed 1000 steps, records video frames via `env.camera.render()`, and saves the output to an MP4 file.
**Usage/Testing:**
To test the headless video generation:Bash# Generate and save a video:
python examples/locomotion/go2_eval.py -e go2-walking --ckpt 100 --headless_render

# Run standard interactive viewer:
python examples/locomotion/go2_eval.py -e go2-walking --ckpt 100


Video recorded in headless_render mode after training policy with updated code and recorded using the added headless code:


https://github.com/user-attachments/assets/918c1237-5c29-4ef0-a799-524f751e3f61

