### PR TITLE
[FEATURE] Replace Vulkan by AMD ROCm backend.

### DIFF
--- a/.github/contributing/CODING_CONVENTIONS.md
+++ b/.github/contributing/CODING_CONVENTIONS.md
@@ -13,7 +13,7 @@ import torch
 
 - Classes: `PascalCase` (e.g., `RigidEntity`, `SimOptions`)
 - Functions/methods: `snake_case` (e.g., `add_entity`, `get_dofs_position`)
-- Constants: `UPPER_CASE` (e.g., `EPS`, `GS_ARCH`)
+- Constants: `UPPER_CASE` (e.g., `EPS`)
 - Private: `_leading_underscore` (e.g., `_initialized`)
 
 ## Configuration via Pydantic Options
@@ -69,7 +69,7 @@ import genesis as gs
 # CPU backend (default for debug mode)
 gs.init(backend=gs.cpu)
 
-# GPU backend (auto-selects CUDA/Metal/Vulkan)
+# GPU backend (auto-selects CUDA/ROCm/Metal)
 gs.init(backend=gs.gpu)
 
 # Explicit precision

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -22,10 +22,6 @@ jobs:
       TI_OFFLINE_CACHE: "1"
       TI_OFFLINE_CACHE_CLEANING_POLICY: "never"
       TI_OFFLINE_CACHE_FILE_PATH: ".cache/taichi"
-      TI_ENABLE_CUDA: "0"
-      TI_ENABLE_METAL: "0"
-      TI_ENABLE_OPENGL: "0"
-      TI_ENABLE_VULKAN: "0"
       TI_DEBUG: "0"
       OMNI_KIT_ACCEPT_EULA: "yes"
 

--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -75,9 +75,8 @@ jobs:
       TI_OFFLINE_CACHE_CLEANING_POLICY: "never"
       TI_OFFLINE_CACHE_FILE_PATH: ".cache/taichi"
       TI_ENABLE_CUDA: ${{ matrix.GS_BACKEND == 'gpu' && '1' || '0' }}
+      TI_ENABLE_AMDGPU: ${{ matrix.GS_BACKEND == 'gpu' && '1' || '0' }}
       TI_ENABLE_METAL: ${{ matrix.GS_BACKEND == 'gpu' && '1' || '0' }}
-      TI_ENABLE_OPENGL: "0"
-      TI_ENABLE_VULKAN: "0"
       TI_DEBUG: "0"
       OMNI_KIT_ACCEPT_EULA: "yes"
 

--- a/README.md
+++ b/README.md
@@ -178,8 +178,7 @@ docker run -it --network=host \
  genesis-amd
  ```
 
-The examples will be accessible from `/workspace/examples`. Note: AMD users should use the vulkan backend. This means you will need to call `gs.init(vulkan)` to initialise Genesis.
-
+The examples will be accessible from `/workspace/examples`. Note: AMD users should use the ROCm (HIP) backend. This means you will need to call `gs.init(gs.amdgpu)` to initialise Genesis.
 
 ## Documentation
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -139,7 +139,7 @@ docker run -it --network=host \
  genesis-amd
 ```
 
-示例文件将可以在 `/workspace/examples` 目录下找到。注意：AMD 用户应使用 Vulkan 后端。这意味着您需要调用 `gs.init(vulkan)` 来初始化 Genesis。
+示例文件将可以在 `/workspace/examples` 目录下找到。注意：AMD 用户应使用 ROCm (HIP) 后端。这意味着您需要调用 `gs.init(gs.amdgpu)` 来初始化 Genesis。
 
 ### 文档
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -140,7 +140,7 @@ docker run -it --network=host \
  genesis-amd
 ```
 
-Les exemples seront accessibles depuis `/workspace/examples`. Note : Les utilisateurs AMD doivent utiliser le backend Vulkan. Cela signifie que vous devrez appeler `gs.init(vulkan)` pour initialiser Genesis.
+Les exemples seront accessibles depuis `/workspace/examples`. Note : Les utilisateurs AMD doivent utiliser le backend ROCm (HIP). Cela signifie que vous devrez appeler `gs.init(gs.amdgpu)` pour initialiser Genesis.
 
 ## Documentation
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -141,7 +141,7 @@ docker run -it --network=host \
  genesis-amd
 ```
 
-サンプルは`/workspace/examples`からアクセス可能です。注意：AMDユーザーはVulkanバックエンドを使用してください。これは、Genesisを初期化するために`gs.init(vulkan)`を呼び出す必要があることを意味します。
+サンプルは`/workspace/examples`からアクセス可能です。注意：AMDユーザーはROCm (HIP)バックエンドを使用してください。これは、Genesisを初期化するために`gs.init(gs.amdgpu)`を呼び出す必要があることを意味します。
 
 ## ドキュメント
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -140,7 +140,7 @@ docker run -it --network=host \
  genesis-amd
 ```
 
-예제는 `/workspace/examples` 경로에서 접근할 수 있습니다. 참고: AMD 사용자는 Vulkan 백엔드를 사용해야 합니다. 즉, Genesis를 초기화하려면 `gs.init(vulkan)`을 호출해야 합니다.
+예제는 `/workspace/examples` 경로에서 접근할 수 있습니다. 참고: AMD 사용자는 ROCm (HIP) 백엔드를 사용해야 합니다. 즉, Genesis를 초기화하려면 `gs.init(gs.amdgpu)`을 호출해야 합니다.
 
 ## 문서
 

--- a/genesis/constants.py
+++ b/genesis/constants.py
@@ -1,6 +1,5 @@
 import enum
 
-import gstaichi as ti
 
 # dynamic loading
 ACTIVE = 1
@@ -68,9 +67,8 @@ class backend(IntEnum):
     cpu = 0
     gpu = 1
     cuda = 2
-    vulkan = 3
+    amdgpu = 3
     metal = 4
-    opengl = 5
 
     def __format__(self, format_spec):
         return f"gs.{self.name}"
@@ -85,49 +83,6 @@ class IMAGE_TYPE(IntEnum):
 
     def __format__(self, format_spec):
         return self.name
-
-
-# FIXME: Remove this static map entirely and rather determines the appropriate GPU backend dynamically, based on
-# hardware (using torch default device)
-GS_ARCH = {
-    "macOS": {
-        backend.cpu: backend.cpu,
-        backend.gpu: backend.metal,
-        backend.metal: backend.metal,
-        backend.vulkan: backend.vulkan,
-    },
-    "Linux": {
-        backend.cpu: backend.cpu,
-        backend.gpu: backend.cuda,
-        backend.cuda: backend.cuda,
-        backend.vulkan: backend.vulkan,
-    },
-    "Windows": {
-        backend.cpu: backend.cpu,
-        backend.gpu: backend.cuda,
-        backend.cuda: backend.cuda,
-        backend.vulkan: backend.vulkan,
-    },
-}
-
-# FIXME: The list of support backends should honor `TI_ENABLE_*` env var
-TI_ARCH = {
-    "macOS": {
-        backend.cpu: ti.cpu,
-        backend.metal: ti.metal,
-        backend.vulkan: ti.vulkan,
-    },
-    "Linux": {
-        backend.cpu: ti.cpu,
-        backend.cuda: ti.cuda,
-        backend.vulkan: ti.vulkan,
-    },
-    "Windows": {
-        backend.cpu: ti.cpu,
-        backend.cuda: ti.cuda,
-        backend.vulkan: ti.vulkan,
-    },
-}
 
 
 # parallelize

--- a/genesis/engine/entities/fem_entity.py
+++ b/genesis/engine/entities/fem_entity.py
@@ -643,7 +643,7 @@ class FEMEntity(Entity):
             self.set_vel(self._sim.cur_substep_local, self._tgt["vel"])
 
         if self._tgt["act"] is not None:
-            assert self._tgt["act"] in [gs.ACTIVE, gs.INACTIVE]
+            assert self._tgt["act"] in (gs.ACTIVE, gs.INACTIVE)
             self.set_active(self._sim.cur_substep_local, self._tgt["act"])
 
         if self._tgt["actu"] is not None:

--- a/genesis/engine/materials/MPM/base.py
+++ b/genesis/engine/materials/MPM/base.py
@@ -1,4 +1,5 @@
 import platform
+import sys
 
 import gstaichi as ti
 
@@ -48,7 +49,7 @@ class Base(Material):
         super().__init__()
 
         if sampler is None:
-            sampler = "pbs" if (gs.platform == "Linux" and platform.machine() == "x86_64") else "random"
+            sampler = "pbs" if (sys.platform == "linux" and platform.machine() == "x86_64") else "random"
         if not (sampler in ("pbs", "random", "regular") or sampler.startswith("pbs-")):
             gs.raise_exception(
                 f"Particle sampler must be either 'pbs(-[0-9]+)', 'random' or 'regular. Got '{sampler}'."

--- a/genesis/engine/materials/PBD/liquid.py
+++ b/genesis/engine/materials/PBD/liquid.py
@@ -1,8 +1,7 @@
 import platform
+import sys
 
 import gstaichi as ti
-
-import genesis as gs
 
 from .base import Base
 
@@ -35,7 +34,7 @@ class Liquid(Base):
         viscosity_relaxation=0.01,
     ):
         if sampler is None:
-            sampler = "pbs" if (gs.platform == "Linux" and platform.machine() == "x86_64") else "random"
+            sampler = "pbs" if (sys.platform == "linux" and platform.machine() == "x86_64") else "random"
 
         super().__init__()
 

--- a/genesis/engine/materials/PBD/particle.py
+++ b/genesis/engine/materials/PBD/particle.py
@@ -1,8 +1,7 @@
+import sys
 import platform
 
 import gstaichi as ti
-
-import genesis as gs
 
 from .base import Base
 
@@ -33,7 +32,7 @@ class Particle(Base):
         sampler=None,
     ):
         if sampler is None:
-            sampler = "pbs" if (gs.platform == "Linux" and platform.machine() == "x86_64") else "random"
+            sampler = "pbs" if (sys.platform == "linux" and platform.machine() == "x86_64") else "random"
 
         super().__init__()
 

--- a/genesis/engine/materials/SPH/base.py
+++ b/genesis/engine/materials/SPH/base.py
@@ -1,8 +1,7 @@
+import sys
 import platform
 
 import gstaichi as ti
-
-import genesis as gs
 
 from ..base import Material
 
@@ -28,7 +27,7 @@ class Base(Material):
         sampler=None,
     ):
         if sampler is None:
-            sampler = "pbs" if (gs.platform == "Linux" and platform.machine() == "x86_64") else "random"
+            sampler = "pbs" if (sys.platform == "linux" and platform.machine() == "x86_64") else "random"
 
         super().__init__()
 

--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -1257,12 +1257,12 @@ class Viewer(pyglet.window.Window):
         self.switch_to()
         pyglet.clock.tick()
 
-        if gs.platform != "Windows":
-            pyglet.app.platform_event_loop.step(0.0)
-        else:
+        if sys.platform == "win32":
             # even changing `platform_event_loop.step(0.0)` to 0.001 causes the viewer to hang on Windows
             # this is a workaround on Windows. not sure if it's correct
             time.sleep(0.001)
+        else:
+            pyglet.app.platform_event_loop.step(0.0)
 
         self.dispatch_pending_events()
         if self._is_active:

--- a/genesis/options/renderers.py
+++ b/genesis/options/renderers.py
@@ -38,7 +38,7 @@ class RayTracer(RendererOptions):
     Parameters
     ----------
     device_index : int, optional
-        Device ID used for the raytracer. Defaults to 0.
+        Device ID used for the raytracer. None for Genesis' device. Defaults to None.
     logging_level : str, optional
         Logging level. Should be one of "debug", "info", "warning". Defaults to "warning".
     state_limit : int, optional
@@ -65,7 +65,7 @@ class RayTracer(RendererOptions):
         Lower bound for direct face normal vs vertex normal for face normal interpolation. Range is [0, 180]. Defaults to 180.
     """
 
-    device_index: int = 0
+    device_index: Optional[int] = None
     logging_level: str = "warning"
     state_limit: int = 2**25
     tracing_depth: int = 32

--- a/genesis/utils/particle.py
+++ b/genesis/utils/particle.py
@@ -90,7 +90,7 @@ def trimesh_to_particles_pbs(mesh, p_size, sampler, pos=(0, 0, 0)):
     """
     assert "pbs" in sampler
 
-    if not (gs.platform == "Linux" and platform.machine() == "x86_64"):
+    if not (sys.platform == "linux" and platform.machine() == "x86_64"):
         gs.raise_exception(f"Physics-based particle sampler '{sampler}' is only supported on Linux x86.")
 
     # compute file name via hashing for caching
@@ -359,8 +359,8 @@ def particles_to_mesh(positions, radius, backend):
     args_dict = parse_args(backend)
 
     if "openvdb" in backend:
-        if gs.platform != "Linux" or sys.version_info[:2] == (3, 9):
-            gs.raise_exception("Backend 'openvdb' is only supported on Linux and Python 3.9 specfically.")
+        if sys.platform != "linux" or sys.version_info[:2] == (3, 9):
+            gs.raise_exception("Backend 'openvdb' is only supported on Linux and Python 3.9 specifically.")
 
         import ParticleMesherPy
 
@@ -414,7 +414,7 @@ def init_foam_generator(
     k_foam,
     foam_density,
 ):
-    if gs.platform != "Linux" or sys.version_info[:2] == (3, 9):
+    if sys.platform != "linux" or sys.version_info[:2] == (3, 9):
         gs.raise_exception("This method is only supported on Linux and Python 3.9 specfically.")
 
     import ParticleMesherPy
@@ -453,7 +453,7 @@ def generate_foam_particles(generator, positions, velocities):
 
 
 def filter_surface(positions, radii, particle_radius, half_width=8.0, radius_scale=1.0):
-    if gs.platform != "Linux" or sys.version_info[:2] == (3, 9):
+    if sys.platform != "linux" or sys.version_info[:2] == (3, 9):
         gs.raise_exception("This method is only supported on Linux and Python 3.9 specfically.")
 
     import ParticleMesherPy

--- a/genesis/vis/rasterizer.py
+++ b/genesis/vis/rasterizer.py
@@ -27,7 +27,7 @@ class Rasterizer(RBC):
         if self._offscreen:
             # Select PyOpenGL backend for `pyrender.OffscreenRenderer`.
             # If env variable is set, use specified platform if supported, otherwise some platform-specific default.
-            platform = os.environ.get("PYOPENGL_PLATFORM", "egl" if gs.platform == "Linux" else "pyglet")
+            platform = os.environ.get("PYOPENGL_PLATFORM", "egl" if sys.platform == "linux" else "pyglet")
             if platform not in ("osmesa", "pyglet", "egl"):
                 gs.logger.warning(f"PYOPENGL_PLATFORM='{platform}' not supported. Falling back to 'pyglet'.")
                 platform = "pyglet"

--- a/genesis/vis/viewer.py
+++ b/genesis/vis/viewer.py
@@ -1,5 +1,6 @@
 import importlib
 import os
+import sys
 import threading
 from traceback import TracebackException
 from typing import TYPE_CHECKING
@@ -75,15 +76,15 @@ class Viewer(RBC):
         # Try all candidate onscreen OpenGL "platforms" if none is specifically requested
         opengl_platform_orig = os.environ.get("PYOPENGL_PLATFORM")
         if opengl_platform_orig is None:
-            if gs.platform == "Windows":
+            if sys.platform == "win32":
                 all_opengl_platforms = ("wgl",)  # same as "native"
-            elif gs.platform == "Linux":
+            elif sys.platform == "linux":
                 # "native" is platform-specific ("egl" or "glx")
                 all_opengl_platforms = ("native", "egl", "glx", "osmesa")
             else:
                 all_opengl_platforms = ("native",)
         else:
-            if opengl_platform_orig == "osmesa" and gs.platform != "Linux":
+            if opengl_platform_orig == "osmesa" and sys.platform != "linux":
                 gs.raise_exception("PYOPENGL_PLATFORM='osmesa' is only supported on Linux OS for now.")
             all_opengl_platforms = (opengl_platform_orig,)
 

--- a/genesis/vis/visualizer.py
+++ b/genesis/vis/visualizer.py
@@ -1,3 +1,5 @@
+import sys
+
 import genesis as gs
 from genesis.repr_base import RBC
 
@@ -62,13 +64,13 @@ class Visualizer(RBC):
                 viewer_width = viewer_height / VIEWER_DEFAULT_ASPECT_RATIO
                 viewer_options.res = (int(viewer_width), int(viewer_height))
             if viewer_options.run_in_thread is None:
-                if gs.platform == "Linux":
+                if sys.platform == "linux":
                     viewer_options.run_in_thread = True
-                elif gs.platform == "macOS":
+                elif sys.platform == "darwin":
                     viewer_options.run_in_thread = False
-                elif gs.platform == "Windows":
+                elif sys.platform == "win32":
                     viewer_options.run_in_thread = True
-            if gs.platform == "macOS" and viewer_options.run_in_thread:
+            if sys.platform == "darwin" and viewer_options.run_in_thread:
                 gs.raise_exception("Running viewer in background thread is not supported on MacOS.")
 
             self._viewer = Viewer(viewer_options, self._context)

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2520,7 +2520,7 @@ def test_mjcf_parsing_with_include():
 
 @pytest.mark.required
 @pytest.mark.parametrize("gjk_collision", [True, False])
-def test_urdf_parsing(show_viewer, tol, gjk_collision):
+def test_urdf_parsing(gjk_collision, show_viewer, tol):
     POS_OFFSET = 0.8
     WOLRD_QUAT = np.array([1.0, 1.0, -0.3, +0.3])
     DOOR_JOINT_DAMPING = 1.5
@@ -2581,7 +2581,7 @@ def test_urdf_parsing(show_viewer, tol, gjk_collision):
             entities[key].set_quat(np.array([0.0, 0.0, 0.0, 1.0]), relative=relative)
         if show_viewer:
             scene.visualizer.update()
-        _check_entity_positions(relative, tol=gs.EPS)
+        _check_entity_positions(relative, tol=tol)
 
     # Check that `set_qpos` applies the same absolute transform in all cases
     door_angle = np.array([1.1])
@@ -2596,7 +2596,7 @@ def test_urdf_parsing(show_viewer, tol, gjk_collision):
         entities[key].set_qpos(door_angle)
     if show_viewer:
         scene.visualizer.update()
-    _check_entity_positions(relative=True, tol=gs.EPS)
+    _check_entity_positions(relative=True, tol=tol)
 
     # Add dof damping to stabilitze the physics
     for key in ((False, False), (False, True), (True, False), (True, True)):


### PR DESCRIPTION
## Description

* Simplify backend and device logics
* Introduce new 'amdgpu' backend based on AMD ROCm (HIP)
* Remove partially broken 'vulkan' backend for generic GPU support (incl. Intel XPU)

## Related Issue

Resolves https://github.com/Genesis-Embodied-AI/Genesis/issues/2228
Resolves https://github.com/Genesis-Embodied-AI/Genesis/issues/1987

## How Has This Been / Can This Be Tested?

Tested on Integrated AMD GPU using [AMD's official docker container based on v7.2](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html):
```python
docker run -it \
    --cap-add=SYS_PTRACE \
    --security-opt seccomp=unconfined \
    --device=/dev/kfd \
    --device=/dev/dri \
    --group-add video \
    --ipc=host \
    --shm-size 8G \
    rocm/pytorch:latest
```

```bash
============================ ROCm System Management Interface ============================
WARNING: AMD GPU device(s) is/are in a low-power state. Check power control/runtime_status

====================================== Product Info ======================================
GPU[0]          : Card Series:          AMD Radeon Graphics
GPU[0]          : Card Model:           0x150e
GPU[0]          : Card Vendor:          Advanced Micro Devices, Inc. [AMD/ATI]
GPU[0]          : Card SKU:             STRIXEMU
GPU[0]          : Subsystem ID:         0x512f
GPU[0]          : Device Rev:           0xd1
GPU[0]          : Node ID:              1
GPU[0]          : GUID:                 16910
GPU[0]          : GFX Version:          gfx1150
==========================================================================================
================================== End of ROCm SMI Log ===================================
```


It is still experimental for now, and a few nits on gstaichi side needs to be fixed, but it works pretty decently already.