### PR TITLE
[MISC] Speedup parallel linesearch while dramatically improving accuracy.

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -2201,6 +2201,51 @@ def func_ls_init_and_eval_p0_opt(
 
 
 @qd.func
+def func_ls_constraint_quad_contrib(
+    i_c,
+    alpha,
+    i_b,
+    nef,
+    constraint_state: array_class.ConstraintState,
+):
+    """Per-constraint (qf_0, qf_1, qf_2) contribution to the quadratic cost coefficients at `alpha`.
+
+    Handles friction (i_c < nef; linear-regime toggle when x falls outside [-rf, rf]) and
+    contact (i_c >= nef; active only when x < 0). Equality constraints are pre-summed into
+    quad_gauss + eq_sum during the p0 kernel and should be skipped by the caller (i.e. the
+    caller's constraint loop starts at `ne`, not 0).
+
+    Shared by the serial monolith evaluator (func_ls_point_fn_opt) and the cooperative
+    subgroup variant used inside the parallel linesearch kernel.
+    """
+    Jaref_c = constraint_state.Jaref[i_c, i_b]
+    jv_c = constraint_state.jv[i_c, i_b]
+    D = constraint_state.efc_D[i_c, i_b]
+    qf_0 = D * (gs.qd_float(0.5) * Jaref_c * Jaref_c)
+    qf_1 = D * (jv_c * Jaref_c)
+    qf_2 = D * (gs.qd_float(0.5) * jv_c * jv_c)
+    x = Jaref_c + alpha * jv_c
+    if i_c < nef:
+        f = constraint_state.efc_frictionloss[i_c, i_b]
+        r = constraint_state.diag[i_c, i_b]
+        rf = r * f
+        linear_neg = x <= -rf
+        linear_pos = x >= rf
+        if linear_neg or linear_pos:
+            qf_0 = linear_neg * f * (-gs.qd_float(0.5) * rf - Jaref_c) + linear_pos * f * (
+                -gs.qd_float(0.5) * rf + Jaref_c
+            )
+            qf_1 = linear_neg * (-f * jv_c) + linear_pos * (f * jv_c)
+            qf_2 = gs.qd_float(0.0)
+    else:
+        active = x < 0
+        qf_0 = qf_0 * active
+        qf_1 = qf_1 * active
+        qf_2 = qf_2 * active
+    return qf_0, qf_1, qf_2
+
+
+@qd.func
 def func_ls_point_fn_opt(
     i_b,
     alpha,
@@ -2209,7 +2254,7 @@ def func_ls_point_fn_opt(
 ):
     """Evaluate linesearch cost, gradient, and curvature at a single candidate alpha.
 
-    Iterates over only friction and contact constraints — equality constraints are skipped by initializing accumulators
+    Iterates over only friction and contact constraints - equality constraints are skipped by initializing accumulators
     from quad_gauss + eq_sum (pre-computed during init).
 
     Quad coefficients are recomputed on the fly from Jaref, jv, efc_D rather than read from a precomputed quad array.
@@ -2224,41 +2269,11 @@ def func_ls_point_fn_opt(
     quad_total_1 = constraint_state.quad_gauss[1, i_b] + constraint_state.eq_sum[1, i_b]
     quad_total_2 = constraint_state.quad_gauss[2, i_b] + constraint_state.eq_sum[2, i_b]
 
-    # Friction constraints [ne, nef): 5 loads (Jaref, jv, D, f, diag) + recompute quad
-    for i_c in range(ne, nef):
-        Jaref_c = constraint_state.Jaref[i_c, i_b]
-        jv_c = constraint_state.jv[i_c, i_b]
-        D = constraint_state.efc_D[i_c, i_b]
-        f = constraint_state.efc_frictionloss[i_c, i_b]
-        r = constraint_state.diag[i_c, i_b]
-        qf_0 = D * (0.5 * Jaref_c * Jaref_c)
-        qf_1 = D * (jv_c * Jaref_c)
-        qf_2 = D * (0.5 * jv_c * jv_c)
-        x = Jaref_c + alpha * jv_c
-        rf = r * f
-        linear_neg = x <= -rf
-        linear_pos = x >= rf
-        if linear_neg or linear_pos:
-            qf_0 = linear_neg * f * (-0.5 * rf - Jaref_c) + linear_pos * f * (-0.5 * rf + Jaref_c)
-            qf_1 = linear_neg * (-f * jv_c) + linear_pos * (f * jv_c)
-            qf_2 = 0.0
+    for i_c in range(ne, n_con):
+        qf_0, qf_1, qf_2 = func_ls_constraint_quad_contrib(i_c, alpha, i_b, nef, constraint_state)
         quad_total_0 = quad_total_0 + qf_0
         quad_total_1 = quad_total_1 + qf_1
         quad_total_2 = quad_total_2 + qf_2
-
-    # Contact constraints [nef, n_con): 3 loads (Jaref, jv, D) + recompute quad
-    for i_c in range(nef, n_con):
-        Jaref_c = constraint_state.Jaref[i_c, i_b]
-        jv_c = constraint_state.jv[i_c, i_b]
-        D = constraint_state.efc_D[i_c, i_b]
-        x = Jaref_c + alpha * jv_c
-        active = x < 0
-        qf_0 = D * (0.5 * Jaref_c * Jaref_c)
-        qf_1 = D * (jv_c * Jaref_c)
-        qf_2 = D * (0.5 * jv_c * jv_c)
-        quad_total_0 = quad_total_0 + qf_0 * active
-        quad_total_1 = quad_total_1 + qf_1 * active
-        quad_total_2 = quad_total_2 + qf_2 * active
 
     cost = alpha * alpha * quad_total_2 + alpha * quad_total_1 + quad_total_0
     grad = 2 * alpha * quad_total_2 + quad_total_1

--- a/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
@@ -465,97 +465,63 @@ def _func_parallel_linesearch_eval(
                 sh_cand_alpha[0] = best_alpha
             qd.simt.block.sync()
 
-            # === Phase 3: Cooperative gradient bisection ===
-            best_alpha_shared = sh_cand_alpha[0]
-            if best_alpha_shared > 0.0:
-                # Cooperatively compute gradient at best_alpha
-                alpha_eval = best_alpha_shared
+            # === Phase 3: Serial linesearch refinement (thread 0) ===
+            # The grid search (Phase 1+2) picks a good starting alpha via cooperative evaluation.
+            # Phase 3 re-evaluates it serially via func_ls_point_fn_opt (consistent with the
+            # post-linesearch cost kernel), then runs a Newton-step bracketing walk to converge.
+            #
+            # Three fixes vs the original bisection-based Phase 3:
+            # 1. Always entered (not gated on best_alpha > 0) - the cooperative grid search can
+            #    report "no improvement" when serial evaluation disagrees.
+            # 2. candidates[0] is always written by Phase 3 - prevents the grid search's
+            #    cooperatively-selected alpha from leaking to the apply step unvalidated.
+            # 3. Bracketing walk (Newton steps until the gradient sign flips or `ls_iterations`
+            #    is hit) instead of the previous 12-step gradient bisection - bisection
+            #    converged to suboptimal zero-crossings on piecewise-quadratic cost functions.
+            if tid == 0:
+                constraint_state.candidates[0, i_b] = 0.0
+                constraint_state.candidates[4, i_b] = gs.qd_float(1e30)
 
-                # Cooperative gradient: accumulate quad_total_1 and quad_total_2
-                local_qt1 = gs.qd_float(0.0)
-                local_qt2 = gs.qd_float(0.0)
-                i_c = ne + tid
-                while i_c < n_con:
-                    Jaref_c = constraint_state.Jaref[i_c, i_b]
-                    jv_c = constraint_state.jv[i_c, i_b]
-                    D = constraint_state.efc_D[i_c, i_b]
-                    x = Jaref_c + alpha_eval * jv_c
-                    if i_c < nef:
-                        f_val = constraint_state.efc_frictionloss[i_c, i_b]
-                        r_val = constraint_state.diag[i_c, i_b]
-                        rf = r_val * f_val
-                        linear_neg = x <= -rf
-                        linear_pos = x >= rf
-                        qf_1 = D * (jv_c * Jaref_c)
-                        qf_2 = D * (0.5 * jv_c * jv_c)
-                        if linear_neg or linear_pos:
-                            qf_1 = linear_neg * (-f_val * jv_c) + linear_pos * (f_val * jv_c)
-                            qf_2 = 0.0
-                        local_qt1 = local_qt1 + qf_1
-                        local_qt2 = local_qt2 + qf_2
-                    else:
-                        act = x < 0
-                        local_qt1 = local_qt1 + D * (jv_c * Jaref_c) * act
-                        local_qt2 = local_qt2 + D * (0.5 * jv_c * jv_c) * act
-                    i_c += _K
+                # Re-evaluate grid winner (or alpha=0) serially
+                p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver.func_ls_point_fn_opt(
+                    i_b,
+                    sh_cand_alpha[0],
+                    constraint_state,
+                    rigid_global_info,
+                )
+                if p0_cost < p1_cost:
+                    p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver.func_ls_point_fn_opt(
+                        i_b,
+                        gs.qd_float(0.0),
+                        constraint_state,
+                        rigid_global_info,
+                    )
 
-                # Reduce qt1 and qt2
-                sh_val[tid] = local_qt1
-                sh_val2[tid] = local_qt2
-                qd.simt.block.sync()
-                stride = _K // 2
-                while stride > 0:
-                    if tid < stride:
-                        sh_val[tid] += sh_val[tid + stride]
-                        sh_val2[tid] += sh_val2[tid + stride]
-                    qd.simt.block.sync()
-                    stride //= 2
+                # Always write candidates[0] - even if already converged
+                if p1_cost < p0_cost:
+                    constraint_state.candidates[0, i_b] = p1_alpha
 
-                if tid == 0:
-                    qt1_total = constraint_state.quad_gauss[1, i_b] + constraint_state.eq_sum[1, i_b] + sh_val[0]
-                    qt2_total = constraint_state.quad_gauss[2, i_b] + constraint_state.eq_sum[2, i_b] + sh_val2[0]
-                    g_best = 2.0 * alpha_eval * qt2_total + qt1_total
-
-                    if qd.abs(g_best) > gtol:
-                        hess_best = 2.0 * qt2_total
-                        newton_done = False
-
-                        # Try one Newton correction first (O(1) compute + 1 cost eval)
-                        if hess_best > rigid_global_info.EPS[None]:
-                            alpha_nc = alpha_eval - g_best / hess_best
-                            if alpha_nc > 0.0:
-                                c_nc, g_nc = _ls_eval_cost_grad(alpha_nc, i_b, constraint_state)
-                                if c_nc < p0_cost and c_nc < constraint_state.candidates[4, i_b]:
-                                    constraint_state.candidates[0, i_b] = alpha_nc
-                                    constraint_state.candidates[4, i_b] = c_nc
-                                    newton_done = True
-                        # Fall back to bisection if Newton didn't converge
-                        if not newton_done:
-                            bis_a = alpha_eval * 0.5
-                            bis_b = alpha_eval
-                            if g_best < 0.0:
-                                bis_a = alpha_eval
-                                bis_b = alpha_eval * 2.0
-
-                            _, g_a = _ls_eval_cost_grad(bis_a, i_b, constraint_state)
-                            _, g_b = _ls_eval_cost_grad(bis_b, i_b, constraint_state)
-
-                            if g_a < 0.0 and g_b > 0.0:
-                                _N_BISECT = qd.static(LS_BISECT_STEPS)
-                                for _bis_it in range(_N_BISECT):
-                                    mid_b = (bis_a + bis_b) * 0.5
-                                    c_mid_b, g_mid_b = _ls_eval_cost_grad(mid_b, i_b, constraint_state)
-                                    if qd.abs(g_mid_b) < gtol or qd.abs(bis_b - bis_a) < rigid_global_info.EPS[None]:
-                                        break
-                                    if g_mid_b < 0.0:
-                                        bis_a = mid_b
-                                    else:
-                                        bis_b = mid_b
-                                mid_b = (bis_a + bis_b) * 0.5
-                                c_mid_b, _ = _ls_eval_cost_grad(mid_b, i_b, constraint_state)
-                                if c_mid_b < p0_cost and c_mid_b < constraint_state.candidates[4, i_b]:
-                                    constraint_state.candidates[0, i_b] = mid_b
-                                    constraint_state.candidates[4, i_b] = c_mid_b
+                if qd.abs(p1_deriv_0) > gtol:
+                    # Bracketing walk: Newton steps until gradient sign flips or max iterations.
+                    direction = (p1_deriv_0 < 0) * 2 - 1
+                    bracket_done = False
+                    while (
+                        p1_deriv_0 * direction <= -gtol
+                        and constraint_state.ls_it[i_b] < rigid_global_info.ls_iterations[None]
+                    ):
+                        p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver.func_ls_point_fn_opt(
+                            i_b,
+                            p1_alpha - p1_deriv_0 / p1_deriv_1,
+                            constraint_state,
+                            rigid_global_info,
+                        )
+                        if qd.abs(p1_deriv_0) < gtol:
+                            constraint_state.candidates[0, i_b] = p1_alpha
+                            bracket_done = True
+                            break
+                    if not bracket_done:
+                        constraint_state.candidates[0, i_b] = p1_alpha
+            qd.simt.block.sync()
         else:
             if tid == 0:
                 constraint_state.candidates[0, i_b] = 0.0

--- a/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
@@ -37,6 +37,70 @@ LS_ALPHA_MAX = 1e4
 
 
 @qd.func
+def _subgroup_reduce_add_f32(tid, v):
+    """Sum-reduce a scalar across a 32-thread subgroup, broadcasting to every thread.
+
+    Down-shuffle tree (stride 16 -> 1) leaves tid 0 with the full sum; a final
+    shuffle-from-lane-0 distributes the result to every lane so the caller can
+    use it in control flow without branching on tid.
+    """
+    for stride in qd.static((16, 8, 4, 2, 1)):
+        v = v + qd.simt.subgroup.shuffle(v, qd.cast(tid + stride, qd.u32))
+    return qd.simt.subgroup.shuffle(v, qd.cast(0, qd.u32))
+
+
+@qd.func
+def _func_ls_point_fn_coop(
+    tid,
+    i_b,
+    alpha,
+    constraint_state: array_class.ConstraintState,
+    rigid_global_info: array_class.RigidGlobalInfo,
+):
+    """Cooperative K-thread evaluation of cost, gradient, and curvature at `alpha`.
+
+    Same semantics as solver.func_ls_point_fn_opt, but each of the 32 subgroup
+    threads handles a strided slice of the friction + contact constraints. The
+    per-constraint body is shared (solver.func_ls_constraint_quad_contrib); the
+    strided partial sums are combined via a sync-free subgroup shuffle tree and
+    broadcast back to every lane, so the caller's control flow runs in lockstep.
+
+    Does not increment `constraint_state.ls_it` - the caller manages the
+    iteration counter locally to avoid cross-thread memory-ordering concerns.
+    """
+    ne = constraint_state.n_constraints_equality[i_b]
+    nef = ne + constraint_state.n_constraints_frictionloss[i_b]
+    n_con = constraint_state.n_constraints[i_b]
+
+    local_qt0 = gs.qd_float(0.0)
+    local_qt1 = gs.qd_float(0.0)
+    local_qt2 = gs.qd_float(0.0)
+
+    i_c = ne + tid
+    while i_c < n_con:
+        qf_0, qf_1, qf_2 = solver.func_ls_constraint_quad_contrib(i_c, alpha, i_b, nef, constraint_state)
+        local_qt0 = local_qt0 + qf_0
+        local_qt1 = local_qt1 + qf_1
+        local_qt2 = local_qt2 + qf_2
+        i_c += qd.static(LS_PARALLEL_K)
+
+    red_qt0 = _subgroup_reduce_add_f32(tid, local_qt0)
+    red_qt1 = _subgroup_reduce_add_f32(tid, local_qt1)
+    red_qt2 = _subgroup_reduce_add_f32(tid, local_qt2)
+
+    qt0_total = constraint_state.quad_gauss[0, i_b] + constraint_state.eq_sum[0, i_b] + red_qt0
+    qt1_total = constraint_state.quad_gauss[1, i_b] + constraint_state.eq_sum[1, i_b] + red_qt1
+    qt2_total = constraint_state.quad_gauss[2, i_b] + constraint_state.eq_sum[2, i_b] + red_qt2
+
+    cost = alpha * alpha * qt2_total + alpha * qt1_total + qt0_total
+    grad = gs.qd_float(2.0) * alpha * qt2_total + qt1_total
+    hess = gs.qd_float(2.0) * qt2_total
+    if hess <= 0.0:
+        hess = rigid_global_info.EPS[None]
+    return alpha, cost, grad, hess
+
+
+@qd.func
 def _ls_eval_cost_grad(
     alpha,
     i_b,
@@ -465,10 +529,11 @@ def _func_parallel_linesearch_eval(
                 sh_cand_alpha[0] = best_alpha
             qd.simt.block.sync()
 
-            # === Phase 3: Serial linesearch refinement (thread 0) ===
-            # The grid search (Phase 1+2) picks a good starting alpha via cooperative evaluation.
-            # Phase 3 re-evaluates it serially via func_ls_point_fn_opt (consistent with the
-            # post-linesearch cost kernel), then runs a Newton-step bracketing walk to converge.
+            # === Phase 3: Cooperative linesearch refinement ===
+            # All K threads participate in every per-alpha evaluation via
+            # _func_ls_point_fn_coop, which returns the same (cost, grad, hess) on
+            # every thread so the control flow below runs in subgroup lockstep.
+            # Writes to candidates[*, i_b] and ls_it[i_b] are gated on tid == 0.
             #
             # Three fixes vs the original bisection-based Phase 3:
             # 1. Always entered (not gated on best_alpha > 0) - the cooperative grid search can
@@ -482,45 +547,51 @@ def _func_parallel_linesearch_eval(
                 constraint_state.candidates[0, i_b] = 0.0
                 constraint_state.candidates[4, i_b] = gs.qd_float(1e30)
 
-                # Re-evaluate grid winner (or alpha=0) serially
-                p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver.func_ls_point_fn_opt(
-                    i_b,
-                    sh_cand_alpha[0],
-                    constraint_state,
-                    rigid_global_info,
+            # Local copy of ls_it so we don't pay for cross-thread memory ordering;
+            # written back to global memory at the end of Phase 3.
+            local_ls_it = constraint_state.ls_it[i_b]
+            max_ls_it = rigid_global_info.ls_iterations[None]
+
+            # Re-evaluate grid winner cooperatively
+            p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = _func_ls_point_fn_coop(
+                tid, i_b, sh_cand_alpha[0], constraint_state, rigid_global_info
+            )
+            local_ls_it = local_ls_it + 1
+            if p0_cost < p1_cost:
+                p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = _func_ls_point_fn_coop(
+                    tid, i_b, gs.qd_float(0.0), constraint_state, rigid_global_info
                 )
-                if p0_cost < p1_cost:
-                    p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver.func_ls_point_fn_opt(
+                local_ls_it = local_ls_it + 1
+
+            # Always write candidates[0] - even if already converged
+            if p1_cost < p0_cost:
+                if tid == 0:
+                    constraint_state.candidates[0, i_b] = p1_alpha
+
+            if qd.abs(p1_deriv_0) > gtol:
+                # Bracketing walk: Newton steps until gradient sign flips or max iterations.
+                direction = (p1_deriv_0 < 0) * 2 - 1
+                bracket_done = False
+                while p1_deriv_0 * direction <= -gtol and local_ls_it < max_ls_it:
+                    p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = _func_ls_point_fn_coop(
+                        tid,
                         i_b,
-                        gs.qd_float(0.0),
+                        p1_alpha - p1_deriv_0 / p1_deriv_1,
                         constraint_state,
                         rigid_global_info,
                     )
-
-                # Always write candidates[0] - even if already converged
-                if p1_cost < p0_cost:
-                    constraint_state.candidates[0, i_b] = p1_alpha
-
-                if qd.abs(p1_deriv_0) > gtol:
-                    # Bracketing walk: Newton steps until gradient sign flips or max iterations.
-                    direction = (p1_deriv_0 < 0) * 2 - 1
-                    bracket_done = False
-                    while (
-                        p1_deriv_0 * direction <= -gtol
-                        and constraint_state.ls_it[i_b] < rigid_global_info.ls_iterations[None]
-                    ):
-                        p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver.func_ls_point_fn_opt(
-                            i_b,
-                            p1_alpha - p1_deriv_0 / p1_deriv_1,
-                            constraint_state,
-                            rigid_global_info,
-                        )
-                        if qd.abs(p1_deriv_0) < gtol:
+                    local_ls_it = local_ls_it + 1
+                    if qd.abs(p1_deriv_0) < gtol:
+                        if tid == 0:
                             constraint_state.candidates[0, i_b] = p1_alpha
-                            bracket_done = True
-                            break
-                    if not bracket_done:
+                        bracket_done = True
+                        break
+                if not bracket_done:
+                    if tid == 0:
                         constraint_state.candidates[0, i_b] = p1_alpha
+
+            if tid == 0:
+                constraint_state.ls_it[i_b] = local_ls_it
             qd.simt.block.sync()
         else:
             if tid == 0:

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2212,9 +2212,8 @@ def test_contact_forces(prefer_parallel_linesearch, show_viewer):
         for _ in range(160):
             scene.step()
 
-        # FIXME: Why forces are not resolved more accurately when enabling parallel linesearch?!
         contact_forces = cube.get_links_net_contact_force()
-        assert_allclose(contact_forces[0], -cube_weight, atol=5e-3 if prefer_parallel_linesearch else 5e-6)
+        assert_allclose(contact_forces[0], -cube_weight, atol=5e-6)
 
 
 @pytest.mark.required


### PR DESCRIPTION
### BEFORE

<img width="1988" height="1186" alt="image" src="https://github.com/user-attachments/assets/00833b54-794a-4490-8531-a78a8d156d2f" />

### AFTER

<img width="1500" height="900" alt="image" src="https://github.com/user-attachments/assets/128d826d-835f-42a2-a95a-01e6518691ad" />

For completeness, benchmark script is available [here](https://github.com/user-attachments/files/26691038/benchmark_linesearch_accuracy.py).
