### PR TITLE
[BUG FIX] Fix 'draw_debug_frames' after PR#1869.

### DIFF
--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -832,7 +832,7 @@ class RasterizerContext:
 
     def draw_debug_frames(self, poses, axis_length=1.0, origin_size=0.015, axis_radius=0.01):
         mesh = trimesh.creation.axis(origin_size=origin_size, axis_radius=axis_radius, axis_length=axis_length)
-        node = pyrender.Mesh.from_trimesh(mesh, name=f"debug_frame_{gs.UID()}", is_marker=True)
+        node = pyrender.Mesh.from_trimesh(mesh, name=f"debug_frame_{gs.UID()}", poses=poses, is_marker=True)
         self.add_external_node(node)
         return node
 


### PR DESCRIPTION
## Related Issue

Resolves https://github.com/Genesis-Embodied-AI/Genesis/issues/2049

## How Has This Been / Can This Be Tested?

Run `python examples/tutorials/IK_motion_planning_grasp.py`