### PR TITLE
[MISC] Fix race condition in memory benchmarks causing zero to be reported.

### DIFF
--- a/tests/monitor_test_mem.py
+++ b/tests/monitor_test_mem.py
@@ -141,7 +141,13 @@ def main() -> None:
             last_output_line = potential_output_line
         old_mem_by_test = _mem_by_test
         time.sleep(CHECK_INTERVAL)
-    print("Test monitor exiting")
+    for _test in old_mem_by_test:
+        result_line = format_result_line(_test, max_mem_by_test[_test])
+        f.write(result_line + "\n")
+        num_results_written += 1
+    f.flush()
+    f.close()
+    print(f"Test monitor exiting ({num_results_written} results written)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When the parent pytest process exits, os.getppid() flips to 1 and the monitor loop exits before it can detect that tracked tests disappeared. Flush any remaining results after the loop ends.

<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines:
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/contributing/PULL_REQUESTS.md
2. Prepare your PR according to the "Submitting Code Changes"
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/contributing/PULL_REQUESTS.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [CHANGING] for changes that will change simulation's behaviour
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->
- fixes case of running  a single test, e.g.
```
pytest -m benchmarks -v -k dex_hand --mem-monitoring-filepath=../tmp/dex_hand_genesis_field1.csv
```

Before:

```
tests/test_rigid_benchmarks.py::test_speed[dex_hand-None-None-4096-gpu] 2 tests running, of which 1 on gpu. Num results written: 0 [updating]
[gw0] [100%] PASSED tests/test_rigid_benchmarks.py::test_speed[dex_hand-None-None-4096-gpu]

================================================================================= warnings summary ==================================================================================
tests/test_rigid_benchmarks.py::test_speed[dex_hand-None-None-4096-gpu]
tests/test_rigid_benchmarks.py::test_speed[dex_hand-None-None-4096-gpu]
  /home/hugh/git/genesis/.venv/lib/python3.10/site-packages/pygltflib/__init__.py:830: UserWarning: pygltflib currently does not remove image data from the buffer when converting to data uri.Please open an issue at https://gitlab.com/dodgyville/pygltflib/issues
    warnings.warn("pygltflib currently does not remove image data "

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================= slowest durations =================================================================================

(3 durations < 100s hidden.)
================================================================ 1 passed, 2 skipped, 2 warnings in 89.52s (0:01:29) ================================================================
[Quadrants] version 0.4.3, llvm 20.1.0, commit eff73c38, linux, python 3.10.18
[I 03/16/26 17:43:27.824 3249591] [shell.py:_shell_pop_print@25] Graphical python shell detected, using wrapped sys.stdout
(genesis-world) hugh@hugh5090:~/git/genesis$ Test monitor exiting

(genesis-world) hugh@hugh5090:~/git/genesis$ cat ../tmp/dex_hand_genesis_field1.csv
(genesis-world) hugh@hugh5090:~/git/genesis$ cat ../tmp/dex_hand_genesis_field1.csv
(genesis-world) hugh@hugh5090:~/git/genesis$ ls -lhrt ../tmp/dex_hand_genesis_field1.csv
-rw-rw-r-- 1 hugh hugh 0 Mar 16 17:43 ../tmp/dex_hand_genesis_field1.csv
```

After:
```
(genesis-world) hugh@hugh5090:~/git/genesis$ GS_ENABLE_NDARRAY=0 pytest -m benchmarks -v -k dex_hand --mem-monitoring-filepath=../tmp/dex_hand_genesis_field1.csv
================================================================================ test session starts ================================================================================
platform linux -- Python 3.10.18, pytest-9.0.1, pluggy-1.6.0 -- /home/hugh/git/genesis/.venv/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/hugh/git/genesis
configfile: pyproject.toml
plugins: forked-1.6.0, print-1.2.0, anyio-4.11.0, syrupy-5.0.0, xdist-3.8.0, random-order-1.2.0, rerunfailures-16.1
1 worker [1 item]s / 1 skipped
scheduling tests via WorkStealingScheduling

tests/test_rigid_benchmarks.py::test_speed[dex_hand-None-None-4096-gpu] 2 tests running, of which 1 on gpu. Num results written: 0 [updating]
[gw0] [100%] PASSED tests/test_rigid_benchmarks.py::test_speed[dex_hand-None-None-4096-gpu]

================================================================================= warnings summary ==================================================================================
tests/test_rigid_benchmarks.py::test_speed[dex_hand-None-None-4096-gpu]
tests/test_rigid_benchmarks.py::test_speed[dex_hand-None-None-4096-gpu]
  /home/hugh/git/genesis/.venv/lib/python3.10/site-packages/pygltflib/__init__.py:830: UserWarning: pygltflib currently does not remove image data from the buffer when converting to data uri.Please open an issue at https://gitlab.com/dodgyville/pygltflib/issues
    warnings.warn("pygltflib currently does not remove image data "

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================= slowest durations =================================================================================

(3 durations < 100s hidden.)
================================================================ 1 passed, 2 skipped, 2 warnings in 87.24s (0:01:27) ================================================================
[Quadrants] version 0.4.3, llvm 20.1.0, commit eff73c38, linux, python 3.10.18
[I 03/16/26 17:51:20.598 3250579] [shell.py:_shell_pop_print@25] Graphical python shell detected, using wrapped sys.stdout
(genesis-world) hugh@hugh5090:~/git/genesis$ Test monitor exiting (1 results written)

(genesis-world) hugh@hugh5090:~/git/genesis$ cat ../tmp/dex_hand_genesis_field1.csv
env=dex_hand    | batch_size=4096       | backend=gpu   | dtype=field   | max_mem_mb=8606
(genesis-world) hugh@hugh5090:~/git/genesis$
```

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I read the **CONTRIBUTING** document.
- [ ] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [ ] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
