### PR TITLE
[MISC] Store texture path for primitive morphs as metadata.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1,8 +1,8 @@
+import inspect
 from copy import copy
 from itertools import chain
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, Any
 from functools import wraps
-import inspect
 
 import gstaichi as ti
 import numpy as np
@@ -164,6 +164,8 @@ class RigidEntity(Entity):
             n_dofs = 6
             init_qpos = np.concatenate([morph.pos, morph.quat])
 
+        metadata: dict[str, Any] = {"texture_path": None}
+
         if isinstance(morph, gs.options.morphs.Box):
             extents = np.array(morph.size)
             tmesh = mu.create_box(extents=extents)
@@ -171,45 +173,35 @@ class RigidEntity(Entity):
             geom_data = extents
             geom_type = gs.GEOM_TYPE.BOX
             link_name_prefix = "box"
-
         elif isinstance(morph, gs.options.morphs.Sphere):
             tmesh = mu.create_sphere(radius=morph.radius)
             cmesh = tmesh
             geom_data = np.array([morph.radius])
             geom_type = gs.GEOM_TYPE.SPHERE
             link_name_prefix = "sphere"
-
         elif isinstance(morph, gs.options.morphs.Cylinder):
             tmesh = mu.create_cylinder(radius=morph.radius, height=morph.height)
             cmesh = tmesh
             geom_data = None
             geom_type = gs.GEOM_TYPE.MESH
             link_name_prefix = "cylinder"
-
         elif isinstance(morph, gs.options.morphs.Plane):
+            metadata["texture_path"] = mu.DEFAULT_PLANE_TEXTURE_PATH
             tmesh, cmesh = mu.create_plane(
                 normal=morph.normal,
                 plane_size=morph.plane_size,
                 tile_size=morph.tile_size,
-                texture_path=mu.DEFAULT_PLANE_TEXTURE_PATH
+                color_or_texture=metadata["texture_path"],
             )
             geom_data = np.array(morph.normal)
             geom_type = gs.GEOM_TYPE.PLANE
             link_name_prefix = "plane"
-
         else:
             gs.raise_exception("Unsupported primitive shape")
 
         # contains one visual geom (vgeom) and one collision geom (geom)
         g_infos = []
         if morph.visualization:
-            # For planes with textures, store the texture path in metadata
-            metadata = {}
-            if isinstance(morph, gs.options.morphs.Plane):
-                # Check if a texture was applied (not a solid color)
-                if hasattr(tmesh.visual, 'material') and tmesh.visual.material is not None:
-                    metadata["texture_path"] = mu.DEFAULT_PLANE_TEXTURE_PATH
-
             g_infos.append(
                 dict(
                     contype=0,

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -37,7 +37,7 @@ CVX_PATH_QUANTIZE_FACTOR = 1e-6
 Y_UP_TRANSFORM = np.asarray(  # translation on the bottom row
     [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, -1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float32
 )
-DEFAULT_PLANE_TEXTURE_PATH = "textures/checker.png"
+DEFAULT_PLANE_TEXTURE_PATH = "textures/checker.png"  # use checkerboard texture by default
 
 
 class MeshInfo:
@@ -891,7 +891,14 @@ def create_box(extents=None, color=(1.0, 1.0, 1.0, 1.0), bounds=None, wireframe=
     return mesh
 
 
-def create_plane(normal=(0.0, 0.0, 1.0), plane_size=(1e3, 1e3), tile_size=(1, 1), color=None, texture_path=DEFAULT_PLANE_TEXTURE_PATH):
+def create_plane(
+    normal=(0.0, 0.0, 1.0), plane_size=(1e3, 1e3), tile_size=(1, 1), color_or_texture=DEFAULT_PLANE_TEXTURE_PATH
+):
+    if isinstance(color_or_texture, str):
+        color, texture_path = None, color_or_texture
+    else:
+        color, texture_path = color_or_texture, None
+
     thickness = 1e-2  # for safety
     mesh = trimesh.creation.box(extents=[plane_size[0], plane_size[1], thickness])
     mesh.vertices[:, 2] -= thickness / 2
@@ -914,7 +921,7 @@ def create_plane(normal=(0.0, 0.0, 1.0), plane_size=(1e3, 1e3), tile_size=(1, 1)
     vmesh.vertices[:, 2] -= thickness / 2
     vmesh.vertices = gu.transform_by_R(vmesh.vertices, gu.z_up_to_R(np.asarray(normal, dtype=np.float32)))
 
-    if color is None:  # use checkerboard texture
+    if texture_path is not None:
         n_tile_x, n_tile_y = plane_size[0] / tile_size[0], plane_size[1] / tile_size[1]
         vmesh.visual = trimesh.visual.TextureVisuals(
             uv=np.array(

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -510,6 +510,7 @@ def test_2_channels_luminance_alpha_textures(show_viewer):
         )
     )
 
+
 @pytest.mark.required
 def test_plane_texture_path_preservation(show_viewer):
     """Test that plane primitives preserve texture paths in metadata."""
@@ -518,6 +519,7 @@ def test_plane_texture_path_preservation(show_viewer):
 
     # The texture path should be stored in metadata
     assert plane.vgeoms[0].vmesh.metadata["texture_path"] == "textures/checker.png"
+
 
 @pytest.mark.required
 @pytest.mark.skipif(platform.machine() == "aarch64", reason="Module 'tetgen' is crashing on Linux ARM.")


### PR DESCRIPTION
Store "default" texture path for the plane primitive in Mesh.metadata, similar to other paths, so it can be retrieved later by other tools, exporters, etc.
Changes summary:
1- genesis/utils/mesh.py - create_plane(...)
The function that sets the default texture on the plane, also adds it to a metadata dictionary, and returns the meta data to its caller.
2- genesis/engine/entities/rigid_entity/rigid_entity.py - _load_primitive(...)
Here we add the metadata from create_plane to the gs.Mesh.from_trimesh call

The unit test in test_mesh.py::test_plane_texture_path_preservation just makes sure that texture path is preserved in the vgeom.vmeh.metadata