### PR TITLE
[BUG FIX] Fix keyboard teleop when viewer has focus via reserved_keys

### DIFF
--- a/genesis/options/vis.py
+++ b/genesis/options/vis.py
@@ -35,6 +35,13 @@ class ViewerOptions(Options):
         The field of view (in degrees) of the camera.
     disable_keyboard_shortcuts : bool
         Whether to disable all keyboard shortcuts in the viewer. Defaults to False.
+    reserved_keys : tuple of int, optional
+        Key symbols (e.g. from ``pyglet.window.key``) reserved for the application.
+        The viewer will not use these keys for its shortcuts; their press state is
+        tracked and can be read via :meth:`genesis.vis.viewer.Viewer.get_pressed_keys`.
+        Use this so application key bindings (e.g. arrow keys for teleop) take
+        priority over the viewer's shortcuts when the window has focus, without
+        disabling the viewer's shortcuts for other keys.
     """
 
     res: Optional[tuple] = None
@@ -47,6 +54,7 @@ class ViewerOptions(Options):
     camera_fov: float = 40
     enable_interaction: bool = False
     disable_keyboard_shortcuts: bool = False
+    reserved_keys: Optional[tuple] = None
 
 
 class VisOptions(Options):

--- a/genesis/vis/viewer.py
+++ b/genesis/vis/viewer.py
@@ -42,6 +42,7 @@ class Viewer(RBC):
         self._camera_fov = options.camera_fov
         self._enable_interaction = options.enable_interaction
         self._disable_keyboard_shortcuts = options.disable_keyboard_shortcuts
+        self._reserved_keys = options.reserved_keys
 
         # Validate viewer options
         if any(e.shape != (3,) for e in (self._camera_init_pos, self._camera_init_lookat, self._camera_up)):
@@ -102,6 +103,7 @@ class Viewer(RBC):
                         env_separate_rigid=self.context.env_separate_rigid,
                         enable_interaction=self._enable_interaction,
                         disable_keyboard_shortcuts=self._disable_keyboard_shortcuts,
+                        reserved_keys=self._reserved_keys,
                         viewer_flags={
                             "window_title": f"Genesis {gs.__version__}",
                             "refresh_rate": self._refresh_rate,
@@ -174,6 +176,10 @@ class Viewer(RBC):
         # lock FPS
         if self._max_FPS is not None:
             self.rate.sleep()
+
+    def get_pressed_keys(self):
+        """Return the set of key symbols currently held down (only populated when ViewerOptions.reserved_keys is set)."""
+        return self._pyrender_viewer.get_pressed_keys()
 
     def close_offscreen(self, render_target):
         return self._pyrender_viewer.close_offscreen(render_target)


### PR DESCRIPTION
## Description

When the viewer window has focus, keyboard events are consumed by the pyrender/pyglet event loop, so pynput-based teleop (e.g. arrow keys in `keyboard_teleop`) does not receive them. This PR adds an optional **reserved_keys** mechanism so that application-defined keys take priority over the viewer’s shortcuts for those keys only, without disabling the viewer’s shortcuts for other keys.

**Changes:**
- **genesis/options/vis.py**: Add `ViewerOptions.reserved_keys` (optional tuple of pyglet key symbols). When set, the viewer does not use these keys for its shortcuts and tracks their state for `get_pressed_keys()`.
- **genesis/vis/viewer.py**: Pass `reserved_keys` to the pyrender Viewer; add `get_pressed_keys()` that delegates to the pyrender viewer.
- **genesis/ext/pyrender/viewer.py**: Add `reserved_keys` parameter; when non-empty, track key state for those symbols, skip default shortcut handling for them, and expose `get_pressed_keys()` and `on_deactivate()` to clear state on focus loss.
- **examples/keyboard_teleop.py**: Use `ViewerOptions(reserved_keys=RESERVED_KEYS)` for teleop keys and merge `scene.viewer.get_pressed_keys()` with pynput so teleop works with or without viewer focus; do not use `disable_keyboard_shortcuts`, so GUI shortcuts (e.g. [a], [z], [r]) remain available.

Backward compatible: if `reserved_keys` is not set, viewer behavior is unchanged.

## Motivation and Context

In `keyboard_teleop.py`, arrow keys and other teleop keys had no effect when the user was focused on the Genesis viewer, because the viewer’s event loop received the key events first and pynput did not see them. The only workaround was `disable_keyboard_shortcuts=True`, which disables all viewer shortcuts (camera reset, record, etc.). This PR fixes the bug in a non-invasive way: only keys listed in `reserved_keys` are reserved for the application; all other keys keep their default viewer shortcuts.

## How Has This Been / Can This Be Tested?

- **Environment**: Windows 10, Python with Genesis and pynput installed.
- **Steps**:
  1. Run `python examples/keyboard_teleop.py`.
  2. Click inside the viewer window to give it focus.
  3. Press arrow keys (↑↓←→) and n/m/j/k/u/space: end-effector and gripper should respond.
  4. Press [a], [z], [r], etc.: viewer shortcuts (camera rotation, reset, record) should still work.
  5. Optionally click outside the viewer and press the same teleop keys: pynput fallback should still work.
- All tests were run and passed.

## Screenshots (if appropriate):

N/A

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.