### PR TITLE
[BUG FIX] gravity dimension mismatch

### DIFF
--- a/examples/locomotion/go2_env.py
+++ b/examples/locomotion/go2_env.py
@@ -89,7 +89,7 @@ class Go2Env:
         self.robot.set_dofs_kv([self.env_cfg["kd"]] * self.num_actions, self.motors_dof_idx)
 
         # Define global gravity direction vector
-        self.global_gravity = torch.tensor([0.0, 0.0, -1.0], dtype=gs.tc_float, device=gs.device)
+        self.init_global_gravity = torch.tensor([0.0, 0.0, -1.0], dtype=gs.tc_float, device=gs.device)
 
         # Initial state
         self.init_base_pos = torch.tensor(self.env_cfg["base_init_pos"], dtype=gs.tc_float, device=gs.device)
@@ -101,7 +101,7 @@ class Go2Env:
             device=gs.device,
         )
         self.init_qpos = torch.concatenate((self.init_base_pos, self.init_base_quat, self.init_dof_pos))
-        self.init_projected_gravity = transform_by_quat(self.global_gravity, self.inv_base_init_quat)
+        self.init_projected_gravity = transform_by_quat(self.init_global_gravity, self.inv_base_init_quat)
 
         # initialize buffers
         self.base_lin_vel = torch.empty((self.num_envs, 3), dtype=gs.tc_float, device=gs.device)
@@ -130,6 +130,7 @@ class Go2Env:
         self.dof_pos = torch.empty_like(self.actions)
         self.dof_vel = torch.empty_like(self.actions)
         self.last_dof_vel = torch.zeros_like(self.actions)
+        self.global_gravity = torch.tensor([[0.0, 0.0, -1.0]] * self.num_envs, dtype=gs.tc_float, device=gs.device)
         self.base_pos = torch.empty((self.num_envs, 3), dtype=gs.tc_float, device=gs.device)
         self.base_quat = torch.empty((self.num_envs, 4), dtype=gs.tc_float, device=gs.device)
         self.default_dof_pos = torch.tensor(


### PR DESCRIPTION
## Description

**Error occurred when running the reinforcement learning sample command `python examples/locomotion/go2_train.py. `**

**The error message is as follows：**
```
Traceback (most recent call last):
  File "/home/long/Genesis/examples/locomotion/go2_train.py", line 180, in <module>
    main()
  File "/home/long/Genesis/examples/locomotion/go2_train.py", line 176, in main
    runner.learn(num_learning_iterations=args.max_iterations, init_at_random_ep_len=True)
  File "/home/long/miniforge3/envs/genesis/lib/python3.10/site-packages/rsl_rl/runners/on_policy_runner.py", line 151, in learn
    obs, rewards, dones, infos = self.env.step(actions.to(self.env.device))
  File "/home/long/Genesis/examples/locomotion/go2_env.py", line 174, in step
    self.projected_gravity = transform_by_quat(self.global_gravity, inv_base_quat)
  File "/home/long/miniforge3/envs/genesis/lib/python3.10/site-packages/genesis/utils/geom.py", line 1048, in transform_by_quat
    return _tc_transform_by_quat(v, quat)
RuntimeError: The following operation failed in the TorchScript interpreter.
Traceback of TorchScript (most recent call last):
  File "/home/long/miniforge3/envs/genesis/lib/python3.10/site-packages/genesis/utils/geom.py", line 1032, in _tc_transform_by_quat
    v_x, v_y, v_z = vs[..., :1], vs[..., 1:2], vs[..., 2:]

    u_x.copy_(v_x * (q_xx + q_ww - q_yy - q_zz) + v_y * (2.0 * q_xy - 2.0 * q_wz) + v_z * (2.0 * q_xz + 2.0 * q_wy))
    ~~~~~~~~~ <--- HERE
    u_y.copy_(v_x * (2.0 * q_wz + 2.0 * q_xy) + v_y * (q_ww - q_xx + q_yy - q_zz) + v_z * (2.0 * q_yz - 2.0 * q_wx))
    u_z.copy_(v_x * (2.0 * q_xz - 2.0 * q_wy) + v_y * (2.0 * q_wx + 2.0 * q_yz) + v_z * (q_ww - q_xx - q_yy + q_zz))
RuntimeError: output with shape [1] doesn't match the broadcast shape [4096, 1]
```