### PR TITLE
[MISC] Unify linesearch refinement between decomposed and monolith solver paths.

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -115,7 +115,10 @@ class ConstraintSolver:
         self.jv = cs.jv
         self.quad_gauss = cs.quad_gauss
 
-        self.candidates = cs.candidates
+        self.ls_alpha = cs.ls_alpha
+        self.ls_p0_cost = cs.ls_p0_cost
+        self.ls_alpha_newton = cs.ls_alpha_newton
+        self.ls_gtol = cs.ls_gtol
         self.ls_it = cs.ls_it
         self.ls_result = cs.ls_result
         if self._solver_type == gs.constraint_solver.CG:
@@ -2473,6 +2476,123 @@ def func_linesearch_and_apply_alpha(
 
 
 @qd.func
+def func_linesearch_refine(
+    i_b,
+    p1_alpha,
+    p1_cost,
+    p1_deriv_0,
+    p1_deriv_1,
+    p0_cost,
+    gtol,
+    constraint_state: array_class.ConstraintState,
+    rigid_global_info: array_class.RigidGlobalInfo,
+):
+    """Bracketing walk + 3-alpha dual-bracket refinement.
+
+    Shared by the monolith linesearch (func_linesearch_batch) and the decomposed path's Phase 3 (solver_breakdown).
+    Takes an initial point (p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1) and refines it via Newton steps until the
+    gradient sign flips, then polishes with batched 3-alpha evaluation.
+
+    Returns (res_alpha, ls_result) where ls_result is a status code for diagnostics.
+    """
+    res_alpha = gs.qd_float(0.0)
+    ls_result = 0
+    done = False
+
+    direction = (p1_deriv_0 < 0) * 2 - 1
+    p2update = 0
+    p2_alpha = p1_alpha
+    p2_cost = p1_cost
+    p2_deriv_0 = p1_deriv_0
+    p2_deriv_1 = p1_deriv_1
+    while p1_deriv_0 * direction <= -gtol and constraint_state.ls_it[i_b] < rigid_global_info.ls_iterations[None]:
+        p2_alpha, p2_cost, p2_deriv_0, p2_deriv_1 = p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1
+        p2update = 1
+        p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = func_ls_point_fn_opt(
+            i_b, p1_alpha - p1_deriv_0 / p1_deriv_1, constraint_state, rigid_global_info
+        )
+        if qd.abs(p1_deriv_0) < gtol:
+            res_alpha = p1_alpha
+            done = True
+            break
+    if not done:
+        if constraint_state.ls_it[i_b] >= rigid_global_info.ls_iterations[None]:
+            ls_result = 3
+            res_alpha = p1_alpha
+            done = True
+        if not p2update and not done:
+            ls_result = 6
+            res_alpha = p1_alpha
+            done = True
+        if not done:
+            alpha_0 = p1_alpha - p1_deriv_0 / p1_deriv_1
+            alpha_1 = p1_alpha
+            alpha_2 = (p1_alpha + p2_alpha) * 0.5
+            while constraint_state.ls_it[i_b] < rigid_global_info.ls_iterations[None]:
+                costs, grads, hess = func_ls_point_fn_3alphas_opt(
+                    i_b, alpha_0, alpha_1, alpha_2, constraint_state, rigid_global_info
+                )
+                alphas = qd.Vector([alpha_0, alpha_1, alpha_2])
+                p1_next = alpha_0
+                p2_next = alpha_1
+                best_a = gs.qd_float(0.0)
+                best_c = gs.qd_float(0.0)
+                best_found = False
+                for i in qd.static(range(3)):
+                    if qd.abs(grads[i]) < gtol and (not best_found or costs[i] < best_c):
+                        best_a = alphas[i]
+                        best_c = costs[i]
+                        best_found = True
+                if best_found:
+                    res_alpha = best_a
+                    done = True
+                else:
+                    b1, p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1, p1_next = update_bracket_no_eval_local(
+                        p1_alpha,
+                        p1_cost,
+                        p1_deriv_0,
+                        p1_deriv_1,
+                        alphas,
+                        costs,
+                        grads,
+                        hess,
+                    )
+                    b2, p2_alpha, p2_cost, p2_deriv_0, p2_deriv_1, p2_next = update_bracket_no_eval_local(
+                        p2_alpha,
+                        p2_cost,
+                        p2_deriv_0,
+                        p2_deriv_1,
+                        alphas,
+                        costs,
+                        grads,
+                        hess,
+                    )
+                    if b1 == 0 and b2 == 0:
+                        if costs[2] < p0_cost:
+                            ls_result = 0
+                        else:
+                            ls_result = 7
+                        res_alpha = alpha_2
+                        done = True
+                if done:
+                    break
+                alpha_0 = p1_next
+                alpha_1 = p2_next
+                alpha_2 = (p1_alpha + p2_alpha) * 0.5
+            if not done:
+                if p1_cost <= p2_cost and p1_cost < p0_cost:
+                    ls_result = 4
+                    res_alpha = p1_alpha
+                elif p2_cost <= p1_cost and p2_cost < p0_cost:
+                    ls_result = 4
+                    res_alpha = p2_alpha
+                else:
+                    ls_result = 5
+                    res_alpha = 0.0
+    return res_alpha, ls_result
+
+
+@qd.func
 def func_linesearch_batch(
     i_b,
     entities_info: array_class.EntitiesInfo,
@@ -2524,125 +2644,13 @@ def func_linesearch_batch(
                 constraint_state.ls_result[i_b] = 0
             res_alpha = p1_alpha
         else:
-            # Phase 2: Bracketing
-            direction = (p1_deriv_0 < 0) * 2 - 1
-            p2update = 0
-            p2_alpha, p2_cost, p2_deriv_0, p2_deriv_1 = p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1
-            while (
-                p1_deriv_0 * direction <= -gtol and constraint_state.ls_it[i_b] < rigid_global_info.ls_iterations[None]
-            ):
-                p2_alpha, p2_cost, p2_deriv_0, p2_deriv_1 = p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1
-                p2update = 1
-
-                p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = func_ls_point_fn_opt(
-                    i_b, p1_alpha - p1_deriv_0 / p1_deriv_1, constraint_state, rigid_global_info
-                )
-                if qd.abs(p1_deriv_0) < gtol:
-                    res_alpha = p1_alpha
-                    done = True
-                    break
-            if not done:
-                if constraint_state.ls_it[i_b] >= rigid_global_info.ls_iterations[None]:
-                    constraint_state.ls_result[i_b] = 3
-                    res_alpha = p1_alpha
-                    done = True
-
-                if not p2update and not done:
-                    constraint_state.ls_result[i_b] = 6
-                    res_alpha = p1_alpha
-                    done = True
-
-                if not done:
-                    # Phase 3: Refinement with batched 3-alpha evaluation
-                    alpha_0 = p1_alpha - p1_deriv_0 / p1_deriv_1  # Newton from p1
-                    alpha_1 = p1_alpha  # p2_next (= current p1)
-                    alpha_2 = (p1_alpha + p2_alpha) * 0.5  # midpoint
-
-                    while constraint_state.ls_it[i_b] < rigid_global_info.ls_iterations[None]:
-                        # Batch evaluate cost, gradient, hessian for all 3 alphas in one constraint loop
-                        costs, grads, hess = func_ls_point_fn_3alphas_opt(
-                            i_b, alpha_0, alpha_1, alpha_2, constraint_state, rigid_global_info
-                        )
-                        alphas = qd.Vector([alpha_0, alpha_1, alpha_2])
-
-                        # Check convergence among 3 candidates
-                        p1_next_alpha = alpha_0
-                        p2_next_alpha = alpha_1
-
-                        best_alpha = gs.qd_float(0.0)
-                        best_cost = gs.qd_float(0.0)
-                        best_found = False
-                        for i in qd.static(range(3)):
-                            if qd.abs(grads[i]) < gtol and (not best_found or costs[i] < best_cost):
-                                best_alpha = alphas[i]
-                                best_cost = costs[i]
-                                best_found = True
-
-                        if best_found:
-                            res_alpha = best_alpha
-                            done = True
-                        else:
-                            (
-                                b1,
-                                p1_alpha,
-                                p1_cost,
-                                p1_deriv_0,
-                                p1_deriv_1,
-                                p1_next_alpha,
-                            ) = update_bracket_no_eval_local(
-                                p1_alpha,
-                                p1_cost,
-                                p1_deriv_0,
-                                p1_deriv_1,
-                                alphas,
-                                costs,
-                                grads,
-                                hess,
-                            )
-                            (
-                                b2,
-                                p2_alpha,
-                                p2_cost,
-                                p2_deriv_0,
-                                p2_deriv_1,
-                                p2_next_alpha,
-                            ) = update_bracket_no_eval_local(
-                                p2_alpha,
-                                p2_cost,
-                                p2_deriv_0,
-                                p2_deriv_1,
-                                alphas,
-                                costs,
-                                grads,
-                                hess,
-                            )
-
-                            if b1 == 0 and b2 == 0:
-                                if costs[2] < p0_cost:
-                                    constraint_state.ls_result[i_b] = 0
-                                else:
-                                    constraint_state.ls_result[i_b] = 7
-                                res_alpha = alpha_2
-                                done = True
-
-                        if done:
-                            break
-
-                        # Compute next 3 alphas for next iteration
-                        alpha_0 = p1_next_alpha
-                        alpha_1 = p2_next_alpha
-                        alpha_2 = (p1_alpha + p2_alpha) * 0.5
-
-                    if not done:
-                        if p1_cost <= p2_cost and p1_cost < p0_cost:
-                            constraint_state.ls_result[i_b] = 4
-                            res_alpha = p1_alpha
-                        elif p2_cost <= p1_cost and p2_cost < p0_cost:
-                            constraint_state.ls_result[i_b] = 4
-                            res_alpha = p2_alpha
-                        else:
-                            constraint_state.ls_result[i_b] = 5
-                            res_alpha = 0.0
+            res_alpha, ls_result = func_linesearch_refine(
+                i_b, p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1, p0_cost, gtol, constraint_state, rigid_global_info
+            )
+            constraint_state.ls_result[i_b] = ls_result
+            # Status 7: both brackets stalled and midpoint cost >= p0_cost. Reject the non-improving alpha.
+            if ls_result == 7:
+                res_alpha = 0.0
     return res_alpha
 
 
@@ -3268,7 +3276,7 @@ def func_solve_body(
 
 
 @func_solve_body.register(
-    is_compatible=lambda *args, **kwargs: _get_static_config(*args, **kwargs).prefer_parallel_linesearch != 1
+    is_compatible=lambda *args, **kwargs: _get_static_config(*args, **kwargs).prefer_decomposed_solver != 1
 )
 @qd.kernel(fastcache=gs.use_fastcache)
 def func_solve_body_monolith(

--- a/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
@@ -13,24 +13,9 @@ from genesis.engine.solvers.rigid.constraint import solver
 # Similar to BLOCK_DIM in func_hessian_direct_tiled: determines parallelism and shared memory layout.
 LS_PARALLEL_K = 32
 
-# Floor for the Newton step estimate used to center the log-spaced search range.
-# When |grad/hess| is near-zero the search range [alpha*1e-2, alpha*1e2] would collapse;
-# this clamp keeps the range meaningful. The value is well below typical linesearch tolerances
-# (ls_tolerance * tolerance ~ 1e-2 * 1e-8 for double, ~ 1e-2 * 1e-5 for float) so it never
-# masks a genuinely small optimal step.
-LS_PARALLEL_MIN_STEP = 1e-6
-
 # Block sizes for shared-memory reductions in _kernel_parallel_linesearch_p0 and _jv.
 _P0_BLOCK = 32
 _JV_BLOCK = 32
-
-# Maximum bisection iterations for gradient-guided refinement after grid search.
-LS_BISECT_STEPS = 12
-
-# Number of alpha candidates evaluated via cooperative constraint reduction.
-# Each candidate is evaluated by ALL K threads cooperating on the constraint sum,
-# reducing per-thread work from O(n_constraints) to O(n_constraints/K).
-LS_N_CANDIDATES = 6
 
 # Maximum allowed alpha (prevents divergence from degenerate steps).
 LS_ALPHA_MAX = 1e4
@@ -107,35 +92,25 @@ def _func_parallel_linesearch_p0(
     rigid_global_info: array_class.RigidGlobalInfo,
     static_rigid_sim_config: qd.template(),
 ):
-    """Parallel linesearch P0 kernel: fused mv + jv + snorm + quad_gauss + eq_sum + p0_cost.
+    """Decomposed constraint solver P0 kernel: fused mv + jv + snorm + quad_gauss + eq_sum + p0_cost.
 
-    Parallel grid-search linesearch algorithm overview
-    --------------------------------------------------
-    A block of K=32 threads cooperates on each env. Both approaches are O(n_constraints) per
-    evaluation, but the grid search parallelizes each evaluation across 32 threads
-    (n_constraints/32 work per thread), whereas the iterative approach runs each evaluation on
-    a single thread.
-
-    The algorithm is split across two kernels:
+    Decomposed solver algorithm overview
+    -------------------------------------
+    A block of K=32 threads cooperates on each env for setup and apply; the linesearch refinement runs serially on
+    thread 0 using func_linesearch_refine (shared with the monolith path).
 
     P0 kernel (this function):
         Phase 0a: Compute mv = M @ search (cooperative over DOFs, 32 threads).
         Phase 0b: Compute jv = J @ search (cooperative over constraints, 32 threads).
         Phase 1: Fused snorm + quad_gauss parallel reduction over n_dofs.
-        Phase 2: Parallel reduction over n_constraints for eq_sum and p0_cost.
+        Phase 2: Parallel reduction over n_constraints for eq_sum and p0_cost. Also computes alpha_newton.
 
     Eval kernel (_kernel_parallel_linesearch_eval):
-        a) Grid search: Evaluate N_CANDIDATES=6 log-spaced alphas plus the Newton step,
-           all 32 threads cooperating on each candidate's constraint reduction.
-        b) Newton correction: One Newton step from the best grid candidate. Accepted if it
-           improves cost.
-        c) Bisection fallback: If Newton fails, bracket the zero-crossing of the gradient
-           and bisect up to LS_BISECT_STEPS=12 times.
-        d) Apply: Update qacc, Ma, Jaref with the chosen alpha (cooperative over DOFs).
+        a) Serial refinement (thread 0): re-evaluate the Newton step via func_linesearch_refine.
+        b) Apply: Update qacc, Ma, Jaref with the chosen alpha (cooperative over DOFs).
 
-    Post-linesearch: Separate kernels for constraint force update, cost update, gradient
-    update, Hessian update (Newton only), and search direction update. These reuse the
-    batch-level functions from solver.py.
+    Post-linesearch: Separate kernels for constraint force update, cost update, gradient update, Hessian update (Newton
+    only), and search direction update. These reuse the batch-level functions from solver.py.
     """
     _B = constraint_state.grad.shape[1]
     _T = qd.static(_P0_BLOCK)
@@ -219,8 +194,8 @@ def _func_parallel_linesearch_p0(
             if snorm < rigid_global_info.EPS[None]:
                 # Converged — only thread 0 writes
                 if tid == 0:
-                    constraint_state.candidates[0, i_b] = 0.0
-                    constraint_state.candidates[1, i_b] = 0.0
+                    constraint_state.ls_alpha[i_b] = 0.0
+                    constraint_state.ls_p0_cost[i_b] = 0.0
                     constraint_state.improved[i_b] = False
             else:
                 # Thread 0 writes quad_gauss to global memory
@@ -309,29 +284,21 @@ def _func_parallel_linesearch_p0(
                     constraint_state.eq_sum[1, i_b] = sh_qg_grad[0]
                     constraint_state.eq_sum[2, i_b] = sh_qg_hess[0]
                     constraint_state.ls_it[i_b] = 1
-                    constraint_state.candidates[1, i_b] = constraint_state.gauss[i_b] + sh_p0_cost[0]
+                    constraint_state.ls_p0_cost[i_b] = constraint_state.gauss[i_b] + sh_p0_cost[0]
                     # Initialize best alpha, search range, and best-cost tracker for parallel linesearch
-                    constraint_state.candidates[0, i_b] = 0.0  # default: no step
+                    constraint_state.ls_alpha[i_b] = 0.0  # default: no step
 
-                    # Use full Newton step (DOF + all constraints) as the range center.
+                    # Newton step estimate from the full DOF + constraint gradient/hessian
                     total_hess = 2.0 * (constraint_state.quad_gauss[2, i_b] + sh_constraint_hess[0])
                     if total_hess > 0.0:
                         total_grad = constraint_state.quad_gauss[1, i_b] + sh_constraint_grad[0]
-                        alpha_newton = qd.max(
-                            qd.abs(total_grad / total_hess), gs.qd_float(qd.static(LS_PARALLEL_MIN_STEP))
-                        )
-                        constraint_state.candidates[2, i_b] = alpha_newton * 1e-2
-                        constraint_state.candidates[3, i_b] = alpha_newton * 10.0
-                        constraint_state.candidates[5, i_b] = alpha_newton  # exact Newton step for eval
+                        constraint_state.ls_alpha_newton[i_b] = qd.abs(total_grad / total_hess)
                     else:
-                        constraint_state.candidates[2, i_b] = 1e-6
-                        constraint_state.candidates[3, i_b] = 1e2
-                        constraint_state.candidates[5, i_b] = 0.0
-                    constraint_state.candidates[4, i_b] = gs.qd_float(1e30)  # best cost across passes
-                    # Store gtol for gradient-guided bisection after grid search
+                        constraint_state.ls_alpha_newton[i_b] = 0.0
+                    # Store gtol for gradient-guided refinement
                     n_dofs_val = constraint_state.search.shape[0]
                     scale = rigid_global_info.meaninertia[i_b] * qd.max(1, n_dofs_val)
-                    constraint_state.candidates[7, i_b] = (
+                    constraint_state.ls_gtol[i_b] = (
                         rigid_global_info.tolerance[None] * rigid_global_info.ls_tolerance[None] * snorm * scale
                     )
 
@@ -340,225 +307,68 @@ def _func_parallel_linesearch_p0(
 def _func_parallel_linesearch_eval(
     constraint_state: array_class.ConstraintState,
     rigid_global_info: array_class.RigidGlobalInfo,
-    static_rigid_sim_config: qd.template(),
 ):
-    """Evaluate alpha candidates via cooperative constraint reduction, then bisect.
+    """Decomposed solver eval kernel: serial refinement from Newton step + cooperative apply.
 
-    All K threads cooperate on each candidate: each thread reduces n_constraints/K
-    constraints, then a shared-memory tree reduction sums the partial costs. This is
-    O(n_candidates × n_constraints/K) per thread instead of O(K × n_constraints).
-
-    Phase 1: Cooperatively evaluate N_CANDIDATES + Newton alpha, pick best via argmin.
-    Phase 2: Cooperatively evaluate analytical gradient at best, try one Newton correction first then bisect if needed.
+    The P0 kernel precomputes a Newton step (ls_alpha_newton). This kernel refines it via func_linesearch_refine, then
+    cooperatively applies the chosen alpha to qacc, Ma, and Jaref.
     """
     _B = constraint_state.grad.shape[1]
     _K = qd.static(LS_PARALLEL_K)
-    _NC = qd.static(LS_N_CANDIDATES)
 
     qd.loop_config(name="parallel_linesearch_eval", block_dim=_K)
     for i_flat in range(_B * _K):
         tid = i_flat % _K
         i_b = i_flat // _K
 
-        # Shared memory for reductions (reused across phases)
-        sh_val = qd.simt.block.SharedArray((_K,), gs.qd_float)
-        sh_val2 = qd.simt.block.SharedArray((_K,), gs.qd_float)
-        # Shared arrays for candidate costs and alphas (only _NC+1 used)
-        sh_cand_cost = qd.simt.block.SharedArray((_K,), gs.qd_float)
-        sh_cand_alpha = qd.simt.block.SharedArray((_K,), gs.qd_float)
-
         active = constraint_state.n_constraints[i_b] > 0 and constraint_state.improved[i_b]
 
         if active:
-            ne = constraint_state.n_constraints_equality[i_b]
-            nef = ne + constraint_state.n_constraints_frictionloss[i_b]
-            n_con = constraint_state.n_constraints[i_b]
-            lo = constraint_state.candidates[2, i_b]
-            hi = constraint_state.candidates[3, i_b]
-            p0_cost = constraint_state.candidates[1, i_b]
-            gtol = constraint_state.candidates[7, i_b]
+            p0_cost = constraint_state.ls_p0_cost[i_b]
+            gtol = constraint_state.ls_gtol[i_b]
+            alpha_newton = constraint_state.ls_alpha_newton[i_b]
 
-            # Pre-compute log-space step for candidate generation
-            _log_lo = qd.log(lo)
-            _cand_step = (qd.log(hi) - _log_lo) / qd.max(1.0, qd.cast(_NC - 1, gs.qd_float))
-            alpha_newton = constraint_state.candidates[5, i_b]
-
-            # === Phase 1: Cooperative evaluation of N_CANDIDATES alphas ===
-            # Evaluate each candidate sequentially; all K threads cooperate on constraint reduction.
-            n_total_cands = _NC + 1  # +1 for Newton alpha
-            for cand_idx in range(n_total_cands):
-                # Generate alpha for this candidate
-                alpha_c = gs.qd_float(0.0)
-                if cand_idx < _NC:
-                    alpha_c = qd.exp(_log_lo + qd.cast(cand_idx, gs.qd_float) * _cand_step)
-                else:
-                    alpha_c = alpha_newton  # last candidate is Newton alpha
-
-                # DOF + equality cost (O(1), same for all threads)
-                dof_eq_cost = (
-                    alpha_c * alpha_c * constraint_state.quad_gauss[2, i_b]
-                    + alpha_c * constraint_state.quad_gauss[1, i_b]
-                    + constraint_state.quad_gauss[0, i_b]
-                    + alpha_c * alpha_c * constraint_state.eq_sum[2, i_b]
-                    + alpha_c * constraint_state.eq_sum[1, i_b]
-                    + constraint_state.eq_sum[0, i_b]
+            # === Serial linesearch refinement (thread 0) ===
+            # Gated: skip when the Newton step is zero (degenerate hessian)
+            if alpha_newton > 0.0 and tid == 0:
+                constraint_state.ls_alpha[i_b] = 0.0
+                p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver.func_ls_point_fn_opt(
+                    i_b,
+                    alpha_newton,
+                    constraint_state,
+                    rigid_global_info,
                 )
+                if p0_cost < p1_cost:
+                    p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver.func_ls_point_fn_opt(
+                        i_b,
+                        gs.qd_float(0.0),
+                        constraint_state,
+                        rigid_global_info,
+                    )
 
-                # Cooperative constraint cost: each thread handles strided constraints
-                local_cost = gs.qd_float(0.0)
-                i_c = ne + tid  # start from ne (skip equality, already in eq_sum)
-                while i_c < n_con:
-                    Jaref_c = constraint_state.Jaref[i_c, i_b]
-                    jv_c = constraint_state.jv[i_c, i_b]
-                    D = constraint_state.efc_D[i_c, i_b]
-                    x = Jaref_c + alpha_c * jv_c
-                    if i_c < nef:
-                        # Friction constraint
-                        f_val = constraint_state.efc_frictionloss[i_c, i_b]
-                        r_val = constraint_state.diag[i_c, i_b]
-                        rf = r_val * f_val
-                        linear_neg = x <= -rf
-                        linear_pos = x >= rf
-                        if linear_neg or linear_pos:
-                            local_cost = local_cost + linear_neg * f_val * (-0.5 * rf - Jaref_c - alpha_c * jv_c)
-                            local_cost = local_cost + linear_pos * f_val * (-0.5 * rf + Jaref_c + alpha_c * jv_c)
-                        else:
-                            local_cost = local_cost + D * 0.5 * x * x
-                    else:
-                        # Contact constraint (active if x < 0)
-                        if x < 0:
-                            local_cost = local_cost + D * 0.5 * x * x
-                    i_c += _K
+                if p1_cost < p0_cost:
+                    constraint_state.ls_alpha[i_b] = p1_alpha
 
-                # Tree reduction for constraint cost
-                sh_val[tid] = local_cost
-                qd.simt.block.sync()
-                stride = _K // 2
-                while stride > 0:
-                    if tid < stride:
-                        sh_val[tid] += sh_val[tid + stride]
-                    qd.simt.block.sync()
-                    stride //= 2
-
-                # Thread 0 stores total cost for this candidate
-                if tid == 0:
-                    total_cost = dof_eq_cost + sh_val[0]
-                    sh_cand_cost[cand_idx] = total_cost
-                    sh_cand_alpha[cand_idx] = alpha_c
-                qd.simt.block.sync()
-
-            # === Phase 2: Find best candidate (thread 0) ===
-            if tid == 0:
-                best_alpha = gs.qd_float(0.0)
-                best_cost = p0_cost
-                best_cost_prev = constraint_state.candidates[4, i_b]
-                for ci in range(n_total_cands):
-                    c = sh_cand_cost[ci]
-                    if c < best_cost and c < best_cost_prev:
-                        best_cost = c
-                        best_alpha = sh_cand_alpha[ci]
-
-                constraint_state.candidates[0, i_b] = best_alpha
-                if best_alpha > 0.0:
-                    constraint_state.candidates[4, i_b] = best_cost
-                # Store best alpha for Phase 3 cooperative bisection
-                sh_cand_alpha[0] = best_alpha
+                if qd.abs(p1_deriv_0) > gtol:
+                    res_alpha, ls_result = solver.func_linesearch_refine(
+                        i_b,
+                        p1_alpha,
+                        p1_cost,
+                        p1_deriv_0,
+                        p1_deriv_1,
+                        p0_cost,
+                        gtol,
+                        constraint_state,
+                        rigid_global_info,
+                    )
+                    # Skip status 7 (brackets stalled, midpoint non-improving) to preserve
+                    # the validated p1_alpha already written above
+                    if qd.abs(res_alpha) > rigid_global_info.EPS[None] and ls_result != 7:
+                        constraint_state.ls_alpha[i_b] = res_alpha
             qd.simt.block.sync()
-
-            # === Phase 3: Cooperative gradient bisection ===
-            best_alpha_shared = sh_cand_alpha[0]
-            if best_alpha_shared > 0.0:
-                # Cooperatively compute gradient at best_alpha
-                alpha_eval = best_alpha_shared
-
-                # Cooperative gradient: accumulate quad_total_1 and quad_total_2
-                local_qt1 = gs.qd_float(0.0)
-                local_qt2 = gs.qd_float(0.0)
-                i_c = ne + tid
-                while i_c < n_con:
-                    Jaref_c = constraint_state.Jaref[i_c, i_b]
-                    jv_c = constraint_state.jv[i_c, i_b]
-                    D = constraint_state.efc_D[i_c, i_b]
-                    x = Jaref_c + alpha_eval * jv_c
-                    if i_c < nef:
-                        f_val = constraint_state.efc_frictionloss[i_c, i_b]
-                        r_val = constraint_state.diag[i_c, i_b]
-                        rf = r_val * f_val
-                        linear_neg = x <= -rf
-                        linear_pos = x >= rf
-                        qf_1 = D * (jv_c * Jaref_c)
-                        qf_2 = D * (0.5 * jv_c * jv_c)
-                        if linear_neg or linear_pos:
-                            qf_1 = linear_neg * (-f_val * jv_c) + linear_pos * (f_val * jv_c)
-                            qf_2 = 0.0
-                        local_qt1 = local_qt1 + qf_1
-                        local_qt2 = local_qt2 + qf_2
-                    else:
-                        act = x < 0
-                        local_qt1 = local_qt1 + D * (jv_c * Jaref_c) * act
-                        local_qt2 = local_qt2 + D * (0.5 * jv_c * jv_c) * act
-                    i_c += _K
-
-                # Reduce qt1 and qt2
-                sh_val[tid] = local_qt1
-                sh_val2[tid] = local_qt2
-                qd.simt.block.sync()
-                stride = _K // 2
-                while stride > 0:
-                    if tid < stride:
-                        sh_val[tid] += sh_val[tid + stride]
-                        sh_val2[tid] += sh_val2[tid + stride]
-                    qd.simt.block.sync()
-                    stride //= 2
-
-                if tid == 0:
-                    qt1_total = constraint_state.quad_gauss[1, i_b] + constraint_state.eq_sum[1, i_b] + sh_val[0]
-                    qt2_total = constraint_state.quad_gauss[2, i_b] + constraint_state.eq_sum[2, i_b] + sh_val2[0]
-                    g_best = 2.0 * alpha_eval * qt2_total + qt1_total
-
-                    if qd.abs(g_best) > gtol:
-                        hess_best = 2.0 * qt2_total
-                        newton_done = False
-
-                        # Try one Newton correction first (O(1) compute + 1 cost eval)
-                        if hess_best > rigid_global_info.EPS[None]:
-                            alpha_nc = alpha_eval - g_best / hess_best
-                            if alpha_nc > 0.0:
-                                c_nc, g_nc = _ls_eval_cost_grad(alpha_nc, i_b, constraint_state)
-                                if c_nc < p0_cost and c_nc < constraint_state.candidates[4, i_b]:
-                                    constraint_state.candidates[0, i_b] = alpha_nc
-                                    constraint_state.candidates[4, i_b] = c_nc
-                                    newton_done = True
-                        # Fall back to bisection if Newton didn't converge
-                        if not newton_done:
-                            bis_a = alpha_eval * 0.5
-                            bis_b = alpha_eval
-                            if g_best < 0.0:
-                                bis_a = alpha_eval
-                                bis_b = alpha_eval * 2.0
-
-                            _, g_a = _ls_eval_cost_grad(bis_a, i_b, constraint_state)
-                            _, g_b = _ls_eval_cost_grad(bis_b, i_b, constraint_state)
-
-                            if g_a < 0.0 and g_b > 0.0:
-                                _N_BISECT = qd.static(LS_BISECT_STEPS)
-                                for _bis_it in range(_N_BISECT):
-                                    mid_b = (bis_a + bis_b) * 0.5
-                                    c_mid_b, g_mid_b = _ls_eval_cost_grad(mid_b, i_b, constraint_state)
-                                    if qd.abs(g_mid_b) < gtol or qd.abs(bis_b - bis_a) < rigid_global_info.EPS[None]:
-                                        break
-                                    if g_mid_b < 0.0:
-                                        bis_a = mid_b
-                                    else:
-                                        bis_b = mid_b
-                                mid_b = (bis_a + bis_b) * 0.5
-                                c_mid_b, _ = _ls_eval_cost_grad(mid_b, i_b, constraint_state)
-                                if c_mid_b < p0_cost and c_mid_b < constraint_state.candidates[4, i_b]:
-                                    constraint_state.candidates[0, i_b] = mid_b
-                                    constraint_state.candidates[4, i_b] = c_mid_b
         else:
             if tid == 0:
-                constraint_state.candidates[0, i_b] = 0.0
+                constraint_state.ls_alpha[i_b] = 0.0
             qd.simt.block.sync()
 
         # === Phase 4: Cooperative apply alpha (fused, saves 1 kernel launch) ===
@@ -566,7 +376,7 @@ def _func_parallel_linesearch_eval(
         if active:
             n_dofs_apply = constraint_state.qacc.shape[0]
             n_con_apply = constraint_state.n_constraints[i_b]
-            alpha_apply = constraint_state.candidates[0, i_b]
+            alpha_apply = constraint_state.ls_alpha[i_b]
             if qd.abs(alpha_apply) < rigid_global_info.EPS[None]:
                 if tid == 0:
                     constraint_state.improved[i_b] = False
@@ -826,8 +636,8 @@ def _kernel_solve_graph(
         _func_parallel_linesearch_p0(
             dofs_info, entities_info, dofs_state, constraint_state, rigid_global_info, static_rigid_sim_config
         )
-        # Fused: grid search + bisection + apply alpha
-        _func_parallel_linesearch_eval(constraint_state, rigid_global_info, static_rigid_sim_config)
+        # Fused: refinement + apply alpha
+        _func_parallel_linesearch_eval(constraint_state, rigid_global_info)
         if qd.static(static_rigid_sim_config.solver_type == gs.constraint_solver.CG):
             _func_cg_only_save_prev_grad(constraint_state, static_rigid_sim_config)
         _func_update_constraint_forces(constraint_state, static_rigid_sim_config)
@@ -843,7 +653,7 @@ def _kernel_solve_graph(
 @solver.func_solve_body.register(
     is_compatible=lambda *args, **kwargs: (
         not (static_rigid_sim_config := solver._get_static_config(*args, **kwargs)).requires_grad
-        and static_rigid_sim_config.prefer_parallel_linesearch != 0
+        and static_rigid_sim_config.prefer_decomposed_solver != 0
     )
 )
 def func_solve_decomposed(

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -395,10 +395,6 @@ class RigidSolver(KinematicSolver):
         return self.n_envs <= gpu_cores
 
     def _build_static_config(self):
-        prefer_parallel_linesearch = self._options.prefer_parallel_linesearch
-        if gs.backend == gs.cpu or self._enable_mujoco_compatibility or self.sim.options.requires_grad:
-            prefer_parallel_linesearch = False
-
         static_rigid_sim_config = dict(
             backend=gs.backend,
             para_level=self.sim._para_level,
@@ -416,10 +412,13 @@ class RigidSolver(KinematicSolver):
             sparse_solve=self._options.sparse_solve,
             integrator=self._integrator,
             solver_type=self._options.constraint_solver,
-            prefer_parallel_linesearch={None: -1, False: 0, True: 1}[prefer_parallel_linesearch],
             broadphase_traversal=self._resolve_broadphase_traversal(),
             parallel_init=self._should_use_parallel_init(),
         )
+
+        # Prefer the monolith solver on CPU (always faster there, perf dispatch is a waste of effort)
+        if gs.backend == gs.cpu or self.sim.options.requires_grad:
+            static_rigid_sim_config["prefer_decomposed_solver"] = 0
 
         if self.is_active:
             # TODO: These alternative tiled algorithms are designed to reduce the impact of latency. However, naive

--- a/genesis/options/solvers.py
+++ b/genesis/options/solvers.py
@@ -522,12 +522,6 @@ class RigidOptions(Options):
     enable_multi_contact: StrictBool = True
     enable_mujoco_compatibility: StrictBool = False
 
-    # Linesearch strategy selection:
-    #   * None:  perf dispatch chooses between monolith + iterative and decomposed + parallel linesearch
-    #   * False: force monolith + iterative (Newton-guided) linesearch
-    #   * True:  force decomposed + parallel (grid search) linesearch
-    prefer_parallel_linesearch: StrictBool | None = None
-
     # GJK collision detection
     use_gjk_collision: StrictBool | None = None
 

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -268,7 +268,10 @@ class StructConstraintState(metaclass=BASE_METACLASS):
     mv: V_ANNOTATION
     jv: V_ANNOTATION
     quad_gauss: V_ANNOTATION
-    candidates: V_ANNOTATION
+    ls_alpha: V_ANNOTATION
+    ls_p0_cost: V_ANNOTATION
+    ls_alpha_newton: V_ANNOTATION
+    ls_gtol: V_ANNOTATION
     eq_sum: V_ANNOTATION
     ls_it: V_ANNOTATION
     ls_result: V_ANNOTATION
@@ -350,7 +353,10 @@ def get_constraint_state(constraint_solver, solver):
         cg_beta=V(dtype=gs.qd_float, shape=(_B,)),
         cg_pg_dot_pMg=V(dtype=gs.qd_float, shape=(_B,)),
         quad_gauss=V(dtype=gs.qd_float, shape=(3, _B)),
-        candidates=V(dtype=gs.qd_float, shape=(12, _B)),
+        ls_alpha=V(dtype=gs.qd_float, shape=(_B,)),
+        ls_p0_cost=V(dtype=gs.qd_float, shape=(_B,)),
+        ls_alpha_newton=V(dtype=gs.qd_float, shape=(_B,)),
+        ls_gtol=V(dtype=gs.qd_float, shape=(_B,)),
         eq_sum=V(dtype=gs.qd_float, shape=(3, _B)),
         Ma=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B)),
         Ma_ws=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B)),
@@ -2033,7 +2039,7 @@ class StructRigidSimStaticConfig(metaclass=AutoInitMeta):
     integrator: int
     solver_type: int
     requires_grad: bool
-    prefer_parallel_linesearch: int = -1  # -1 = None (auto), 0 = False, 1 = True
+    prefer_decomposed_solver: int = -1  # -1 = None (auto), 0 = False, 1 = True
     parallel_init: bool = False  # parallelize init over (constraints, envs) when GPU is not saturated by envs alone
     broadphase_traversal: int = 0
     enable_tiled_cholesky_mass_matrix: bool = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -721,22 +721,20 @@ def initialize_genesis(request, monkeypatch, tmp_path, backend, precision, perfo
         )
         gc.collect()
 
-        # Set default prefer_parallel_linesearch based on backend so that both iterative (CPU) and parallel (GPU)
-        # linesearch paths are systematically tested, while still allowing individual tests to override explicitly.
-        # Skip for benchmarks - let performance dispatch choose freely.
+        # Prefer the decomposed solver on GPU so both code paths (decomposed on GPU, monolith on CPU) are tested
+        # Skip for benchmarks - let auto-detection choose freely
         expr = Expression.compile(request.config.option.markexpr)
         is_benchmarks = expr.evaluate(MarkMatcher.from_markers((pytest.mark.benchmarks,)))
         if not is_benchmarks:
-            from genesis.options.solvers import RigidOptions
+            from genesis.utils.array_class import StructRigidSimStaticConfig
 
-            _orig_model_post_init = RigidOptions.model_post_init
+            _StructRigidSimStaticConfig_init_orig = StructRigidSimStaticConfig.__init__
 
-            def _patched_model_post_init(self, context):
-                _orig_model_post_init(self, context)
-                if self.prefer_parallel_linesearch is None:
-                    self.prefer_parallel_linesearch = True
+            def _StructRigidSimStaticConfig_init(self, *args, **kwargs):
+                kwargs.setdefault("prefer_decomposed_solver", int(gs.backend != gs.cpu))
+                _StructRigidSimStaticConfig_init_orig(self, *args, **kwargs)
 
-            monkeypatch.setattr(RigidOptions, "model_post_init", _patched_model_post_init)
+            monkeypatch.setattr(StructRigidSimStaticConfig, "__init__", _StructRigidSimStaticConfig_init)
 
         if gs.backend != gs.cpu and gs.device.index is not None:
             if _torch_get_gpu_idx(gs.device.index) not in _get_gpu_indices():

--- a/tests/test_rigid_benchmarks.py
+++ b/tests/test_rigid_benchmarks.py
@@ -450,6 +450,7 @@ def make_box_pyramid(n_envs, solver=None, gjk=None, n_cubes=3, **scene_kwargs):
         rigid_options=gs.options.RigidOptions(
             **get_rigid_solver_options(
                 dt=STEP_DT,
+                tolerance=1e-5,
                 **(dict(constraint_solver=solver) if solver is not None else {}),
                 **(dict(use_gjk_collision=gjk) if gjk is not None else {}),
             )

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2122,8 +2122,7 @@ def test_all_fixed(show_viewer):
 @pytest.mark.required
 @pytest.mark.parametrize("precision", ["32"])
 @pytest.mark.parametrize("backend", [gs.gpu])
-@pytest.mark.parametrize("prefer_parallel_linesearch", [False, True])
-def test_contact_forces(prefer_parallel_linesearch, show_viewer):
+def test_contact_forces(show_viewer):
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
             dt=0.01,
@@ -2131,7 +2130,6 @@ def test_contact_forces(prefer_parallel_linesearch, show_viewer):
         rigid_options=gs.options.RigidOptions(
             # Enabling box-box algorithm to improve code coverage
             box_box_detection=True,
-            prefer_parallel_linesearch=prefer_parallel_linesearch,
         ),
         viewer_options=gs.options.ViewerOptions(
             camera_pos=(3, -1, 1.5),
@@ -2154,7 +2152,7 @@ def test_contact_forces(prefer_parallel_linesearch, show_viewer):
         ),
         # visualize_contact=True,
     )
-    scene.build()
+    scene.build(n_envs=5)
 
     cube_weight = scene.rigid_solver._gravity[0] * cube.get_mass()
     motors_dof = np.arange(7)
@@ -2166,19 +2164,19 @@ def test_contact_forces(prefer_parallel_linesearch, show_viewer):
     end_effector = franka.get_link("hand")
     qpos = franka.inverse_kinematics(
         link=end_effector,
-        pos=np.array([0.65, 0.0, 0.13]),
-        quat=np.array([0, 1, 0, 0]),
+        pos=np.tile([0.65, 0.0, 0.13], (scene.n_envs, 1)),
+        quat=np.tile([0, 1, 0, 0], (scene.n_envs, 1)),
     )
-    franka.control_dofs_position(qpos[:-2], motors_dof)
+    franka.control_dofs_position(qpos[:, :-2], motors_dof)
 
     # hold
     for i in range(50):
         scene.step()
     contact_forces = cube.get_links_net_contact_force()
-    assert_allclose(contact_forces[0], -cube_weight, atol=1e-5)
+    assert_allclose(contact_forces[:, 0], -cube_weight, atol=1e-5)
 
     # grasp
-    franka.control_dofs_position(qpos[:-2], motors_dof)
+    franka.control_dofs_position(qpos[:, :-2], motors_dof)
     franka.control_dofs_position(0.0, fingers_dof)
     for i in range(20):
         scene.step()
@@ -2186,35 +2184,39 @@ def test_contact_forces(prefer_parallel_linesearch, show_viewer):
     # lift
     qpos = franka.inverse_kinematics(
         link=end_effector,
-        pos=np.array([0.65, 0.0, 0.2]),
-        quat=np.array([0.0, 1, 0, 0]),
+        pos=np.tile([0.65, 0.0, 0.2], (scene.n_envs, 1)),
+        quat=np.tile([0.0, 1, 0, 0], (scene.n_envs, 1)),
     )
-    franka.control_dofs_position(qpos[:-2], motors_dof)
+    franka.control_dofs_position(qpos[:, :-2], motors_dof)
     for i in range(100):
         scene.step()
 
-    # Check contact forces while randomizing gripper orientations.
+    # Check contact forces while randomizing gripper orientations across parallel envs.
     # Note that it is necessary to reset the scene state because the box is slowly falling without noslip solver.
     state = scene.get_state()
-    rng = np.random.RandomState(42)
+    rng = np.random.RandomState(0)
+    all_errors = []
     for i_trial in range(10):
         scene.reset(state)
 
-        perturb = gu.axis_angle_to_quat(np.array(rng.uniform(-np.deg2rad(45), np.deg2rad(45))), rng.randn(3))
-        lift_quat = gu.transform_quat_by_quat(perturb, np.array([0, 1, 0, 0], dtype=gs.np_float))
+        angles = rng.uniform(-np.deg2rad(45), np.deg2rad(45), size=scene.n_envs).astype(gs.np_float)
+        axes = rng.randn(scene.n_envs, 3).astype(gs.np_float)
+        perturbs = gu.axis_angle_to_quat(angles, axes)
+        lift_quats = gu.transform_quat_by_quat(perturbs, np.tile([0, 1, 0, 0], (scene.n_envs, 1)).astype(gs.np_float))
         qpos = franka.inverse_kinematics(
             link=end_effector,
-            pos=np.array([0.65, 0.0, 0.2]),
-            quat=lift_quat,
+            pos=np.tile([0.65, 0.0, 0.2], (scene.n_envs, 1)).astype(gs.np_float),
+            quat=lift_quats,
         )
-        franka.control_dofs_position(qpos[:-2], motors_dof)
+        franka.control_dofs_position(qpos[:, :-2], motors_dof)
         franka.control_dofs_position(0.0, fingers_dof)
         for _ in range(160):
             scene.step()
 
-        # FIXME: Why forces are not resolved more accurately when enabling parallel linesearch?!
-        contact_forces = cube.get_links_net_contact_force()
-        assert_allclose(contact_forces[0], -cube_weight, atol=5e-3 if prefer_parallel_linesearch else 5e-6)
+        contact_forces = tensor_to_array(cube.get_links_net_contact_force())
+        errors = np.linalg.norm(contact_forces[:, 0, :] + cube_weight, ord=np.inf, axis=-1)
+        all_errors.append(errors)
+    assert np.percentile(all_errors, 95) < 5e-5
 
 
 @pytest.mark.required
@@ -4716,7 +4718,7 @@ def test_mesh_align(show_viewer, tol):
     scene.reset()
 
     # Simulate
-    for _ in range(400):
+    for _ in range(450):
         scene.step()
 
     assert_allclose(mango.get_dofs_velocity(), 0, tol=0.05)
@@ -5641,7 +5643,7 @@ def test_heterogeneous_robots(show_viewer, tol):
         scene.step()
 
     # Velocity should be near zero (settled)
-    assert_allclose(het_obj.get_vel(), 0.0, tol=0.02)
+    assert_allclose(het_obj.get_vel(), 0.0, tol=0.05)
 
     # All objects should be near their initial z-positions (settled on ground)
     pos = het_obj.get_pos()

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -203,12 +203,6 @@ def test_imu_sensor(show_viewer, tol, n_envs):
             substeps=1,
             gravity=(0.0, 0.0, GRAVITY),
         ),
-        # FIXME: Force iterative linesearch: the parallel linesearch's grid search + single Newton
-        # correction accumulates ~1e-4 residual over ~60 resting contact steps in float32,
-        # exceeding the 5e-6 tolerance required by the IMU acceleration assertions below.
-        rigid_options=gs.options.RigidOptions(
-            prefer_parallel_linesearch=False,
-        ),
         profiling_options=gs.options.ProfilingOptions(
             show_FPS=False,
         ),


### PR DESCRIPTION
## Motivation and Context

Falling back to newton alpha if no point on the grid is showing improvement is a real fix. This is necessary to correct the error distribution compared to iterative. Without it, we are just stopping too early compared to the desired tolerance, so it runs faster because it does less iterations but does not satisfy the required tolerance. This was validated by [@Mingrui](https://genesis-ai-company.slack.com/team/U09EYPPHWHW) earlier.
Once fixed (one-liner), I can confirm that parallel linesearch does not bring any performance improvement. Parallel vs Iterative are almost perfectly matching. it was just faster because of the wrong gating I just mentioned
Asking for 1e-6 tolerance using float32 precision is not realistic. This means that the gradient is scaled by 1e-8. If you use float32 in the first place, you do not expect machine precision in the first place.

## Description

Replace the cooperative grid search + bisection refinement with a simpler architecture: the P0 kernel computes a Newton step estimate, and the eval kernel refines it serially via a shared `func_linesearch_refine` (bracketing walk + 3-alpha dual-bracket). This function is used by both the decomposed and monolith solver paths, eliminating ~120 lines of duplicated refinement logic.

The `candidates[12, B]` array is replaced with 4 named scalar fields (`ls_alpha`, `ls_p0_cost`, `ls_alpha_newton`, `ls_gtol`). The user-facing option `prefer_parallel_linesearch` is removed; an internal `prefer_decomposed_solver` flag auto-selects based on backend/context.

Lowering the tolerance from 1e-6 to 1e-5. I did a small analysis and this is the sweet spot. Typically, I get 40k FPS on box pyramid 6 with 1e-5, but 30k FPS with 5e-6, which is only twice larger. This should preserve (and ever increase the performance compared to the current decomposed version on main), while satisfying the tolerance requirement and ensuring consistency between monolith and decomposed.

### BEFORE

<img width="1988" height="1186" alt="image" src="https://github.com/user-attachments/assets/00833b54-794a-4490-8531-a78a8d156d2f" />

### AFTER

<img width="1500" height="900" alt="image" src="https://github.com/user-attachments/assets/128d826d-835f-42a2-a95a-01e6518691ad" />

For completeness, benchmark script is available [here](https://github.com/user-attachments/files/26691038/benchmark_linesearch_accuracy.py).
