### PR TITLE
[BUG FIX] Fix wrong type for gs.materials.Rigid.gravity_compensation.

### DIFF
--- a/genesis/engine/materials/rigid.py
+++ b/genesis/engine/materials/rigid.py
@@ -66,7 +66,7 @@ class Rigid(Material):
         sdf_cell_size=0.005,
         sdf_min_res=32,
         sdf_max_res=128,
-        gravity_compensation=0,
+        gravity_compensation=0.0,
         coupling_mode=None,
         coupling_link_filter=None,
         enable_coupling_collision=True,


### PR DESCRIPTION
Before this change, pyright inferred that the argument was an integer because of the default value.