### PR TITLE
[BUG FIX] Fix merge fixed links (cont'd).

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -651,31 +651,20 @@ class RigidEntity(Entity):
         # * Mujoco unified parser always adds a root 'world' link if it does not exist, and fuse all fixed links from
         #   root to first articulated body.
         # * Our legacy parser adds a root 'world' link if the root joint is not a fixed joint in file morph.
-        # This check is somewhat fragile, but there is no way to distinguish between virtual and manually added root.
-        base_l_info, base_j_info, base_g_info = l_infos[0], links_j_infos[0], links_g_infos[0]
-        # Safe to remove the virtual world link if the child has a free joint (the free joint absorbs the full pose
-        # into init_qpos regardless of pos/quat), or if the child has an identity transform (no structural information
-        # would be lost by removing the world link).
-        child_has_freejoint = (
-            any(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in links_j_infos[1]) if len(l_infos) > 1 else False
-        )
-        child_is_identity = (
-            ((np.abs(l_infos[1]["pos"]) < gs.EPS).all() and (np.abs(l_infos[1]["quat"] - (1, 0, 0, 0)) < gs.EPS).all())
-            if len(l_infos) > 1
-            else False
-        )
-        if (
-            len(l_infos) > 1
-            and (child_has_freejoint or child_is_identity)
-            and (base_l_info["name"] == "world" and base_j_info and base_j_info[0]["name"] == "world")
-            and sum(j_info["n_dofs"] for j_info in base_j_info) == 0
-            and not base_g_info
-        ):
-            del l_infos[0], links_j_infos[0], links_g_infos[0]
-            for l_info in l_infos:
-                l_info["parent_idx"] = max(l_info["parent_idx"] - 1, -1)
-                if "root_idx" in l_info:
-                    l_info["root_idx"] = max(l_info["root_idx"] - 1, -1)
+        # Remove this virtual world link if the child has a free joint (the free joint absorbs the full pose into
+        # 'init_qpos' regardless of pos/quat), or if the child has an identity transform.
+        base_j_info, base_g_info = links_j_infos[0], links_g_infos[0]
+        if len(l_infos) > 1 and (sum(j_info["n_dofs"] for j_info in base_j_info) == 0) and not base_g_info:
+            child_has_freejoint = any(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in links_j_infos[1])
+            child_is_identity = (np.abs(l_infos[1]["pos"]) < gs.EPS).all() and (
+                np.abs(l_infos[1]["quat"] - (1, 0, 0, 0)) < gs.EPS
+            ).all()
+            if child_has_freejoint or child_is_identity:
+                del l_infos[0], links_j_infos[0], links_g_infos[0]
+                for l_info in l_infos:
+                    l_info["parent_idx"] = max(l_info["parent_idx"] - 1, -1)
+                    if "root_idx" in l_info:
+                        l_info["root_idx"] = max(l_info["root_idx"] - 1, -1)
 
         # URDF is a robot description file so all links have same root_idx
         if isinstance(morph, gs.morphs.URDF) and not morph._enable_mujoco_compatibility:

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2885,6 +2885,58 @@ def test_urdf_parsing_merge_fixed_links(urdf_path, fixed, show_viewer, tol):
     assert_allclose(com_robot_1, com_robot_2, tol=tol)
 
 
+@pytest.fixture(scope="session")
+def box_freejoint_offset():
+    mjcf = ET.Element("mujoco", model="test_freejoint")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+
+    base_body = ET.SubElement(worldbody, "body", name="base", pos="0 0 1.0", quat="1.0 0 0 1.0")
+    ET.SubElement(base_body, "freejoint", name="root")
+    ET.SubElement(base_body, "inertial", pos="0 0 0", mass="1.0", diaginertia="0.01 0.01 0.01")
+    ET.SubElement(base_body, "geom", type="box", size="0.05 0.05 0.05")
+
+    child_body = ET.SubElement(base_body, "body", name="child", pos="0 0 0.1")
+    ET.SubElement(child_body, "inertial", pos="0 0 0", mass="0.5", diaginertia="0.001 0.001 0.001")
+    ET.SubElement(child_body, "joint", name="joint1", type="hinge", axis="0 1 0")
+    ET.SubElement(child_body, "geom", type="box", size="0.03 0.03 0.05")
+
+    return mjcf
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("model_name", ["box_freejoint_offset"])
+def test_mjcf_parsing_merge_fixed_links(xml_path, show_viewer):
+    """Test that get_pos reflects set_qpos for MJCF robots with freejoint and non-zero initial body position."""
+    POS = (1.0, 2.0, 3.0)
+    QUAT = (0.0, 1.0, 0.0, 0.0)
+
+    scene = gs.Scene(
+        show_viewer=show_viewer,
+    )
+    robot = scene.add_entity(
+        gs.morphs.MJCF(
+            file=xml_path,
+        )
+    )
+    scene.build()
+
+    assert_allclose(robot.get_pos(), (0.0, 0.0, 1.0), tol=gs.EPS)
+    assert_allclose(robot.get_quat(), np.array([1.0, 0.0, 0.0, 1.0]) / math.sqrt(2), tol=gs.EPS)
+
+    robot.set_qpos((*POS, *QUAT), qs_idx_local=slice(None, 7))
+    assert_allclose(robot.get_pos(), POS, tol=gs.EPS)
+    assert_allclose(robot.get_quat(), QUAT, tol=gs.EPS)
+
+    scene.reset()
+    assert_allclose(robot.get_pos(), (0.0, 0.0, 1.0), tol=gs.EPS)
+    assert_allclose(robot.get_quat(), np.array([1.0, 0.0, 0.0, 1.0]) / math.sqrt(2), tol=gs.EPS)
+
+    robot.set_pos(POS)
+    robot.set_quat(QUAT)
+    assert_allclose(robot.get_pos(), POS, tol=gs.EPS)
+    assert_allclose(robot.get_quat(), QUAT, tol=gs.EPS)
+
+
 @pytest.mark.required
 def test_urdf_capsule(tmp_path, show_viewer, tol):
     urdf_path = tmp_path / "capsule.urdf"
@@ -4605,52 +4657,3 @@ def test_hibernation_and_contact_islands(show_viewer):
 
     # Stacked boxes should form 1 contact island
     assert solver.constraint_solver.contact_island.n_islands[0] == 1
-
-
-@pytest.mark.required
-def test_set_qpos_get_pos_mjcf_freejoint(tmp_path, show_viewer, tol):
-    """Test that get_pos reflects set_qpos for MJCF robots with freejoint and non-zero initial body position.
-
-    Regression test for a bug where the virtual 'world' root link was not removed for MJCF bodies whose first body
-    had a non-zero initial position, causing base_link_idx to point to the static world link instead of the actual
-    robot base.
-    """
-    # Minimal MJCF: body with non-zero pos AND non-identity quat (like G1 pelvis at z=0.793) and a freejoint.
-    # Both pos and quat are non-trivial to ensure we don't rely on either being identity.
-    mjcf_content = """\
-    <mujoco model="test_freejoint">
-      <worldbody>
-        <body name="base" pos="0 0 0.793" quat="0.9238795 0 0 0.3826834">
-          <freejoint name="root"/>
-          <inertial pos="0 0 0" mass="1.0" diaginertia="0.01 0.01 0.01"/>
-          <geom type="box" size="0.05 0.05 0.05"/>
-          <body name="child" pos="0 0 0.1">
-            <inertial pos="0 0 0" mass="0.5" diaginertia="0.001 0.001 0.001"/>
-            <joint name="joint1" type="hinge" axis="0 1 0"/>
-            <geom type="box" size="0.03 0.03 0.05"/>
-          </body>
-        </body>
-      </worldbody>
-    </mujoco>
-    """
-    xml_path = str(tmp_path / "test_freejoint.xml")
-    with open(xml_path, "w") as f:
-        f.write(mjcf_content)
-
-    scene = gs.Scene(show_viewer=show_viewer)
-    robot = scene.add_entity(gs.morphs.MJCF(file=xml_path))
-    scene.build()
-
-    # The virtual 'world' link should have been removed; first link should be 'base'
-    assert robot.links[0].name != "world", (
-        f"Virtual 'world' link was not removed. Links: {[l.name for l in robot.links]}"
-    )
-
-    # set_qpos with a known base position
-    target_pos = torch.tensor([1.0, 2.0, 3.0], dtype=gs.tc_float, device=gs.device)
-    target_quat = torch.tensor([1.0, 0.0, 0.0, 0.0], dtype=gs.tc_float, device=gs.device)
-    dof_pos = torch.zeros(robot.n_qs - 7, dtype=gs.tc_float, device=gs.device)
-    robot.set_qpos(torch.cat([target_pos, target_quat, dof_pos]))
-
-    # get_pos must return the base position we just set
-    assert_allclose(robot.get_pos(), target_pos, tol=tol)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines:
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/contributing/PULL_REQUESTS.md
2. Prepare your PR according to the "Submitting Code Changes"
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/contributing/PULL_REQUESTS.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [CHANGING] for changes that will change simulation's behaviour
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description

<!--- Why is this change required? What problem does it solve? -->

Commit 92e67aee ("Fix merge fixed links") added overly strict conditions to the virtual root link removal check in rigid_entity.py:_load_scene(). It required the child link to have pos ≈ 0 and quat ≈ identity:
```
  and (np.abs(l_infos[1]["pos"]) < gs.EPS).all()
  and (np.abs(l_infos[1]["quat"] - (1, 0, 0, 0)) < gs.EPS).all()
```
For any MJCF robot whose first body has a non-zero initial position (e.g., G1 pelvis at z=0.793), these checks fail, the virtual world link is not removed, and base_link_idx points to the static world link instead of the actual base body. This makes get_pos() always return (0, 0, 0).

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I read the **CONTRIBUTING** document.
- [ ] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [ ] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
