### PR TITLE
[BUG FIX] Fix viewer not closed at scene destroy if running in background thread.

### DIFF
--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -1358,8 +1358,9 @@ class Viewer(pyglet.window.Window):
                 try:
                     self.refresh()
                 except AttributeError:
-                    # The graphical window has been closed
-                    self.on_close()
+                    # The graphical window has been closed manually
+                    pass
+            self.on_close()
         else:
             self.refresh()
 
@@ -1373,8 +1374,9 @@ class Viewer(pyglet.window.Window):
             try:
                 self.refresh()
             except AttributeError:
-                # The graphical window has been closed
-                self.on_close()
+                # The graphical window has been closed manually
+                pass
+        self.on_close()
 
     def refresh(self):
         viewer_thread = self._thread or threading.main_thread()


### PR DESCRIPTION
## Related Issue

Resolves https://github.com/Genesis-Embodied-AI/Genesis/issues/2231