### PR TITLE
[BUG FIX] Fix rigid body simulation crashing on old Nvidia GPU (CUDA < sm90).

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "psutil",
-    "quadrants==0.5.0",
+    "quadrants==0.5.1",
     "pydantic>=2.11.0",
     "numpy>=1.26.4",
     "frozendict",


### PR DESCRIPTION
## Description

We migrated the solver to use gpu_graph, which on CUDA uses CUDA graph under the hood

* on SM90+ we use also a conditional CUDA node, so the entire solver iteration loop runs on the GPU
* on CUDA < SM90 we should fall back to using CUDA graph for the solver iteration body, but checking the iteration variable hostside
* however we were incorrectly throwing an error on CUDA < SM90, instead of falling back to checking the iteration variable hostside
* this PR addresses this issue.

Related to https://github.com/Genesis-Embodied-AI/Genesis/issues/2631