### PR TITLE
[BUG FIX] Fix wrong sampler for SPH solver causing numerical stability issues.

### DIFF
--- a/examples/tutorials/sph_liquid.py
+++ b/examples/tutorials/sph_liquid.py
@@ -32,7 +32,7 @@ plane = scene.add_entity(
 liquid = scene.add_entity(
     # viscous liquid
     # material=gs.materials.SPH.Liquid(mu=0.02, gamma=0.02),
-    material=gs.materials.SPH.Liquid(sampler="regular"),
+    material=gs.materials.SPH.Liquid(),
     morph=gs.morphs.Box(
         pos=(0.0, 0.0, 0.65),
         size=(0.4, 0.4, 0.4),

--- a/genesis/engine/materials/SPH/liquid.py
+++ b/genesis/engine/materials/SPH/liquid.py
@@ -21,12 +21,11 @@ class Liquid(Base):
     gamma: float, optional
         The surface tension of the liquid. Controls how strongly the material "clumps" together at boundaries. Default is 0.01
     sampler: str, optional
-        Particle sampler ('pbs', 'regular', 'random'). Note that 'pbs' is only supported on Linux x86 for now. Defaults
-        to 'regular' because:
-
+        Particle sampler ('pbs', 'regular', 'random'). Note that 'pbs' is only supported on Linux x86 for now. Defaults to 'regular' because:
         SPH is sensitive to the initial particle distribution, as it directly determines the initial density and pressure fields.
         To ensure numerical stability, particles must be initialized using a regular sampler that enforces near-uniform spacing.
-        Irregular samplers (e.g. pbs, random) introduce local density fluctuations at initialization, which lead to large spurious pressure forces and can cause the simulation to become unstable or diverge.
+        Irregular samplers (e.g. pbs, random) introduce local density fluctuations at initialization,
+        which lead to large spurious pressure forces and can cause the simulation to become unstable or diverge.
     """
 
     def __init__(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines: 
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
2. Prepare your PR according to the "Submitting Code Changes" 
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/CONTRIBUTING.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [CHANGING] for changes that will change simulation's behaviour
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->
SPH is sensitive to the initial particle distribution, as it directly determines the initial density and pressure fields.

To ensure numerical stability, particles must be initialized using a regular sampler that enforces near-uniform spacing.
Irregular samplers (e.g. pbs, random) introduce local density fluctuations at initialization, which lead to large spurious pressure forces and can cause the simulation to become unstable or diverge.

The current implementation uses the `pbs` particle sampler by default, which results in unstable behavior, as shown in the comparison below on https://github.com/Genesis-Embodied-AI/Genesis/blob/main/examples/tutorials/sph_liquid.py.

<table>
  <tr>
    <th>Irregular sampler (<code>pbs</code>)</th>
    <th>Regular sampler</th>
  </tr>
  <tr>
    <td align="center">
      <video src="https://github.com/user-attachments/assets/f667ec94-91b1-4e9f-8d84-cc9eb60ee66a"
             width="100%" controls></video>
    </td>
    <td align="center">
      <video src="https://github.com/user-attachments/assets/47db3a9a-955d-4a8b-b312-b2f314eeb9be"
             width="100%" controls></video>
    </td>
  </tr>
</table>


## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [ ] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
