### PR TITLE
[MISC] Better parallelization of add collision constraints.

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -590,10 +590,15 @@ def add_collision_constraints(
 
     _B = dofs_state.ctrl_mode.shape[1]
     n_dofs = dofs_state.ctrl_mode.shape[0]
+    max_contact_pairs = collider_state.contact_data.link_a.shape[0]
 
     qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
-    for i_b in range(_B):
-        for i_col in range(collider_state.n_contacts[i_b]):
+    for flat_idx in range(max_contact_pairs * _B):
+        i_b = flat_idx % _B
+        i_col = flat_idx // _B
+        if i_col < collider_state.n_contacts[i_b]:
+            collision_con_start = constraint_state.n_constraints[i_b]
+
             contact_data_link_a = collider_state.contact_data.link_a[i_col, i_b]
             contact_data_link_b = collider_state.contact_data.link_b[i_col, i_b]
 
@@ -618,7 +623,7 @@ def add_collision_constraints(
                 d = (2 * (i % 2) - 1) * (d1 if i < 2 else d2)
                 n = d * contact_data_friction - contact_data_normal
 
-                n_con = qd.atomic_add(constraint_state.n_constraints[i_b], 1)
+                n_con = collision_con_start + i_col * 4 + i
                 if qd.static(static_rigid_sim_config.sparse_solve):
                     for i_d_ in range(constraint_state.jac_n_relevant_dofs[n_con, i_b]):
                         i_d = constraint_state.jac_relevant_dofs[n_con, i_d_, i_b]
@@ -674,6 +679,10 @@ def add_collision_constraints(
                 constraint_state.diag[n_con, i_b] = diag
                 constraint_state.aref[n_con, i_b] = aref
                 constraint_state.efc_D[n_con, i_b] = 1 / diag
+
+    qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
+    for i_b in range(_B):
+        constraint_state.n_constraints[i_b] = constraint_state.n_constraints[i_b] + collider_state.n_contacts[i_b] * 4
 
 
 @qd.func


### PR DESCRIPTION
## Description

Split add_collision_constraints out of add_inequality_constraints into a separate kernel (add_collision_constraints_work) with a transposed flat loop: i_b = flat_idx % B, i_col = flat_idx // B. This ensures warp threads access consecutive i_b values, giving coalesced Jacobian writes.

Constraint slots are allocated deterministically (collision_con_start + i_col * 4 + i) instead of via atomic_add. A follow-up kernel (update_n_constraints_collision) bumps n_constraints per env.

## Motivation and Context

Benchmarks on field:

<img width="759" height="960" alt="20260401_coll_cnostr_2b_1503" src="https://github.com/user-attachments/assets/375fa179-18d1-41d7-bc76-2355c9f28f2d" />

Another run. some variance:

<img width="759" height="960" alt="20260401_coll_cnostr_2b_1503 (1)" src="https://github.com/user-attachments/assets/9115ec7a-c586-4afb-b4fb-3edce319b13b" />