### PR TITLE
[MISC] Speed up linesearch via reducing global reads by recomputing quad.

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -1,4 +1,3 @@
-import os
 from typing import TYPE_CHECKING
 
 import gstaichi as ti
@@ -20,9 +19,6 @@ if TYPE_CHECKING:
 
 
 IS_OLD_TORCH = tuple(map(int, torch.__version__.split(".")[:2])) < (2, 8)
-USE_LS_RECOMPUTE = os.environ.get("GS_SOLVER_LS_RECOMPUTE", "0") == "1"
-# TODO: set default to True for debug
-USE_LS_RECOMPUTE = 1
 
 
 class ConstraintSolver:
@@ -92,7 +88,7 @@ class ConstraintSolver:
         self.mv = cs.mv
         self.jv = cs.jv
         self.quad_gauss = cs.quad_gauss
-        self.quad = cs.quad
+
         self.candidates = cs.candidates
         self.ls_it = cs.ls_it
         self.ls_result = cs.ls_result
@@ -1900,19 +1896,14 @@ def func_ls_init_and_eval_p0_opt(
 ):
     """Fused linesearch initialization and first evaluation point (alpha=0) for a single environment.
 
-    This function merges what were originally two separate operations — initializing the linesearch state (computing mv,
-    jv, quad, quad_gauss) and evaluating the cost at alpha=0 — into a single pass. It also pre-computes eq_sum, the
-    summed quadratic coefficients for equality constraints, and stores it for reuse by subsequent evaluation calls.
+    Merges init (computing mv, jv, quad_gauss) and alpha=0 evaluation into a single pass, and pre-computes eq_sum
+    (the summed quadratic coefficients for always-active equality constraints) for reuse by subsequent evaluation calls.
 
-    The key optimization is exploiting the fact that equality constraints (weld, connect, joint-equality) are always
-    active regardless of alpha. Their contribution to the cost function is constant across all linesearch iterations, so
-    it only needs to be computed once during initialization. By pre-summing eq_sum here, all subsequent calls to
-    func_ls_point_fn_opt and func_ls_point_fn_3alphas_opt can skip iterating over equality constraints entirely,
-    reducing the per-iteration constraint loop from n_constraints to (n_friction + n_contact + n_joint_limit).
-
-    This optimization is most beneficial for scenes with many equality constraints (e.g. multi-body systems connected
-    by weld or connect constraints), where equality constraints can dominate the constraint count. For contact-only
-    scenes with no equality constraints, the speedup is minimal."""
+    Bandwidth optimization: quad coefficients (D*Ja*Ja, D*jv*Ja, D*jv*jv) are recomputed on the fly from Jaref, jv,
+    and efc_D (~8 FLOPs per constraint) instead of being precomputed and stored to a separate quad array. At 0.2%
+    compute utilization (0.40 FLOPs/byte, 147x below roofline), this trades negligible compute for eliminating 3 global
+    memory writes per constraint during init and 3 reads per constraint in every subsequent evaluation call — a 40%
+    bandwidth reduction for contacts (5→3 loads) and 29% for friction (7→5 loads) in the hottest loop."""
     n_dofs = constraint_state.search.shape[0]
     n_entities = entities_info.dof_start.shape[0]
     ne = constraint_state.n_constraints_equality[i_b]
@@ -1959,99 +1950,41 @@ def func_ls_init_and_eval_p0_opt(
     eq_sum_1 = gs.ti_float(0.0)
     eq_sum_2 = gs.ti_float(0.0)
 
-    if ti.static(USE_LS_RECOMPUTE):
-        # Fused loop: read from original arrays, recompute quad on the fly, no quad writes
-        for i_c in range(n_con):
-            Jaref_c = constraint_state.Jaref[i_c, i_b]
-            jv_c = constraint_state.jv[i_c, i_b]
-            D = constraint_state.efc_D[i_c, i_b]
-            qf_0 = D * (0.5 * Jaref_c * Jaref_c)
-            qf_1 = D * (jv_c * Jaref_c)
-            qf_2 = D * (0.5 * jv_c * jv_c)
+    # Recompute quad on the fly from Jaref, jv, efc_D — avoids writing/reading the quad array entirely.
+    # 3 loads per constraint (Jaref, jv, D) + ~8 FLOPs, vs 3 writes + 3 reads through global memory.
+    for i_c in range(n_con):
+        Jaref_c = constraint_state.Jaref[i_c, i_b]
+        jv_c = constraint_state.jv[i_c, i_b]
+        D = constraint_state.efc_D[i_c, i_b]
+        qf_0 = D * (0.5 * Jaref_c * Jaref_c)
+        qf_1 = D * (jv_c * Jaref_c)
+        qf_2 = D * (0.5 * jv_c * jv_c)
 
-            if i_c < ne:
-                # Equality: always active
-                eq_sum_0 = eq_sum_0 + qf_0
-                eq_sum_1 = eq_sum_1 + qf_1
-                eq_sum_2 = eq_sum_2 + qf_2
-                quad_total_0 = quad_total_0 + qf_0
-                quad_total_1 = quad_total_1 + qf_1
-                quad_total_2 = quad_total_2 + qf_2
-            elif i_c < nef:
-                # Friction: check linear regime at x=Jaref (alpha=0)
-                f = constraint_state.efc_frictionloss[i_c, i_b]
-                r = constraint_state.diag[i_c, i_b]
-                rf = r * f
-                linear_neg = Jaref_c <= -rf
-                linear_pos = Jaref_c >= rf
-                if linear_neg or linear_pos:
-                    qf_0 = linear_neg * f * (-0.5 * rf - Jaref_c) + linear_pos * f * (-0.5 * rf + Jaref_c)
-                    qf_1 = linear_neg * (-f * jv_c) + linear_pos * (f * jv_c)
-                    qf_2 = 0.0
-                quad_total_0 = quad_total_0 + qf_0
-                quad_total_1 = quad_total_1 + qf_1
-                quad_total_2 = quad_total_2 + qf_2
-            else:
-                # Contact: check Jaref < 0
-                active = Jaref_c < 0
-                quad_total_0 = quad_total_0 + qf_0 * active
-                quad_total_1 = quad_total_1 + qf_1 * active
-                quad_total_2 = quad_total_2 + qf_2 * active
-    else:
-        # Baseline: precompute quad, write to global, read back per type
-        for i_c in range(n_con):
-            qf_0 = constraint_state.efc_D[i_c, i_b] * (
-                0.5 * constraint_state.Jaref[i_c, i_b] * constraint_state.Jaref[i_c, i_b]
-            )
-            qf_1 = constraint_state.efc_D[i_c, i_b] * (constraint_state.jv[i_c, i_b] * constraint_state.Jaref[i_c, i_b])
-            qf_2 = constraint_state.efc_D[i_c, i_b] * (
-                0.5 * constraint_state.jv[i_c, i_b] * constraint_state.jv[i_c, i_b]
-            )
-            constraint_state.quad[i_c, 0, i_b] = qf_0
-            constraint_state.quad[i_c, 1, i_b] = qf_1
-            constraint_state.quad[i_c, 2, i_b] = qf_2
-
-        # Equality constraints [0, ne): always active, accumulate eq_sum
-        for i_c in range(ne):
-            qf_0 = constraint_state.quad[i_c, 0, i_b]
-            qf_1 = constraint_state.quad[i_c, 1, i_b]
-            qf_2 = constraint_state.quad[i_c, 2, i_b]
+        if i_c < ne:
+            # Equality: always active
             eq_sum_0 = eq_sum_0 + qf_0
             eq_sum_1 = eq_sum_1 + qf_1
             eq_sum_2 = eq_sum_2 + qf_2
             quad_total_0 = quad_total_0 + qf_0
             quad_total_1 = quad_total_1 + qf_1
             quad_total_2 = quad_total_2 + qf_2
-
-        # Friction constraints [ne, nef): check linear regime at x=Jaref (alpha=0)
-        for i_c in range(ne, nef):
-            qf_0 = constraint_state.quad[i_c, 0, i_b]
-            qf_1 = constraint_state.quad[i_c, 1, i_b]
-            qf_2 = constraint_state.quad[i_c, 2, i_b]
-            x = constraint_state.Jaref[i_c, i_b]
+        elif i_c < nef:
+            # Friction: check linear regime at x=Jaref (alpha=0)
             f = constraint_state.efc_frictionloss[i_c, i_b]
             r = constraint_state.diag[i_c, i_b]
             rf = r * f
-            linear_neg = x <= -rf
-            linear_pos = x >= rf
+            linear_neg = Jaref_c <= -rf
+            linear_pos = Jaref_c >= rf
             if linear_neg or linear_pos:
-                qf_0 = linear_neg * f * (-0.5 * rf - constraint_state.Jaref[i_c, i_b]) + linear_pos * f * (
-                    -0.5 * rf + constraint_state.Jaref[i_c, i_b]
-                )
-                qf_1 = linear_neg * (-f * constraint_state.jv[i_c, i_b]) + linear_pos * (
-                    f * constraint_state.jv[i_c, i_b]
-                )
+                qf_0 = linear_neg * f * (-0.5 * rf - Jaref_c) + linear_pos * f * (-0.5 * rf + Jaref_c)
+                qf_1 = linear_neg * (-f * jv_c) + linear_pos * (f * jv_c)
                 qf_2 = 0.0
             quad_total_0 = quad_total_0 + qf_0
             quad_total_1 = quad_total_1 + qf_1
             quad_total_2 = quad_total_2 + qf_2
-
-        # Contact constraints [nef, n_con): check Jaref < 0 (alpha=0 so x=Jaref)
-        for i_c in range(nef, n_con):
-            active = constraint_state.Jaref[i_c, i_b] < 0
-            qf_0 = constraint_state.quad[i_c, 0, i_b]
-            qf_1 = constraint_state.quad[i_c, 1, i_b]
-            qf_2 = constraint_state.quad[i_c, 2, i_b]
+        else:
+            # Contact: check Jaref < 0
+            active = Jaref_c < 0
             quad_total_0 = quad_total_0 + qf_0 * active
             quad_total_1 = quad_total_1 + qf_1 * active
             quad_total_2 = quad_total_2 + qf_2 * active
@@ -2082,17 +2015,12 @@ def func_ls_point_fn_opt(
 ):
     """Evaluate linesearch cost, gradient, and curvature at a single candidate alpha.
 
-    This function computes the quadratic cost and its first two derivatives at a given step size alpha by iterating over
-    only friction, contact, and joint-limit constraints. Equality constraints (weld, connect, joint-equality) are
-    skipped entirely by initializing the accumulators from quad_gauss + eq_sum, where eq_sum was pre-computed by
-    func_ls_init_and_eval_p0_opt during initialization. The benefit scales with the ratio of equality constraints to
-    total constraints.
+    Iterates over only friction and contact constraints — equality constraints are skipped by initializing accumulators
+    from quad_gauss + eq_sum (pre-computed during init).
 
-    The original implementation uses a single loop over all constraints with if/elif branching to classify each
-    constraint by type (equality, friction, or contact). This function instead uses separate loops per type with
-    range-based indexing (range(ne, nef) for friction, range(nef, n_con) for contact), which eliminates the per-
-    iteration type-classification branches. On GPU, removing divergent branches within a constraint loop improves warp
-    execution efficiency, as all threads in a warp follow the same code path."""
+    Quad coefficients are recomputed on the fly from Jaref, jv, efc_D rather than read from a precomputed quad array.
+    This reduces per-constraint loads from 5 to 3 (contacts) and 7 to 5 (friction), a 40%/29% bandwidth reduction.
+    The ~8 FLOPs of recomputation per constraint are almost free."""
     ne = constraint_state.n_constraints_equality[i_b]
     nef = ne + constraint_state.n_constraints_frictionloss[i_b]
     n_con = constraint_state.n_constraints[i_b]
@@ -2102,75 +2030,41 @@ def func_ls_point_fn_opt(
     quad_total_1 = constraint_state.quad_gauss[1, i_b] + constraint_state.eq_sum[1, i_b]
     quad_total_2 = constraint_state.quad_gauss[2, i_b] + constraint_state.eq_sum[2, i_b]
 
-    if ti.static(USE_LS_RECOMPUTE):
-        # Friction constraints [ne, nef): read from original arrays, recompute quad on the fly
-        for i_c in range(ne, nef):
-            Jaref_c = constraint_state.Jaref[i_c, i_b]
-            jv_c = constraint_state.jv[i_c, i_b]
-            D = constraint_state.efc_D[i_c, i_b]
-            f = constraint_state.efc_frictionloss[i_c, i_b]
-            r = constraint_state.diag[i_c, i_b]
-            qf_0 = D * (0.5 * Jaref_c * Jaref_c)
-            qf_1 = D * (jv_c * Jaref_c)
-            qf_2 = D * (0.5 * jv_c * jv_c)
-            x = Jaref_c + alpha * jv_c
-            rf = r * f
-            linear_neg = x <= -rf
-            linear_pos = x >= rf
-            if linear_neg or linear_pos:
-                qf_0 = linear_neg * f * (-0.5 * rf - Jaref_c) + linear_pos * f * (-0.5 * rf + Jaref_c)
-                qf_1 = linear_neg * (-f * jv_c) + linear_pos * (f * jv_c)
-                qf_2 = 0.0
-            quad_total_0 = quad_total_0 + qf_0
-            quad_total_1 = quad_total_1 + qf_1
-            quad_total_2 = quad_total_2 + qf_2
+    # Friction constraints [ne, nef): 5 loads (Jaref, jv, D, f, diag) + recompute quad
+    for i_c in range(ne, nef):
+        Jaref_c = constraint_state.Jaref[i_c, i_b]
+        jv_c = constraint_state.jv[i_c, i_b]
+        D = constraint_state.efc_D[i_c, i_b]
+        f = constraint_state.efc_frictionloss[i_c, i_b]
+        r = constraint_state.diag[i_c, i_b]
+        qf_0 = D * (0.5 * Jaref_c * Jaref_c)
+        qf_1 = D * (jv_c * Jaref_c)
+        qf_2 = D * (0.5 * jv_c * jv_c)
+        x = Jaref_c + alpha * jv_c
+        rf = r * f
+        linear_neg = x <= -rf
+        linear_pos = x >= rf
+        if linear_neg or linear_pos:
+            qf_0 = linear_neg * f * (-0.5 * rf - Jaref_c) + linear_pos * f * (-0.5 * rf + Jaref_c)
+            qf_1 = linear_neg * (-f * jv_c) + linear_pos * (f * jv_c)
+            qf_2 = 0.0
+        quad_total_0 = quad_total_0 + qf_0
+        quad_total_1 = quad_total_1 + qf_1
+        quad_total_2 = quad_total_2 + qf_2
 
-        # Contact constraints [nef, n_con): read from original arrays, recompute quad on the fly
-        for i_c in range(nef, n_con):
-            Jaref_c = constraint_state.Jaref[i_c, i_b]
-            jv_c = constraint_state.jv[i_c, i_b]
-            D = constraint_state.efc_D[i_c, i_b]
-            x = Jaref_c + alpha * jv_c
-            active = x < 0
-            qf_0 = D * (0.5 * Jaref_c * Jaref_c)
-            qf_1 = D * (jv_c * Jaref_c)
-            qf_2 = D * (0.5 * jv_c * jv_c)
-            quad_total_0 = quad_total_0 + qf_0 * active
-            quad_total_1 = quad_total_1 + qf_1 * active
-            quad_total_2 = quad_total_2 + qf_2 * active
-    else:
-        # Baseline: read precomputed quad from global memory
-        for i_c in range(ne, nef):
-            x = constraint_state.Jaref[i_c, i_b] + alpha * constraint_state.jv[i_c, i_b]
-            qf_0 = constraint_state.quad[i_c, 0, i_b]
-            qf_1 = constraint_state.quad[i_c, 1, i_b]
-            qf_2 = constraint_state.quad[i_c, 2, i_b]
-            f = constraint_state.efc_frictionloss[i_c, i_b]
-            r = constraint_state.diag[i_c, i_b]
-            rf = r * f
-            linear_neg = x <= -rf
-            linear_pos = x >= rf
-            if linear_neg or linear_pos:
-                qf_0 = linear_neg * f * (-0.5 * rf - constraint_state.Jaref[i_c, i_b]) + linear_pos * f * (
-                    -0.5 * rf + constraint_state.Jaref[i_c, i_b]
-                )
-                qf_1 = linear_neg * (-f * constraint_state.jv[i_c, i_b]) + linear_pos * (
-                    f * constraint_state.jv[i_c, i_b]
-                )
-                qf_2 = 0.0
-            quad_total_0 = quad_total_0 + qf_0
-            quad_total_1 = quad_total_1 + qf_1
-            quad_total_2 = quad_total_2 + qf_2
-
-        for i_c in range(nef, n_con):
-            x = constraint_state.Jaref[i_c, i_b] + alpha * constraint_state.jv[i_c, i_b]
-            active = x < 0
-            qf_0 = constraint_state.quad[i_c, 0, i_b]
-            qf_1 = constraint_state.quad[i_c, 1, i_b]
-            qf_2 = constraint_state.quad[i_c, 2, i_b]
-            quad_total_0 = quad_total_0 + qf_0 * active
-            quad_total_1 = quad_total_1 + qf_1 * active
-            quad_total_2 = quad_total_2 + qf_2 * active
+    # Contact constraints [nef, n_con): 3 loads (Jaref, jv, D) + recompute quad
+    for i_c in range(nef, n_con):
+        Jaref_c = constraint_state.Jaref[i_c, i_b]
+        jv_c = constraint_state.jv[i_c, i_b]
+        D = constraint_state.efc_D[i_c, i_b]
+        x = Jaref_c + alpha * jv_c
+        active = x < 0
+        qf_0 = D * (0.5 * Jaref_c * Jaref_c)
+        qf_1 = D * (jv_c * Jaref_c)
+        qf_2 = D * (0.5 * jv_c * jv_c)
+        quad_total_0 = quad_total_0 + qf_0 * active
+        quad_total_1 = quad_total_1 + qf_1 * active
+        quad_total_2 = quad_total_2 + qf_2 * active
 
     cost = alpha * alpha * quad_total_2 + alpha * quad_total_1 + quad_total_0
     grad = 2 * alpha * quad_total_2 + quad_total_1
@@ -2194,14 +2088,12 @@ def func_ls_point_fn_3alphas_opt(
 ):
     """Evaluate linesearch cost, gradient, and curvature at three candidate alphas in a single constraint loop pass.
 
-    This function batches the evaluation of three candidate step sizes into one loop over constraints, amortizing the
-    cost of memory loads (Jaref, jv, quad, efc_D, etc.) across all three evaluations. Each constraint's data is loaded
-    once and used to update three independent sets of accumulators simultaneously.
+    Batches three candidate step sizes into one loop, amortizing per-constraint loads (Jaref, jv, efc_D, etc.) across
+    all three evaluations. Equality constraints are skipped via quad_gauss + eq_sum.
 
-    Like func_ls_point_fn_opt, equality constraints (weld, connect, joint-equality) are skipped by initializing all
-    three accumulator sets from quad_gauss + eq_sum. The combined effect of loop fusion (3x fewer constraint iterations
-    vs. three separate calls) and equality skipping makes this particularly effective in the refinement phase of the
-    linesearch, where it is called repeatedly inside a tight loop."""
+    Quad coefficients are recomputed on the fly from Jaref, jv, efc_D — same bandwidth optimization as
+    func_ls_point_fn_opt (3 loads per contact instead of 5, 5 per friction instead of 7). Combined with 3-alpha
+    batching, each constraint's data is loaded once from global memory and reused for 3 alpha evaluations."""
     ne = constraint_state.n_constraints_equality[i_b]
     nef = ne + constraint_state.n_constraints_frictionloss[i_b]
     n_con = constraint_state.n_constraints[i_b]
@@ -2215,149 +2107,78 @@ def func_ls_point_fn_3alphas_opt(
     t1_0, t1_1, t1_2 = base_0, base_1, base_2
     t2_0, t2_1, t2_2 = base_0, base_1, base_2
 
-    if ti.static(USE_LS_RECOMPUTE):
-        # Friction constraints [ne, nef): read from original arrays, recompute quad on the fly
-        for i_c in range(ne, nef):
-            Jaref_c = constraint_state.Jaref[i_c, i_b]
-            jv_c = constraint_state.jv[i_c, i_b]
-            D = constraint_state.efc_D[i_c, i_b]
-            f = constraint_state.efc_frictionloss[i_c, i_b]
-            r = constraint_state.diag[i_c, i_b]
-            qf_0 = D * (0.5 * Jaref_c * Jaref_c)
-            qf_1 = D * (jv_c * Jaref_c)
-            qf_2 = D * (0.5 * jv_c * jv_c)
-            rf = r * f
+    # Friction constraints [ne, nef): 5 loads (Jaref, jv, D, f, diag) + recompute quad, eval 3 alphas
+    for i_c in range(ne, nef):
+        Jaref_c = constraint_state.Jaref[i_c, i_b]
+        jv_c = constraint_state.jv[i_c, i_b]
+        D = constraint_state.efc_D[i_c, i_b]
+        f = constraint_state.efc_frictionloss[i_c, i_b]
+        r = constraint_state.diag[i_c, i_b]
+        qf_0 = D * (0.5 * Jaref_c * Jaref_c)
+        qf_1 = D * (jv_c * Jaref_c)
+        qf_2 = D * (0.5 * jv_c * jv_c)
+        rf = r * f
 
-            x0 = Jaref_c + alpha_0 * jv_c
-            ln0 = x0 <= -rf
-            lp0 = x0 >= rf
-            a0_qf_0, a0_qf_1, a0_qf_2 = qf_0, qf_1, qf_2
-            if ln0 or lp0:
-                a0_qf_0 = ln0 * f * (-0.5 * rf - Jaref_c) + lp0 * f * (-0.5 * rf + Jaref_c)
-                a0_qf_1 = ln0 * (-f * jv_c) + lp0 * (f * jv_c)
-                a0_qf_2 = 0.0
-            t0_0 = t0_0 + a0_qf_0
-            t0_1 = t0_1 + a0_qf_1
-            t0_2 = t0_2 + a0_qf_2
+        x0 = Jaref_c + alpha_0 * jv_c
+        ln0 = x0 <= -rf
+        lp0 = x0 >= rf
+        a0_qf_0, a0_qf_1, a0_qf_2 = qf_0, qf_1, qf_2
+        if ln0 or lp0:
+            a0_qf_0 = ln0 * f * (-0.5 * rf - Jaref_c) + lp0 * f * (-0.5 * rf + Jaref_c)
+            a0_qf_1 = ln0 * (-f * jv_c) + lp0 * (f * jv_c)
+            a0_qf_2 = 0.0
+        t0_0 = t0_0 + a0_qf_0
+        t0_1 = t0_1 + a0_qf_1
+        t0_2 = t0_2 + a0_qf_2
 
-            x1 = Jaref_c + alpha_1 * jv_c
-            ln1 = x1 <= -rf
-            lp1 = x1 >= rf
-            a1_qf_0, a1_qf_1, a1_qf_2 = qf_0, qf_1, qf_2
-            if ln1 or lp1:
-                a1_qf_0 = ln1 * f * (-0.5 * rf - Jaref_c) + lp1 * f * (-0.5 * rf + Jaref_c)
-                a1_qf_1 = ln1 * (-f * jv_c) + lp1 * (f * jv_c)
-                a1_qf_2 = 0.0
-            t1_0 = t1_0 + a1_qf_0
-            t1_1 = t1_1 + a1_qf_1
-            t1_2 = t1_2 + a1_qf_2
+        x1 = Jaref_c + alpha_1 * jv_c
+        ln1 = x1 <= -rf
+        lp1 = x1 >= rf
+        a1_qf_0, a1_qf_1, a1_qf_2 = qf_0, qf_1, qf_2
+        if ln1 or lp1:
+            a1_qf_0 = ln1 * f * (-0.5 * rf - Jaref_c) + lp1 * f * (-0.5 * rf + Jaref_c)
+            a1_qf_1 = ln1 * (-f * jv_c) + lp1 * (f * jv_c)
+            a1_qf_2 = 0.0
+        t1_0 = t1_0 + a1_qf_0
+        t1_1 = t1_1 + a1_qf_1
+        t1_2 = t1_2 + a1_qf_2
 
-            x2 = Jaref_c + alpha_2 * jv_c
-            ln2 = x2 <= -rf
-            lp2 = x2 >= rf
-            a2_qf_0, a2_qf_1, a2_qf_2 = qf_0, qf_1, qf_2
-            if ln2 or lp2:
-                a2_qf_0 = ln2 * f * (-0.5 * rf - Jaref_c) + lp2 * f * (-0.5 * rf + Jaref_c)
-                a2_qf_1 = ln2 * (-f * jv_c) + lp2 * (f * jv_c)
-                a2_qf_2 = 0.0
-            t2_0 = t2_0 + a2_qf_0
-            t2_1 = t2_1 + a2_qf_1
-            t2_2 = t2_2 + a2_qf_2
+        x2 = Jaref_c + alpha_2 * jv_c
+        ln2 = x2 <= -rf
+        lp2 = x2 >= rf
+        a2_qf_0, a2_qf_1, a2_qf_2 = qf_0, qf_1, qf_2
+        if ln2 or lp2:
+            a2_qf_0 = ln2 * f * (-0.5 * rf - Jaref_c) + lp2 * f * (-0.5 * rf + Jaref_c)
+            a2_qf_1 = ln2 * (-f * jv_c) + lp2 * (f * jv_c)
+            a2_qf_2 = 0.0
+        t2_0 = t2_0 + a2_qf_0
+        t2_1 = t2_1 + a2_qf_1
+        t2_2 = t2_2 + a2_qf_2
 
-        # Contact constraints [nef, n_con): read from original arrays, recompute quad on the fly
-        for i_c in range(nef, n_con):
-            Jaref_c = constraint_state.Jaref[i_c, i_b]
-            jv_c = constraint_state.jv[i_c, i_b]
-            D = constraint_state.efc_D[i_c, i_b]
-            qf_0 = D * (0.5 * Jaref_c * Jaref_c)
-            qf_1 = D * (jv_c * Jaref_c)
-            qf_2 = D * (0.5 * jv_c * jv_c)
+    # Contact constraints [nef, n_con): 3 loads (Jaref, jv, D) + recompute quad, eval 3 alphas
+    for i_c in range(nef, n_con):
+        Jaref_c = constraint_state.Jaref[i_c, i_b]
+        jv_c = constraint_state.jv[i_c, i_b]
+        D = constraint_state.efc_D[i_c, i_b]
+        qf_0 = D * (0.5 * Jaref_c * Jaref_c)
+        qf_1 = D * (jv_c * Jaref_c)
+        qf_2 = D * (0.5 * jv_c * jv_c)
 
-            x0 = Jaref_c + alpha_0 * jv_c
-            x1 = Jaref_c + alpha_1 * jv_c
-            x2 = Jaref_c + alpha_2 * jv_c
-            act0 = gs.ti_bool(x0 < 0)
-            act1 = gs.ti_bool(x1 < 0)
-            act2 = gs.ti_bool(x2 < 0)
-            t0_0 = t0_0 + qf_0 * act0
-            t0_1 = t0_1 + qf_1 * act0
-            t0_2 = t0_2 + qf_2 * act0
-            t1_0 = t1_0 + qf_0 * act1
-            t1_1 = t1_1 + qf_1 * act1
-            t1_2 = t1_2 + qf_2 * act1
-            t2_0 = t2_0 + qf_0 * act2
-            t2_1 = t2_1 + qf_1 * act2
-            t2_2 = t2_2 + qf_2 * act2
-    else:
-        # Baseline: read precomputed quad from global memory
-        for i_c in range(ne, nef):
-            Jaref_c = constraint_state.Jaref[i_c, i_b]
-            jv_c = constraint_state.jv[i_c, i_b]
-            qf_0 = constraint_state.quad[i_c, 0, i_b]
-            qf_1 = constraint_state.quad[i_c, 1, i_b]
-            qf_2 = constraint_state.quad[i_c, 2, i_b]
-            f = constraint_state.efc_frictionloss[i_c, i_b]
-            r = constraint_state.diag[i_c, i_b]
-            rf = r * f
-
-            x0 = Jaref_c + alpha_0 * jv_c
-            ln0 = x0 <= -rf
-            lp0 = x0 >= rf
-            a0_qf_0, a0_qf_1, a0_qf_2 = qf_0, qf_1, qf_2
-            if ln0 or lp0:
-                a0_qf_0 = ln0 * f * (-0.5 * rf - Jaref_c) + lp0 * f * (-0.5 * rf + Jaref_c)
-                a0_qf_1 = ln0 * (-f * jv_c) + lp0 * (f * jv_c)
-                a0_qf_2 = 0.0
-            t0_0 = t0_0 + a0_qf_0
-            t0_1 = t0_1 + a0_qf_1
-            t0_2 = t0_2 + a0_qf_2
-
-            x1 = Jaref_c + alpha_1 * jv_c
-            ln1 = x1 <= -rf
-            lp1 = x1 >= rf
-            a1_qf_0, a1_qf_1, a1_qf_2 = qf_0, qf_1, qf_2
-            if ln1 or lp1:
-                a1_qf_0 = ln1 * f * (-0.5 * rf - Jaref_c) + lp1 * f * (-0.5 * rf + Jaref_c)
-                a1_qf_1 = ln1 * (-f * jv_c) + lp1 * (f * jv_c)
-                a1_qf_2 = 0.0
-            t1_0 = t1_0 + a1_qf_0
-            t1_1 = t1_1 + a1_qf_1
-            t1_2 = t1_2 + a1_qf_2
-
-            x2 = Jaref_c + alpha_2 * jv_c
-            ln2 = x2 <= -rf
-            lp2 = x2 >= rf
-            a2_qf_0, a2_qf_1, a2_qf_2 = qf_0, qf_1, qf_2
-            if ln2 or lp2:
-                a2_qf_0 = ln2 * f * (-0.5 * rf - Jaref_c) + lp2 * f * (-0.5 * rf + Jaref_c)
-                a2_qf_1 = ln2 * (-f * jv_c) + lp2 * (f * jv_c)
-                a2_qf_2 = 0.0
-            t2_0 = t2_0 + a2_qf_0
-            t2_1 = t2_1 + a2_qf_1
-            t2_2 = t2_2 + a2_qf_2
-
-        for i_c in range(nef, n_con):
-            Jaref_c = constraint_state.Jaref[i_c, i_b]
-            jv_c = constraint_state.jv[i_c, i_b]
-            qf_0 = constraint_state.quad[i_c, 0, i_b]
-            qf_1 = constraint_state.quad[i_c, 1, i_b]
-            qf_2 = constraint_state.quad[i_c, 2, i_b]
-
-            x0 = Jaref_c + alpha_0 * jv_c
-            x1 = Jaref_c + alpha_1 * jv_c
-            x2 = Jaref_c + alpha_2 * jv_c
-            act0 = gs.ti_bool(x0 < 0)
-            act1 = gs.ti_bool(x1 < 0)
-            act2 = gs.ti_bool(x2 < 0)
-            t0_0 = t0_0 + qf_0 * act0
-            t0_1 = t0_1 + qf_1 * act0
-            t0_2 = t0_2 + qf_2 * act0
-            t1_0 = t1_0 + qf_0 * act1
-            t1_1 = t1_1 + qf_1 * act1
-            t1_2 = t1_2 + qf_2 * act1
-            t2_0 = t2_0 + qf_0 * act2
-            t2_1 = t2_1 + qf_1 * act2
-            t2_2 = t2_2 + qf_2 * act2
+        x0 = Jaref_c + alpha_0 * jv_c
+        x1 = Jaref_c + alpha_1 * jv_c
+        x2 = Jaref_c + alpha_2 * jv_c
+        act0 = gs.ti_bool(x0 < 0)
+        act1 = gs.ti_bool(x1 < 0)
+        act2 = gs.ti_bool(x2 < 0)
+        t0_0 = t0_0 + qf_0 * act0
+        t0_1 = t0_1 + qf_1 * act0
+        t0_2 = t0_2 + qf_2 * act0
+        t1_0 = t1_0 + qf_0 * act1
+        t1_1 = t1_1 + qf_1 * act1
+        t1_2 = t1_2 + qf_2 * act1
+        t2_0 = t2_0 + qf_0 * act2
+        t2_1 = t2_1 + qf_1 * act2
+        t2_2 = t2_2 + qf_2 * act2
 
     EPS = rigid_global_info.EPS[None]
 

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -218,7 +218,6 @@ class StructConstraintState(metaclass=BASE_METACLASS):
     mv: V_ANNOTATION
     jv: V_ANNOTATION
     quad_gauss: V_ANNOTATION
-    quad: V_ANNOTATION
     candidates: V_ANNOTATION
     eq_sum: V_ANNOTATION
     ls_it: V_ANNOTATION
@@ -321,7 +320,6 @@ def get_constraint_state(constraint_solver, solver):
         efc_force=V(dtype=gs.ti_float, shape=(len_constraints_, _B)),
         efc_D=V(dtype=gs.ti_float, shape=(len_constraints_, _B)),
         jv=V(dtype=gs.ti_float, shape=(len_constraints_, _B)),
-        quad=V(dtype=gs.ti_float, shape=(len_constraints_, 3, _B)),
         jac=V(dtype=gs.ti_float, shape=jac_shape),
         jac_relevant_dofs=V(dtype=gs.ti_int, shape=jac_relevant_dofs_shape),
         jac_n_relevant_dofs=V(dtype=gs.ti_int, shape=jac_n_relevant_dofs_shape),


### PR DESCRIPTION
## Description

Quad coefficients are recomputed on the fly from `Jaref`, `jv`, `efc_D` rather than read from a precomputed quad array.
This reduces per-constraint loads from 5 to 3 (contacts) and 7 to 5 (friction), a 40%/29% bandwidth reduction.
The ~8 FLOPs of recomputation per constraint are almost free.

## Checklist:
- [ ] I read the **CONTRIBUTING** document.
- [ ] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [ ] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
