### PR TITLE
[MISC] Add uv installation instructions to translated READMEs.

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -92,6 +92,45 @@ git clone https://github.com/Genesis-Embodied-AI/Genesis.git
 cd Genesis
 pip install -e ".[dev]"
 ```
+建议在移动 HEAD 后系统地执行 `pip install -e ".[dev]"`，以确保所有依赖项和入口点都是最新的。
+
+### 使用 uv
+
+[uv](https://docs.astral.sh/uv/) 是一个快速的 Python 包和项目管理器。
+
+**安装 uv：**
+```bash
+# macOS 和 Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+**使用 uv 快速开始：**
+```bash
+git clone https://github.com/Genesis-Embodied-AI/Genesis.git
+cd Genesis
+uv sync
+```
+
+然后为您的平台安装 PyTorch：
+
+```bash
+# NVIDIA GPU（以 CUDA 12.6 为例）
+uv pip install torch --index-url https://download.pytorch.org/whl/cu126
+
+# 仅 CPU（Linux/Windows）
+uv pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+# Apple Silicon（Metal/MPS）
+uv pip install torch
+```
+
+运行示例：
+```bash
+uv run examples/rigid/single_franka.py
+```
 
 ## Docker
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -93,6 +93,45 @@ git clone https://github.com/Genesis-Embodied-AI/Genesis.git
 cd Genesis
 pip install -e ".[dev]"
 ```
+Il est recommandé d'exécuter systématiquement `pip install -e ".[dev]"` après avoir déplacé le HEAD pour s'assurer que toutes les dépendances et points d'entrée sont à jour.
+
+### Utiliser uv
+
+[uv](https://docs.astral.sh/uv/) est un gestionnaire de paquets et de projets Python rapide.
+
+**Installer uv :**
+```bash
+# Sur macOS et Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Sur Windows
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+**Démarrage rapide avec uv :**
+```bash
+git clone https://github.com/Genesis-Embodied-AI/Genesis.git
+cd Genesis
+uv sync
+```
+
+Ensuite, installez PyTorch pour votre plateforme :
+
+```bash
+# GPU NVIDIA (CUDA 12.6 par exemple)
+uv pip install torch --index-url https://download.pytorch.org/whl/cu126
+
+# CPU uniquement (Linux/Windows)
+uv pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+# Apple Silicon (Metal/MPS)
+uv pip install torch
+```
+
+Exécutez un exemple :
+```bash
+uv run examples/rigid/single_franka.py
+```
 
 ## Docker
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -93,6 +93,45 @@ git clone https://github.com/Genesis-Embodied-AI/Genesis.git
 cd Genesis
 pip install -e ".[dev]"
 ```
+HEADを移動した後は、すべての依存関係とエントリーポイントが最新であることを確認するために、`pip install -e ".[dev]"` を体系的に実行することを推奨します。
+
+### uvを使用する場合
+
+[uv](https://docs.astral.sh/uv/) は高速なPythonパッケージ・プロジェクトマネージャーです。
+
+**uvのインストール：**
+```bash
+# macOSおよびLinux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+**uvでクイックスタート：**
+```bash
+git clone https://github.com/Genesis-Embodied-AI/Genesis.git
+cd Genesis
+uv sync
+```
+
+次に、お使いのプラットフォーム向けにPyTorchをインストールします：
+
+```bash
+# NVIDIA GPU（例：CUDA 12.6）
+uv pip install torch --index-url https://download.pytorch.org/whl/cu126
+
+# CPUのみ（Linux/Windows）
+uv pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+# Apple Silicon（Metal/MPS）
+uv pip install torch
+```
+
+サンプルを実行：
+```bash
+uv run examples/rigid/single_franka.py
+```
 
 ## Docker
 
@@ -141,7 +180,7 @@ docker run -it --network=host \
  genesis-amd
 ```
 
-サンプルは`/workspace/examples`からアクセス可能です。注意：AMDユーザーはROCm (HIP)バックエンドを使用してください。これは、Genesisを初期化するために`gs.init(gs.amdgpu)`を呼び出す必要があることを意味します。
+サンプルは`/workspace/examples`からアクセス可能です。注意：AMDユーザーはROCm (HIP)バックエンドを使用してください。これは、Genesisを初期化するために`gs.init(backend=gs.amdgpu)`を呼び出す必要があることを意味します。
 
 ## ドキュメント
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -93,6 +93,45 @@ git clone https://github.com/Genesis-Embodied-AI/Genesis.git
 cd Genesis
 pip install -e ".[dev]"
 ```
+HEAD를 이동한 후에는 모든 의존성과 엔트리포인트가 최신 상태인지 확인하기 위해 `pip install -e ".[dev]"`를 체계적으로 실행하는 것을 권장합니다.
+
+### uv 사용
+
+[uv](https://docs.astral.sh/uv/)는 빠른 Python 패키지 및 프로젝트 관리자입니다.
+
+**uv 설치:**
+```bash
+# macOS 및 Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+**uv로 빠르게 시작:**
+```bash
+git clone https://github.com/Genesis-Embodied-AI/Genesis.git
+cd Genesis
+uv sync
+```
+
+그 다음, 플랫폼에 맞는 PyTorch를 설치합니다:
+
+```bash
+# NVIDIA GPU (예: CUDA 12.6)
+uv pip install torch --index-url https://download.pytorch.org/whl/cu126
+
+# CPU 전용 (Linux/Windows)
+uv pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+# Apple Silicon (Metal/MPS)
+uv pip install torch
+```
+
+예제 실행:
+```bash
+uv run examples/rigid/single_franka.py
+```
 
 ## Docker
 


### PR DESCRIPTION
## Summary
- Add `uv` package manager installation and usage instructions to translated READMEs (CN, FR, JA, KR)
- Mirrors the uv instructions already present in the main English README

## Test plan
- [ ] Verify markdown renders correctly on GitHub for each translated README