### PR TITLE
[MISC] Avoid argument unpacking in GsTaichi kernels fo SFSolver.

### DIFF
--- a/genesis/engine/solvers/sf_solver.py
+++ b/genesis/engine/solvers/sf_solver.py
@@ -171,10 +171,10 @@ class SFSolver(Solver):
             u, v, w = I
             pl = self.grid.p[self.compute_location(u, v, w, -1, 0, 0)]
             pr = self.grid.p[self.compute_location(u, v, w, 1, 0, 0)]
-            pb = self.grid.p[self.compute_location(u, v, w,  0, -1, 0)]
-            pt = self.grid.p[self.compute_location(u, v, w,  0, 1, 0)]
-            pp = self.grid.p[self.compute_location(u, v, w,  0, 0, -1)]
-            pq = self.grid.p[self.compute_location(u, v, w,  0, 0, 1)]
+            pb = self.grid.p[self.compute_location(u, v, w, 0, -1, 0)]
+            pt = self.grid.p[self.compute_location(u, v, w, 0, 1, 0)]
+            pp = self.grid.p[self.compute_location(u, v, w, 0, 0, -1)]
+            pq = self.grid.p[self.compute_location(u, v, w, 0, 0, 1)]
 
             self.grid.v[I] = self.grid.v_tmp[I] - 0.5 * ti.Vector([pr - pl, pt - pb, pq - pp], dt=gs.ti_float)
 


### PR DESCRIPTION
## Description

Remove *-calling on sf_solver, which is no longer supported in future gstaichi change to make py dataclass parameters renamable in https://github.com/Genesis-Embodied-AI/gstaichi/pull/333 