### PR TITLE
[MISC] Cleanup implementation of heterogeneous rigid/kinematic entities.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -22,7 +22,6 @@ from genesis.utils import mesh as mu
 from genesis.utils import mjcf as mju
 from genesis.utils import terrain as tu
 from genesis.utils import urdf as uu
-from genesis.utils.urdf import compose_inertial_properties, rotate_inertia
 from genesis.utils.misc import DeprecationError, broadcast_tensor, qd_to_numpy, qd_to_torch
 from genesis.engine.states.entities import RigidEntityState
 
@@ -52,63 +51,6 @@ def tracked(fun):
         return fun(self, *args, **kwargs)
 
     return wrapper
-
-
-def compute_inertial_from_geom_infos(cg_infos, vg_infos, rho):
-    """
-    Compute inertial properties (mass, center of mass, inertia tensor) from geometry infos.
-
-    This is a standalone helper function that computes combined inertial properties from
-    a collection of collision and/or visual geometry infos.
-
-    Parameters
-    ----------
-    cg_infos : list[dict]
-        List of collision geometry info dicts, each containing 'mesh', 'pos', 'quat'.
-    vg_infos : list[dict]
-        List of visual geometry info dicts, each containing 'vmesh', 'pos', 'quat'.
-        Used as fallback if cg_infos is empty.
-    rho : float
-        Material density (kg/m^3) used to compute mass from volume.
-
-    Returns
-    -------
-    tuple[float, np.ndarray, np.ndarray]
-        (total_mass, center_of_mass, inertia_tensor)
-    """
-    total_mass = gs.EPS
-    total_com = np.zeros(3, dtype=gs.np_float)
-    total_inertia = np.zeros((3, 3), dtype=gs.np_float)
-
-    # Use collision geoms if available, otherwise fall back to visual geoms
-    for g_info in cg_infos if cg_infos else vg_infos:
-        mesh = g_info["mesh" if cg_infos else "vmesh"]
-        if g_info["type"] == gs.GEOM_TYPE.PLANE:
-            continue
-        geom_pos = g_info.get("pos", gu.zero_pos())
-        geom_quat = g_info.get("quat", gu.identity_quat())
-
-        inertia_mesh = mesh.trimesh
-        if not inertia_mesh.is_watertight:
-            inertia_mesh = trimesh.convex.convex_hull(inertia_mesh)
-
-        if inertia_mesh.volume < -gs.EPS:
-            inertia_mesh.invert()
-
-        geom_mass = inertia_mesh.volume * rho
-        geom_com_local = np.array(inertia_mesh.center_mass, dtype=gs.np_float)
-        geom_inertia_local = inertia_mesh.moment_inertia / inertia_mesh.mass * geom_mass
-
-        # Transform geom properties to link frame
-        geom_com_link = gu.transform_by_quat(geom_com_local, geom_quat) + geom_pos
-        geom_inertia_link = rotate_inertia(geom_inertia_local, gu.quat_to_R(geom_quat))
-
-        # Compose with existing properties
-        total_mass, total_com, total_inertia = compose_inertial_properties(
-            total_mass, total_com, total_inertia, geom_mass, geom_com_link, geom_inertia_link
-        )
-
-    return total_mass, total_com, total_inertia
 
 
 @qd.data_oriented
@@ -181,14 +123,12 @@ class KinematicEntity(Entity):
 
     def _load_morph(self, morph: Morph):
         """Load a single morph into the entity."""
-        # Store g_infos for heterogeneous inertial computation
-        self._first_g_infos = None
         if isinstance(morph, gs.morphs.Mesh):
-            self._first_g_infos = self._load_mesh(morph, self._surface)
+            self._load_mesh(morph, self._surface)
         elif isinstance(morph, (gs.morphs.MJCF, gs.morphs.URDF, gs.morphs.Drone, gs.morphs.USD)):
             self._load_scene(morph, self._surface)
         elif isinstance(morph, gs.morphs.Primitive):
-            self._first_g_infos = self._load_primitive(morph, self._surface)
+            self._load_primitive(morph, self._surface)
         elif isinstance(morph, gs.morphs.Terrain):
             self._load_terrain(morph, self._surface)
         else:
@@ -201,40 +141,21 @@ class KinematicEntity(Entity):
         """
         Load heterogeneous morphs (additional geometry variants for parallel environments).
         Each variant is loaded as additional geoms/vgeoms attached to the single link.
+
+        Variant tracking (geom/vgeom ranges, inertial) is stored on the Link itself.
+        RigidEntity overrides _add_heterogeneous_variant to add collision geoms.
         """
         if not self._enable_heterogeneous:
             return
-
-        # Initialize tracking lists for geom/vgeom ranges per variant.
-        # These store the start/end indices for each variant's geoms and vgeoms,
-        # enabling per-environment dispatch during simulation.
-        self.variants_link_start = gs.List()
-        self.variants_link_end = gs.List()
-        self.variants_n_links = gs.List()
-        self.variants_vgeom_start = gs.List()
-        self.variants_vgeom_end = gs.List()
-
-        # Record the first variant (the main morph)
-        self.variants_link_start.append(self._link_start)
-        self.variants_n_links.append(len(self._links))
-        self.variants_link_end.append(self._link_start + len(self._links))
-        self.variants_vgeom_start.append(self._vgeom_start)
-        self.variants_vgeom_end.append(self._vgeom_start + len(self.vgeoms))
-
-        # Store number of geoms in first variant for balanced block distribution across environments
-        self._first_variant_n_vgeoms = len(self.vgeoms)
 
         # Heterogeneous simulation only supports single-link entities.
         if len(self._links) != 1:
             gs.raise_exception("morph_heterogeneous only supports single-link entities.")
 
-        # Compute first variant's inertial properties using stored g_infos
-        _cg_infos, vg_infos = self._convert_g_infos_to_cg_infos_and_vg_infos(
-            self._morph, self._first_g_infos, is_robot=False
-        )
+        link = self._links[0]
+        link._init_variant_tracking()
 
         # Load additional heterogeneous variants
-        link = self._links[0]
         for morph in self._morph_heterogeneous:
             if isinstance(morph, gs.morphs.Mesh):
                 g_infos = self._load_mesh(morph, self._surface, load_geom_only_for_heterogeneous=True)
@@ -245,22 +166,18 @@ class KinematicEntity(Entity):
                     f"morph_heterogeneous only supports Primitive and Mesh, got: {type(morph).__name__}."
                 )
 
-            _cg_infos, vg_infos = self._convert_g_infos_to_cg_infos_and_vg_infos(morph, g_infos, is_robot=False)
+            cg_infos, vg_infos = self._separate_geom_infos(morph, g_infos, is_robot=False)
+            self._add_heterogeneous_variant(link, cg_infos, vg_infos)
 
-            # Add visual geometries
-            for g_info in vg_infos:
-                link._add_vgeom(
-                    vmesh=g_info["vmesh"],
-                    init_pos=g_info.get("pos", gu.zero_pos()),
-                    init_quat=g_info.get("quat", gu.identity_quat()),
-                )
-
-            # Record ranges for this variant
-            self.variants_link_start.append(self.variants_link_end[-1])
-            self.variants_link_end.append(self._link_start + len(self._links))
-            self.variants_n_links.append(self.variants_link_end[-1] - self.variants_link_start[-1])
-            self.variants_vgeom_start.append(self.variants_vgeom_end[-1])
-            self.variants_vgeom_end.append(self.variants_vgeom_end[-1] + len(vg_infos))
+    def _add_heterogeneous_variant(self, link, cg_infos, vg_infos):
+        """Add a heterogeneous variant to the link. RigidEntity overrides to add collision geoms."""
+        for g_info in vg_infos:
+            link._add_vgeom(
+                vmesh=g_info["vmesh"],
+                init_pos=g_info.get("pos", gu.zero_pos()),
+                init_quat=g_info.get("quat", gu.identity_quat()),
+            )
+        link._record_variant_vgeom_range(len(vg_infos))
 
     def _load_model(self):
         self._links = gs.List()
@@ -748,22 +665,11 @@ class KinematicEntity(Entity):
         self._vgeoms = self.vgeoms
         self._is_built = True
 
-    def _add_by_info(self, l_info, j_infos, g_infos, morph, surface):
-        if len(j_infos) > 1 and any(j_info["type"] in (gs.JOINT_TYPE.FREE, gs.JOINT_TYPE.FIXED) for j_info in j_infos):
-            raise ValueError(
-                "Compounding joints of types 'FREE' or 'FIXED' with any other joint on the same body not supported"
-            )
+    def _create_joints(self, j_infos, link_idx, joint_start):
+        """Create RigidJoint objects from joint info dicts.
 
-        parent_idx = l_info["parent_idx"]
-        if parent_idx >= 0:
-            parent_idx += self._link_start
-        root_idx = l_info.get("root_idx")
-        if root_idx is not None and root_idx >= 0:
-            root_idx += self._link_start
-        link_idx = self.n_links + self._link_start
-        joint_start = self.n_joints + self._joint_start
-
-        # Add parent joints
+        Shared by KinematicEntity._add_by_info and RigidEntity._add_by_info.
+        """
         joints = gs.List()
         self._joints.append(joints)
         for i_j_, j_info in enumerate(j_infos):
@@ -826,6 +732,25 @@ class KinematicEntity(Entity):
             )
             joints.append(joint)
 
+        return joints
+
+    def _add_by_info(self, l_info, j_infos, g_infos, morph, surface):
+        if len(j_infos) > 1 and any(j_info["type"] in (gs.JOINT_TYPE.FREE, gs.JOINT_TYPE.FIXED) for j_info in j_infos):
+            raise ValueError(
+                "Compounding joints of types 'FREE' or 'FIXED' with any other joint on the same body not supported"
+            )
+
+        parent_idx = l_info["parent_idx"]
+        if parent_idx >= 0:
+            parent_idx += self._link_start
+        root_idx = l_info.get("root_idx")
+        if root_idx is not None and root_idx >= 0:
+            root_idx += self._link_start
+        link_idx = self.n_links + self._link_start
+        joint_start = self.n_joints + self._joint_start
+
+        joints = self._create_joints(j_infos, link_idx, joint_start)
+
         # Add child link
         link = KinematicLink(
             entity=self,
@@ -856,11 +781,12 @@ class KinematicEntity(Entity):
         return link, joints
 
     @staticmethod
-    def _convert_g_infos_to_cg_infos_and_vg_infos(morph, g_infos, is_robot):
+    def _separate_geom_infos(morph, g_infos, is_robot):
         """
-        Separate collision from visual geometry and post-process collision meshes.
+        Separate collision from visual geometry.
 
         Used for both normal loading and heterogeneous simulation.
+        RigidEntity overrides this to add collision mesh post-processing.
         """
         cg_infos, vg_infos = [], []
         for g_info in g_infos:
@@ -869,11 +795,6 @@ class KinematicEntity(Entity):
                 cg_infos.append(g_info)
             if morph.visualization and not is_col:
                 vg_infos.append(g_info)
-
-        # Randomize collision mesh colors
-        for g_info in cg_infos:
-            mesh = g_info["mesh"]
-            mesh.set_color((*np.random.rand(3), 0.7))
 
         return cg_infos, vg_infos
 
@@ -1842,111 +1763,32 @@ class RigidEntity(KinematicEntity):
             name,
         )
 
-    def _load_heterogeneous_morphs(self):
-        """
-        Load heterogeneous morphs (additional geometry variants for parallel environments).
-        Each variant is loaded as additional geoms/vgeoms attached to the single link.
-        """
-        if not self._enable_heterogeneous:
-            return
+    def _add_heterogeneous_variant(self, link, cg_infos, vg_infos):
+        # Add collision geometries
+        coup_links = self.material.coup_links
+        for g_info in cg_infos:
+            friction = self.material.friction
+            if friction is None:
+                friction = g_info.get("friction", gu.default_friction())
+            needs_coup = self.material.needs_coup and (coup_links is None or link.name in coup_links)
+            link._add_geom(
+                mesh=g_info["mesh"],
+                init_pos=g_info.get("pos", gu.zero_pos()),
+                init_quat=g_info.get("quat", gu.identity_quat()),
+                type=g_info["type"],
+                friction=friction,
+                sol_params=g_info["sol_params"],
+                data=g_info.get("data"),
+                needs_coup=needs_coup,
+                contype=g_info["contype"],
+                conaffinity=g_info["conaffinity"],
+            )
 
-        # Initialize tracking lists for geom/vgeom ranges per variant.
-        # These store the start/end indices for each variant's geoms and vgeoms,
-        # enabling per-environment dispatch during simulation.
-        self.variants_link_start = gs.List()
-        self.variants_link_end = gs.List()
-        self.variants_n_links = gs.List()
-        self.variants_geom_start = gs.List()
-        self.variants_geom_end = gs.List()
-        self.variants_vgeom_start = gs.List()
-        self.variants_vgeom_end = gs.List()
-        self.variants_inertial_mass = gs.List()
-        self.variants_inertial_pos = gs.List()
-        self.variants_inertial_i = gs.List()
+        # Add visual geoms and record vgeom range via parent
+        super()._add_heterogeneous_variant(link, cg_infos, vg_infos)
 
-        # Record the first variant (the main morph)
-        self.variants_link_start.append(self._link_start)
-        self.variants_n_links.append(len(self._links))
-        self.variants_link_end.append(self._link_start + len(self._links))
-        self.variants_geom_start.append(self._geom_start)
-        first_variant_geom_end = self._geom_start + len(self.geoms)
-        self.variants_geom_end.append(first_variant_geom_end)
-        self.variants_vgeom_start.append(self._vgeom_start)
-        self.variants_vgeom_end.append(self._vgeom_start + len(self.vgeoms))
-
-        # Store number of geoms in first variant for balanced block distribution across environments
-        self._first_variant_n_geoms = len(self.geoms)
-        self._first_variant_n_vgeoms = len(self.vgeoms)
-
-        # Heterogeneous simulation only supports single-link entities
-        if len(self._links) != 1:
-            gs.raise_exception("morph_heterogeneous only supports single-link entities.")
-
-        # Compute first variant's inertial properties using stored g_infos
-        cg_infos, vg_infos = self._convert_g_infos_to_cg_infos_and_vg_infos(
-            self._morph, self._first_g_infos, is_robot=False
-        )
-        het_mass, het_pos, het_i = compute_inertial_from_geom_infos(cg_infos, vg_infos, self.material.rho)
-        self.variants_inertial_mass.append(het_mass)
-        self.variants_inertial_pos.append(het_pos)
-        self.variants_inertial_i.append(het_i)
-
-        # Load additional heterogeneous variants
-        link = self._links[0]
-        for morph in self._morph_heterogeneous:
-            if isinstance(morph, gs.morphs.Mesh):
-                g_infos = self._load_mesh(morph, self._surface, load_geom_only_for_heterogeneous=True)
-            elif isinstance(morph, gs.morphs.Primitive):
-                g_infos = self._load_primitive(morph, self._surface, load_geom_only_for_heterogeneous=True)
-            else:
-                gs.raise_exception(
-                    f"morph_heterogeneous only supports Primitive and Mesh, got: {type(morph).__name__}."
-                )
-
-            cg_infos, vg_infos = self._convert_g_infos_to_cg_infos_and_vg_infos(morph, g_infos, is_robot=False)
-
-            # Compute inertial properties for this variant from collision or visual geometries
-            het_mass, het_pos, het_i = compute_inertial_from_geom_infos(cg_infos, vg_infos, self.material.rho)
-            self.variants_inertial_mass.append(het_mass)
-            self.variants_inertial_pos.append(het_pos)
-            self.variants_inertial_i.append(het_i)
-
-            # Add visual geometries
-            for g_info in vg_infos:
-                link._add_vgeom(
-                    vmesh=g_info["vmesh"],
-                    init_pos=g_info.get("pos", gu.zero_pos()),
-                    init_quat=g_info.get("quat", gu.identity_quat()),
-                )
-
-            # Add collision geometries
-            coup_links = self.material.coup_links
-            for g_info in cg_infos:
-                friction = self.material.friction
-                if friction is None:
-                    friction = g_info.get("friction", gu.default_friction())
-                needs_coup = self.material.needs_coup and (coup_links is None or link.name in coup_links)
-                link._add_geom(
-                    mesh=g_info["mesh"],
-                    init_pos=g_info.get("pos", gu.zero_pos()),
-                    init_quat=g_info.get("quat", gu.identity_quat()),
-                    type=g_info["type"],
-                    friction=friction,
-                    sol_params=g_info["sol_params"],
-                    data=g_info.get("data"),
-                    needs_coup=needs_coup,
-                    contype=g_info["contype"],
-                    conaffinity=g_info["conaffinity"],
-                )
-
-            # Record ranges for this variant
-            self.variants_link_start.append(self.variants_link_end[-1])
-            self.variants_link_end.append(self._link_start + len(self._links))
-            self.variants_n_links.append(self.variants_link_end[-1] - self.variants_link_start[-1])
-            self.variants_geom_start.append(self.variants_geom_end[-1])
-            self.variants_geom_end.append(self.variants_geom_end[-1] + len(cg_infos))
-            self.variants_vgeom_start.append(self.variants_vgeom_end[-1])
-            self.variants_vgeom_end.append(self.variants_vgeom_end[-1] + len(vg_infos))
+        # Record geom range on the link (vgeom range already recorded by parent)
+        link._record_variant_geom_range(len(cg_infos))
 
     def _load_model(self):
         self._equalities = gs.List()
@@ -2071,68 +1913,7 @@ class RigidEntity(KinematicEntity):
             else:
                 free_verts_start += link.n_verts
 
-        # Add parent joints
-        joints = gs.List()
-        self._joints.append(joints)
-        for i_j_, j_info in enumerate(j_infos):
-            n_dofs = j_info["n_dofs"]
-
-            sol_params = np.array(j_info.get("sol_params", gu.default_solver_params()), copy=True)
-            if (
-                len(sol_params.shape) == 2
-                and sol_params.shape[0] == 1
-                and (sol_params[0][3] >= 1.0 or sol_params[0][2] >= sol_params[0][3])
-            ):
-                gs.logger.warning(
-                    f"Joint {j_info['name']}'s sol_params {sol_params[0]} look not right, change to default."
-                )
-                sol_params = gu.default_solver_params()
-
-            dofs_motion_ang = j_info.get("dofs_motion_ang")
-            if dofs_motion_ang is None:
-                if n_dofs == 6:
-                    dofs_motion_ang = np.eye(6, 3, -3)
-                elif n_dofs == 0:
-                    dofs_motion_ang = np.zeros((0, 3))
-                else:
-                    assert False
-
-            dofs_motion_vel = j_info.get("dofs_motion_vel")
-            if dofs_motion_vel is None:
-                if n_dofs == 6:
-                    dofs_motion_vel = np.eye(6, 3)
-                elif n_dofs == 0:
-                    dofs_motion_vel = np.zeros((0, 3))
-                else:
-                    assert False
-
-            joint = RigidJoint(
-                entity=self,
-                name=j_info["name"],
-                idx=joint_start + i_j_,
-                link_idx=link_idx,
-                q_start=self.n_qs + self._q_start,
-                dof_start=self.n_dofs + self._dof_start,
-                n_qs=j_info["n_qs"],
-                n_dofs=n_dofs,
-                type=j_info["type"],
-                pos=j_info.get("pos", gu.zero_pos()),
-                quat=j_info.get("quat", gu.identity_quat()),
-                init_qpos=j_info.get("init_qpos", np.zeros(n_dofs)),
-                sol_params=sol_params,
-                dofs_motion_ang=dofs_motion_ang,
-                dofs_motion_vel=dofs_motion_vel,
-                dofs_limit=j_info.get("dofs_limit", np.tile([[-np.inf, np.inf]], [n_dofs, 1])),
-                dofs_invweight=j_info.get("dofs_invweight", np.zeros(n_dofs)),
-                dofs_frictionloss=j_info.get("dofs_frictionloss", np.zeros(n_dofs)),
-                dofs_stiffness=j_info.get("dofs_stiffness", np.zeros(n_dofs)),
-                dofs_damping=j_info.get("dofs_damping", np.zeros(n_dofs)),
-                dofs_armature=j_info.get("dofs_armature", np.zeros(n_dofs)),
-                dofs_kp=j_info.get("dofs_kp", np.zeros(n_dofs)),
-                dofs_kv=j_info.get("dofs_kv", np.zeros(n_dofs)),
-                dofs_force_range=j_info.get("dofs_force_range", np.tile([[-np.inf, np.inf]], [n_dofs, 1])),
-            )
-            joints.append(joint)
+        joints = self._create_joints(j_infos, link_idx, joint_start)
 
         # Add child link
         link = RigidLink(
@@ -2170,14 +1951,9 @@ class RigidEntity(KinematicEntity):
             link._inertial_i = None
             link._inertial_mass = None
 
-        # Separate collision from visual geometry for post-processing
-        cg_infos, vg_infos = [], []
-        for g_info in g_infos:
-            is_col = g_info["contype"] or g_info["conaffinity"]
-            if morph.collision and is_col:
-                cg_infos.append(g_info)
-            if morph.visualization and not is_col:
-                vg_infos.append(g_info)
+        # Separate collision from visual geometry, post-process collision meshes, and randomize colors.
+        # See _separate_geom_infos for post-processing details.
+        cg_infos, vg_infos = self._separate_geom_infos(morph, g_infos, l_info.get("is_robot", False))
 
         # Add visual geometries
         for g_info in vg_infos:
@@ -2186,42 +1962,6 @@ class RigidEntity(KinematicEntity):
                 init_pos=g_info.get("pos", gu.zero_pos()),
                 init_quat=g_info.get("quat", gu.identity_quat()),
             )
-
-        # Post-process all collision meshes at once.
-        # Destroying the original geometries should be avoided if possible as it will change the way objects
-        # interact with the world due to only computing one contact point per convex geometry. The idea is to
-        # check if each geometry can be convexified independently without resorting on convex decomposition.
-        # If so, the original geometries are preserve. If not, then they are all merged as one. Following the
-        # same approach as before, the resulting geometry is convexify without resorting on convex decomposition
-        # if possible. Mergeing before falling back directly to convex decompositio is important as it gives one
-        # last chance to avoid it. Moreover, it tends to reduce the final number of collision geometries. In
-        # both cases, this improves runtime performance, numerical stability and compilation time.
-        if isinstance(morph, gs.options.morphs.FileMorph):
-            # Choose the appropriate convex decomposition error threshold depending on whether the link at hand
-            # is associated with a robot.
-            # The rational behind it is that performing convex decomposition for robots is mostly useless because
-            # the non-physical part that is added to the original geometries to convexify them are generally inside
-            # the mechanical structure and not interacting directly with the outer world. On top of that, not only
-            # iy increases the memory footprint and compilation time, but also the simulation speed (marginally).
-            if l_info["is_robot"]:
-                decompose_error_threshold = morph.decompose_robot_error_threshold
-            else:
-                decompose_error_threshold = morph.decompose_object_error_threshold
-
-            cg_infos = mu.postprocess_collision_geoms(
-                cg_infos,
-                morph.decimate,
-                morph.decimate_face_num,
-                morph.decimate_aggressiveness,
-                morph.convexify,
-                decompose_error_threshold,
-                morph.coacd_options,
-            )
-
-        # Randomize collision mesh colors. The is especially useful to check convex decomposition.
-        for g_info in cg_infos:
-            mesh = g_info["mesh"]
-            mesh.set_color((*np.random.rand(3), 0.7))
 
         # Add collision geometries
         coup_links = self.material.coup_links
@@ -2246,21 +1986,29 @@ class RigidEntity(KinematicEntity):
         return link, joints
 
     @staticmethod
-    def _convert_g_infos_to_cg_infos_and_vg_infos(morph, g_infos, is_robot):
+    def _separate_geom_infos(morph, g_infos, is_robot):
         """
         Separate collision from visual geometry and post-process collision meshes.
         Used for both normal loading and heterogeneous simulation.
         """
-        cg_infos, vg_infos = [], []
-        for g_info in g_infos:
-            is_col = g_info["contype"] or g_info["conaffinity"]
-            if morph.collision and is_col:
-                cg_infos.append(g_info)
-            if morph.visualization and not is_col:
-                vg_infos.append(g_info)
+        cg_infos, vg_infos = KinematicEntity._separate_geom_infos(morph, g_infos, is_robot)
 
-        # Post-process all collision meshes at once
+        # Post-process all collision meshes at once.
+        # Destroying the original geometries should be avoided if possible as it will change the way objects
+        # interact with the world due to only computing one contact point per convex geometry. The idea is to
+        # check if each geometry can be convexified independently without resorting on convex decomposition.
+        # If so, the original geometries are preserve. If not, then they are all merged as one. Following the
+        # same approach as before, the resulting geometry is convexify without resorting on convex decomposition
+        # if possible. Mergeing before falling back directly to convex decompositio is important as it gives one
+        # last chance to avoid it. Moreover, it tends to reduce the final number of collision geometries. In
+        # both cases, this improves runtime performance, numerical stability and compilation time.
         if isinstance(morph, gs.options.morphs.FileMorph):
+            # Choose the appropriate convex decomposition error threshold depending on whether the link at hand
+            # is associated with a robot.
+            # The rational behind it is that performing convex decomposition for robots is mostly useless because
+            # the non-physical part that is added to the original geometries to convexify them are generally inside
+            # the mechanical structure and not interacting directly with the outer world. On top of that, not only
+            # iy increases the memory footprint and compilation time, but also the simulation speed (marginally).
             if is_robot:
                 decompose_error_threshold = morph.decompose_robot_error_threshold
             else:
@@ -2276,7 +2024,7 @@ class RigidEntity(KinematicEntity):
                 morph.coacd_options,
             )
 
-        # Randomize collision mesh colors
+        # Randomize collision mesh colors. This is especially useful to check convex decomposition.
         for g_info in cg_infos:
             mesh = g_info["mesh"]
             mesh.set_color((*np.random.rand(3), 0.7))

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -25,6 +25,104 @@ AABB_EPS = 0.002
 INERTIA_RATIO_MAX = 100.0
 
 
+def compute_inertial_from_geoms(geoms, rho, is_visual=False):
+    """
+    Compute combined inertial properties (mass, center of mass, inertia tensor) from geom objects.
+
+    Handles all primitive types analytically (SPHERE, ELLIPSOID, CYLINDER,
+    CAPSULE, BOX) and falls back to trimesh for MESH type.
+
+    Parameters
+    ----------
+    geoms : list[RigidGeom] or list[RigidVisGeom]
+        List of geometry objects to compute inertial from.
+    rho : float
+        Material density (kg/m^3).
+    is_visual : bool
+        If True, treat all geoms as MESH type and use visual vertices/faces.
+
+    Returns
+    -------
+    tuple[float, np.ndarray, np.ndarray]
+        (total_mass, center_of_mass, inertia_tensor)
+    """
+    total_mass = 0.0
+    total_com = np.zeros(3, dtype=gs.np_float)
+    total_inertia = np.zeros((3, 3), dtype=gs.np_float)
+
+    for geom in geoms:
+        if is_visual:
+            geom_type = gs.GEOM_TYPE.MESH
+        else:
+            geom_type = geom.type
+
+        geom_pos = geom._init_pos
+        geom_quat = geom._init_quat
+
+        geom_com_local = np.zeros(3)
+        if geom_type == gs.GEOM_TYPE.PLANE:
+            continue
+        elif geom_type == gs.GEOM_TYPE.SPHERE:
+            radius = geom.data[0]
+            geom_mass = (4.0 / 3.0) * np.pi * radius**3 * rho
+            I = (2.0 / 5.0) * geom_mass * radius**2
+            geom_inertia_local = np.diag([I, I, I])
+        elif geom_type == gs.GEOM_TYPE.ELLIPSOID:
+            hx, hy, hz = geom.data[:3]
+            geom_mass = (4.0 / 3.0) * np.pi * hx * hy * hz * rho
+            geom_inertia_local = (geom_mass / 5.0) * np.diag([hy**2 + hz**2, hx**2 + hz**2, hx**2 + hy**2])
+        elif geom_type == gs.GEOM_TYPE.CYLINDER:
+            radius, height = geom.data[:2]
+            geom_mass = np.pi * radius**2 * height * rho
+            I_r = (geom_mass / 12.0) * (3.0 * radius**2 + height**2)
+            I_z = 0.5 * geom_mass * radius**2
+            geom_inertia_local = np.diag([I_r, I_r, I_z])
+        elif geom_type == gs.GEOM_TYPE.CAPSULE:
+            radius, height = geom.data[:2]
+            m_cyl = np.pi * radius**2 * height * rho
+            m_sph = (4.0 / 3.0) * np.pi * radius**3 * rho
+            geom_mass = m_cyl + m_sph
+            I_r = (m_cyl * radius**2 / 12.0 * (3.0 + height**2 / radius**2)) + (
+                m_sph * radius**2 / 4.0 * (83.0 / 80.0 + (height / radius + 3.0 / 4.0) ** 2)
+            )
+            I_h = 0.5 * m_cyl * radius**2 + (2.0 / 5.0) * m_sph * radius**2
+            geom_inertia_local = np.diag([I_r, I_r, I_h])
+        elif geom_type == gs.GEOM_TYPE.BOX:
+            hx, hy, hz = geom.data[:3]
+            geom_mass = (hx * hy * hz) * rho
+            geom_inertia_local = (geom_mass / 12.0) * np.diag([hy**2 + hz**2, hx**2 + hz**2, hx**2 + hy**2])
+        else:
+            # MESH type
+            if is_visual:
+                inertia_mesh = trimesh.Trimesh(geom.init_vverts, geom.init_vfaces, process=False)
+            else:
+                inertia_mesh = trimesh.Trimesh(geom.init_verts, geom.init_faces, process=False)
+
+            if not inertia_mesh.is_watertight:
+                inertia_mesh = trimesh.convex.convex_hull(inertia_mesh)
+
+            # FIXME: without this check, some geom will have negative volume even after the above convex
+            # hull operation, e.g. 'tests/test_examples.py::test_example[rigid/terrain_from_mesh.py-None]'
+            if inertia_mesh.volume < -gs.EPS:
+                inertia_mesh.invert()
+
+            geom_mass = inertia_mesh.volume * rho
+            geom_com_local = inertia_mesh.center_mass
+
+            geom_inertia_local = inertia_mesh.moment_inertia / inertia_mesh.mass * geom_mass
+
+        # Transform geom properties to link frame
+        geom_com_link = gu.transform_by_quat(geom_com_local, geom_quat) + geom_pos
+        geom_inertia_link = rotate_inertia(geom_inertia_local, gu.quat_to_R(geom_quat))
+
+        # Compose with existing properties
+        total_mass, total_com, total_inertia = compose_inertial_properties(
+            total_mass, total_com, total_inertia, geom_mass, geom_com_link, geom_inertia_link
+        )
+
+    return total_mass, total_com, total_inertia
+
+
 class KinematicLink(RBC):
     """
     Kinematic class. One KinematicEntity consists of multiple KinematicLinks, each of which is a rigid body and could
@@ -83,6 +181,18 @@ class KinematicLink(RBC):
         self._quat: "np.typing.ArrayLike" = quat
 
         self._vgeoms: list[RigidVisGeom] = gs.List()
+
+        # Heterogeneous variant tracking (None = not heterogeneous)
+        self._variant_vgeom_ranges: list[tuple[int, int]] | None = None
+
+    def _init_variant_tracking(self):
+        """Start tracking heterogeneous variants. Records first variant from current state."""
+        self._variant_vgeom_ranges = [(self._vgeom_start, self._vgeom_start + self.n_vgeoms)]
+
+    def _record_variant_vgeom_range(self, n_new_vgeoms):
+        """Record a new variant's vgeom range."""
+        prev_end = self._variant_vgeom_ranges[-1][1]
+        self._variant_vgeom_ranges.append((prev_end, prev_end + n_new_vgeoms))
 
     def _build(self):
         for vgeom in self._vgeoms:
@@ -501,6 +611,19 @@ class RigidLink(KinematicLink):
 
         self._geoms: list[RigidGeom] = gs.List()
 
+        # Heterogeneous variant tracking (None = not heterogeneous)
+        self._variant_geom_ranges: list[tuple[int, int]] | None = None
+
+    def _init_variant_tracking(self):
+        """Start tracking heterogeneous variants. Records first variant from current state."""
+        super()._init_variant_tracking()
+        self._variant_geom_ranges = [(self._geom_start, self._geom_start + self.n_geoms)]
+
+    def _record_variant_geom_range(self, n_new_geoms):
+        """Record a new variant's geom range."""
+        prev_geom_end = self._variant_geom_ranges[-1][1]
+        self._variant_geom_ranges.append((prev_geom_end, prev_geom_end + n_new_geoms))
+
     def _build(self):
         super()._build()
 
@@ -526,76 +649,16 @@ class RigidLink(KinematicLink):
             # Get material density
             rho = self.entity.material.rho
 
-            # Process each geom individually and compose their properties
-            for geom in geom_list:
-                if is_visual:
-                    geom_type = gs.GEOM_TYPE.MESH
+            # For heterogeneous links, only use the first variant's geoms for the hint.
+            if self._variant_geom_ranges is not None:
+                start, end = self._variant_geom_ranges[0]
+                if not is_visual:
+                    geom_list = [g for g in geom_list if start <= g.idx < end]
                 else:
-                    geom_type = geom.type
+                    vs, ve = self._variant_vgeom_ranges[0]
+                    geom_list = [vg for vg in geom_list if vs <= vg.idx < ve]
 
-                geom_pos = geom._init_pos
-                geom_quat = geom._init_quat
-
-                geom_com_local = np.zeros(3)
-                if geom_type == gs.GEOM_TYPE.PLANE:
-                    pass
-                elif geom_type == gs.GEOM_TYPE.SPHERE:
-                    radius = geom.data[0]
-                    geom_mass = (4.0 / 3.0) * np.pi * radius**3 * rho
-                    I = (2.0 / 5.0) * geom_mass * radius**2
-                    geom_inertia_local = np.diag([I, I, I])
-                elif geom_type == gs.GEOM_TYPE.ELLIPSOID:
-                    hx, hy, hz = geom.data[:3]
-                    geom_mass = (4.0 / 3.0) * np.pi * hx * hy * hz * rho
-                    geom_inertia_local = (geom_mass / 5.0) * np.diag([hy**2 + hz**2, hx**2 + hz**2, hx**2 + hy**2])
-                elif geom_type == gs.GEOM_TYPE.CYLINDER:
-                    radius, height = geom.data[:2]
-                    geom_mass = np.pi * radius**2 * height * rho
-                    I_r = (geom_mass / 12.0) * (3.0 * radius**2 + height**2)
-                    I_z = 0.5 * geom_mass * radius**2
-                    geom_inertia_local = np.diag([I_r, I_r, I_z])
-                elif geom_type == gs.GEOM_TYPE.CAPSULE:
-                    radius, height = geom.data[:2]
-                    m_cyl = np.pi * radius**2 * height * rho
-                    m_sph = (4.0 / 3.0) * np.pi * radius**3 * rho
-                    geom_mass = m_cyl + m_sph
-                    I_r = (m_cyl * radius**2 / 12.0 * (3.0 + height**2 / radius**2)) + (
-                        m_sph * radius**2 / 4.0 * (83.0 / 80.0 + (height / radius + 3.0 / 4.0) ** 2)
-                    )
-                    I_h = 0.5 * m_cyl * radius**2 + (2.0 / 5.0) * m_sph * radius**2
-                    geom_inertia_local = np.diag([I_r, I_r, I_h])
-                elif geom_type == gs.GEOM_TYPE.BOX:
-                    hx, hy, hz = geom.data[:3]
-                    geom_mass = (hx * hy * hz) * rho
-                    geom_inertia_local = (geom_mass / 12.0) * np.diag([hy**2 + hz**2, hx**2 + hz**2, hx**2 + hy**2])
-                else:  # geom_type == gs.GEOM_TYPE.MESH:
-                    # Create mesh based on geom type
-                    if is_visual:
-                        inertia_mesh = trimesh.Trimesh(geom.init_vverts, geom.init_vfaces, process=False)
-                    else:
-                        inertia_mesh = trimesh.Trimesh(geom.init_verts, geom.init_faces, process=False)
-
-                    if not inertia_mesh.is_watertight:
-                        inertia_mesh = trimesh.convex.convex_hull(inertia_mesh)
-
-                    # FIXME: without this check, some geom will have negative volume even after the above convex
-                    # hull operation, e.g. 'tests/test_examples.py::test_example[rigid/terrain_from_mesh.py-None]'
-                    if inertia_mesh.volume < -gs.EPS:
-                        inertia_mesh.invert()
-
-                    geom_mass = inertia_mesh.volume * rho
-                    geom_com_local = inertia_mesh.center_mass
-
-                    geom_inertia_local = inertia_mesh.moment_inertia / inertia_mesh.mass * geom_mass
-
-                # Transform geom properties to link frame
-                geom_com_link = gu.transform_by_quat(geom_com_local, geom_quat) + geom_pos
-                geom_inertia_link = rotate_inertia(geom_inertia_local, gu.quat_to_R(geom_quat))
-
-                # Compose with existing properties
-                hint_mass, hint_com, hint_inertia = compose_inertial_properties(
-                    hint_mass, hint_com, hint_inertia, geom_mass, geom_com_link, geom_inertia_link
-                )
+            hint_mass, hint_com, hint_inertia = compute_inertial_from_geoms(geom_list, rho, is_visual)
 
             # Compute the bounding box of the links using both visual and collision geometries to be conservative
             for geoms, is_visual in zip((self._geoms, self._vgeoms), (False, True)):
@@ -683,6 +746,27 @@ class RigidLink(KinematicLink):
         # override invweight if fixed
         if self._is_fixed:
             self._invweight = np.zeros((2,), dtype=gs.np_float)
+
+        # Compute per-variant inertial for heterogeneous links
+        if self._variant_geom_ranges is not None:
+            rho = self.entity.material.rho
+            self._variant_inertial = []
+            for v in range(len(self._variant_geom_ranges)):
+                gs_v, ge_v = self._variant_geom_ranges[v]
+                vs_v, ve_v = self._variant_vgeom_ranges[v]
+                # Use collision geoms if available, otherwise fall back to visual geoms
+                variant_geoms = [g for g in self._geoms if gs_v <= g.idx < ge_v]
+                if variant_geoms:
+                    mass, com, inertia = compute_inertial_from_geoms(variant_geoms, rho)
+                else:
+                    variant_vgeoms = [vg for vg in self._vgeoms if vs_v <= vg.idx < ve_v]
+                    if variant_vgeoms:
+                        mass, com, inertia = compute_inertial_from_geoms(variant_vgeoms, rho, is_visual=True)
+                    else:
+                        mass = gs.EPS
+                        com = np.zeros(3, dtype=gs.np_float)
+                        inertia = np.zeros((3, 3), dtype=gs.np_float)
+                self._variant_inertial.append((mass, com, inertia))
 
     def _add_geom(
         self,

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -56,6 +56,17 @@ if TYPE_CHECKING:
     from genesis.engine.simulator import Simulator
 
 
+def _balanced_variant_mapping(n_variants, B):
+    """Map N variants to B environments using balanced block assignment."""
+    if B >= n_variants:
+        base = B // n_variants
+        extra = B % n_variants
+        sizes = np.r_[np.full(extra, base + 1), np.full(n_variants - extra, base)]
+        return np.repeat(np.arange(n_variants), sizes)
+    else:
+        return np.arange(B)
+
+
 IS_OLD_TORCH = tuple(map(int, torch.__version__.split(".")[:2])) < (2, 8)
 
 
@@ -199,7 +210,6 @@ class KinematicSolver(Solver):
         self._init_vvert_fields()
         self._init_vgeom_fields()
         self._init_link_fields()
-        self._process_heterogeneous_link_info()
         self._init_entity_fields()
 
         self._init_envs_offset()
@@ -348,54 +358,27 @@ class KinematicSolver(Solver):
 
         self.links_T = self._rigid_global_info.links_T
 
-    def _process_heterogeneous_link_info(self):
-        """
-        Process heterogeneous link info: dispatch geoms per environment and compute per-env inertial properties.
+        # Dispatch heterogeneous variant vgeom ranges per-environment
+        self._dispatch_heterogeneous_vgeoms()
 
-        This method is called after _init_link_fields to update the per-environment inertial properties
-        for entities with heterogeneous morphs.
-        """
-        for entity in self._entities:
-            # Skip non-heterogeneous entities
-            if not entity._enable_heterogeneous:
+    def _dispatch_heterogeneous_vgeoms(self):
+        """Override per-link vgeom ranges for heterogeneous variants. RigidSolver extends this."""
+        for link in self.links:
+            if link._variant_vgeom_ranges is None:
                 continue
 
-            # Get the number of variants for this entity
-            n_variants = len(entity.variants_vgeom_start)
+            n_variants = len(link._variant_vgeom_ranges)
+            variant_idx = _balanced_variant_mapping(n_variants, self._B)
 
-            # Distribute variants across environments using balanced block assignment:
-            # - If B >= n_variants: first B/n_variants environments get variant 0, next get variant 1, etc.
-            # - If B < n_variants: each environment gets a different variant (some variants unused)
-            if self._B >= n_variants:
-                base = self._B // n_variants
-                extra = self._B % n_variants  # first `extra` chunks get one more
-                sizes = np.r_[np.full(extra, base + 1), np.full(n_variants - extra, base)]
-                variant_idx = np.repeat(np.arange(n_variants), sizes)
-            else:
-                # Each environment gets a unique variant; variants beyond B are unused
-                variant_idx = np.arange(self._B)
+            vgeom_starts = np.array([link._variant_vgeom_ranges[v][0] for v in variant_idx], dtype=gs.np_int)
+            vgeom_ends = np.array([link._variant_vgeom_ranges[v][1] for v in variant_idx], dtype=gs.np_int)
 
-            # Get arrays from entity
-            np_vgeom_start = np.array(entity.variants_vgeom_start, dtype=gs.np_int)
-            np_vgeom_end = np.array(entity.variants_vgeom_end, dtype=gs.np_int)
+            kernel_update_heterogeneous_links_vgeom(link.idx, vgeom_starts, vgeom_ends, self.links_info)
 
-            # Process each link in this heterogeneous entity (currently only single-link supported)
-            for link in entity.links:
-                i_l = link.idx
-
-                # Build per-env arrays for vgeom ranges
-                links_vgeom_start = np_vgeom_start[variant_idx]
-                links_vgeom_end = np_vgeom_end[variant_idx]
-
-                # Update links vgeoms with per-environment values
-                # Note: when batch_links_info is True, the shape is (n_links, B)
-                kernel_update_heterogeneous_links_vgeom(i_l, links_vgeom_start, links_vgeom_end, self.links_info)
-
-                # Update active_envs_idx for vgeoms - indicates which environments each geom is active in
-                for vgeom in link.vgeoms:
-                    active_envs_mask = (links_vgeom_start <= vgeom.idx) & (vgeom.idx < links_vgeom_end)
-                    vgeom.active_envs_mask = torch.tensor(active_envs_mask, device=gs.device)
-                    (vgeom.active_envs_idx,) = np.where(active_envs_mask)
+            for vgeom in link.vgeoms:
+                active_envs_mask = (vgeom_starts <= vgeom.idx) & (vgeom.idx < vgeom_ends)
+                vgeom.active_envs_mask = torch.tensor(active_envs_mask, device=gs.device)
+                (vgeom.active_envs_idx,) = np.where(active_envs_mask)
 
     def _init_vvert_fields(self):
         self.vverts_info = self.data_manager.vverts_info

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -655,79 +655,59 @@ class RigidSolver(KinematicSolver):
 
         self._rigid_global_info.gravity.from_numpy(self.gravity)
 
-    def _process_heterogeneous_link_info(self):
+    def _dispatch_heterogeneous_vgeoms(self):
         """
-        Process heterogeneous link info: dispatch geoms per environment and compute per-env inertial properties.
-        This method is called after _init_link_fields to update the per-environment inertial properties
-        for entities with heterogeneous morphs.
+        Dispatch per-environment geom/vgeom ranges and inertial properties for heterogeneous links.
+
+        Extends the base class (which handles vgeom-only dispatch) to also dispatch collision geom
+        ranges and per-variant inertial properties. Per-variant inertial is pre-computed during
+        link._build() from actual geom objects, using analytic formulas for primitives.
         """
-        for entity in self._entities:
-            # Skip non-heterogeneous entities
-            if not entity._enable_heterogeneous:
+        from genesis.engine.solvers.kinematic_solver import _balanced_variant_mapping
+
+        for link in self.links:
+            if link._variant_vgeom_ranges is None:
                 continue
 
-            # Get the number of variants for this entity
-            n_variants = len(entity.variants_geom_start)
+            n_variants = len(link._variant_vgeom_ranges)
+            variant_idx = _balanced_variant_mapping(n_variants, self._B)
 
-            # Distribute variants across environments using balanced block assignment:
-            # - If B >= n_variants: first B/n_variants environments get variant 0, next get variant 1, etc.
-            # - If B < n_variants: each environment gets a different variant (some variants unused)
-            if self._B >= n_variants:
-                base = self._B // n_variants
-                extra = self._B % n_variants  # first `extra` chunks get one more
-                sizes = np.r_[np.full(extra, base + 1), np.full(n_variants - extra, base)]
-                variant_idx = np.repeat(np.arange(n_variants), sizes)
-            else:
-                # Each environment gets a unique variant; variants beyond B are unused
-                variant_idx = np.arange(self._B)
+            # Build per-env arrays from link's variant data
+            geom_starts = np.array([link._variant_geom_ranges[v][0] for v in variant_idx], dtype=gs.np_int)
+            geom_ends = np.array([link._variant_geom_ranges[v][1] for v in variant_idx], dtype=gs.np_int)
+            vgeom_starts = np.array([link._variant_vgeom_ranges[v][0] for v in variant_idx], dtype=gs.np_int)
+            vgeom_ends = np.array([link._variant_vgeom_ranges[v][1] for v in variant_idx], dtype=gs.np_int)
 
-            # Get arrays from entity
-            np_geom_start = np.array(entity.variants_geom_start, dtype=gs.np_int)
-            np_geom_end = np.array(entity.variants_geom_end, dtype=gs.np_int)
-            np_vgeom_start = np.array(entity.variants_vgeom_start, dtype=gs.np_int)
-            np_vgeom_end = np.array(entity.variants_vgeom_end, dtype=gs.np_int)
+            # Build per-env inertial arrays from pre-computed per-variant inertial
+            links_inertial_mass = np.array([link._variant_inertial[v][0] for v in variant_idx], dtype=gs.np_float)
+            links_inertial_pos = np.array([link._variant_inertial[v][1] for v in variant_idx], dtype=gs.np_float)
+            links_inertial_i = np.array([link._variant_inertial[v][2] for v in variant_idx], dtype=gs.np_float)
 
-            # Process each link in this heterogeneous entity (currently only single-link supported)
-            for link in entity.links:
-                i_l = link.idx
+            # Update links_info with per-environment values
+            # Note: when batch_links_info is True, the shape is (n_links, B)
+            kernel_update_heterogeneous_link_info(
+                link.idx,
+                geom_starts,
+                geom_ends,
+                vgeom_starts,
+                vgeom_ends,
+                links_inertial_mass,
+                links_inertial_pos,
+                links_inertial_i,
+                self.links_info,
+            )
 
-                # Build per-env arrays for geom/vgeom ranges
-                links_geom_start = np_geom_start[variant_idx]
-                links_geom_end = np_geom_end[variant_idx]
-                links_vgeom_start = np_vgeom_start[variant_idx]
-                links_vgeom_end = np_vgeom_end[variant_idx]
+            # Set active_envs on geoms — indicates which environments each geom is active in
+            for geom in link.geoms:
+                active_envs_mask = (geom_starts <= geom.idx) & (geom.idx < geom_ends)
+                geom.active_envs_mask = torch.tensor(active_envs_mask, device=gs.device)
+                (geom.active_envs_idx,) = np.where(active_envs_mask)
 
-                # Build per-env arrays for inertial properties
-                links_inertial_mass = np.array(
-                    [entity.variants_inertial_mass[v] for v in variant_idx], dtype=gs.np_float
-                )
-                links_inertial_pos = np.array([entity.variants_inertial_pos[v] for v in variant_idx], dtype=gs.np_float)
-                links_inertial_i = np.array([entity.variants_inertial_i[v] for v in variant_idx], dtype=gs.np_float)
-
-                # Update links_info with per-environment values
-                # Note: when batch_links_info is True, the shape is (n_links, B)
-                kernel_update_heterogeneous_link_info(
-                    i_l,
-                    links_geom_start,
-                    links_geom_end,
-                    links_vgeom_start,
-                    links_vgeom_end,
-                    links_inertial_mass,
-                    links_inertial_pos,
-                    links_inertial_i,
-                    self.links_info,
-                )
-
-                # Update active_envs_idx for geoms and vgeoms - indicates which environments each geom is active in
-                for geom in link.geoms:
-                    active_envs_mask = (links_geom_start <= geom.idx) & (geom.idx < links_geom_end)
-                    geom.active_envs_mask = torch.tensor(active_envs_mask, device=gs.device)
-                    (geom.active_envs_idx,) = np.where(active_envs_mask)
-
-                for vgeom in link.vgeoms:
-                    active_envs_mask = (links_vgeom_start <= vgeom.idx) & (vgeom.idx < links_vgeom_end)
-                    vgeom.active_envs_mask = torch.tensor(active_envs_mask, device=gs.device)
-                    (vgeom.active_envs_idx,) = np.where(active_envs_mask)
+            # Set active_envs on vgeoms
+            for vgeom in link.vgeoms:
+                active_envs_mask = (vgeom_starts <= vgeom.idx) & (vgeom.idx < vgeom_ends)
+                vgeom.active_envs_mask = torch.tensor(active_envs_mask, device=gs.device)
+                (vgeom.active_envs_idx,) = np.where(active_envs_mask)
 
     def _init_vert_fields(self):
         self.verts_info = self.data_manager.verts_info


### PR DESCRIPTION
   - Extract `compute_inertial_from_geoms` from `RigidLink._build()` into a reusable function with analytic formulas for all primitive types (SPHERE, ELLIPSOID, CYLINDER, CAPSULE, BOX), replacing the mesh-only `compute_inertial_from_geom_infos`
   - Move heterogeneous variant tracking (geom/vgeom ranges, inertial) from entity-level `variants_*` lists to per-link attributes (`_variant_vgeom_ranges`, `_variant_geom_ranges`, `_variant_inertial`), computed at build time
   - Replace 4 entity hooks with a single `_add_heterogeneous_variant` hook; delete `_process_heterogeneous_link_info` from both solvers, replaced by `_dispatch_heterogeneous_vgeoms` inlined in `_init_link_fields`
   - Delete dead code: `variants_link_start/end/n_links`, `_first_variant_n_geoms/n_vgeoms`, `_first_g_infos`